### PR TITLE
LoRA: dequantize model

### DIFF
--- a/lit_gpt/lora.py
+++ b/lit_gpt/lora.py
@@ -685,3 +685,20 @@ def merge_lora_weights(model: GPT) -> None:
     for module in model.modules():
         if isinstance(module, LoRALinear):
             module.merge()
+
+
+def dequantize_model(model: GPT) -> None:
+    """Dequantizes pretrained weights of the model.
+
+    For now supports weights that were quantization into either nf4 or fp4 dtype.
+    """
+    import bitsandbytes as bnb
+
+    for module in model.modules():
+        if isinstance(module, LoRALinear):
+            weight = module.linear.weight
+            if weight.dtype == torch.uint8:
+                dequantized_weight = bnb.functional.dequantize_4bit(weight.data, weight.quant_state).to(
+                    module.linear.compute_dtype
+                )
+                module.linear.weight = bnb.nn.Params4bit(dequantized_weight, requires_grad=False, **weight.__dict__)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -82,9 +82,11 @@ def test_lora_merge():
 @pytest.mark.parametrize("quant_type", ["nf4", "fp4"])
 @pytest.mark.parametrize(
     "compute_dtype",
-    [torch.float16, torch.bfloat16]
-    if (torch.cuda.is_available() and torch.cuda.is_bf16_supported())
-    else [torch.float16],
+    (
+        [torch.float16, torch.bfloat16]
+        if (torch.cuda.is_available() and torch.cuda.is_bf16_supported())
+        else [torch.float16]
+    ),
 )
 def test_dequantize_model(quant_type, compute_dtype):
     from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE, BitsandbytesPrecision


### PR DESCRIPTION
Hi there 👋 

This PR adds functionality to dequantize the model that was initially quantized, in case anyone wants to use these weights elsewhere.

The logic is to dequantize to `float16` dtype, that is [hardcoded](https://github.com/TimDettmers/bitsandbytes/blob/8a45bfa51c4193e64b1de4424c9af05344f74173/bitsandbytes/nn/modules.py#L168) in `quant_state` and then cast to the compute dtype, the one that was used for trainable LoRA parameters and data inputs.
This is exactly how it's [done](https://github.com/TimDettmers/bitsandbytes/blob/8a45bfa51c4193e64b1de4424c9af05344f74173/bitsandbytes/autograd/_functions.py#L516) in BNB.

Note: the PR is not yet finalized as, for completeness, I also want to add dequantization for `bnb.int8`.