### PR TITLE
Fix display of remaining time in pretrain script

### DIFF
--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -244,15 +244,14 @@ def fit(
                 samples=(state["iter_num"] * train.micro_batch_size),
                 lengths=(state["iter_num"] * train.micro_batch_size * model.max_seq_length),
             )
+            remaining_days = (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"]) / 1440
             metrics = {
                 "loss": loss,
                 "iter": state["iter_num"],
                 "step": state["step_count"],
                 "epoch": train_iterator.epoch,
                 "iter_time": t1 - iter_t0,
-                "remaining_time": (
-                    (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"])
-                ),
+                "remaining_days": remaining_days,
                 "tokens": state["iter_num"] * train.micro_batch_size * model.max_seq_length,
                 "total_tokens": (
                     state["iter_num"] * train.micro_batch_size * model.max_seq_length * fabric.world_size
@@ -263,7 +262,7 @@ def fit(
             fabric.print(
                 f"iter {metrics['iter']} | step {metrics['step']}: loss {metrics['loss']:.4f}, iter time:"
                 f" {metrics['iter_time'] * 1000:.2f} ms{' (optimizer.step),' if not is_accumulating else ','}"
-                f" remaining time: {timedelta(seconds=int(metrics['remaining_time']))!s}"
+                f" remaining days: {remaining_days:.1f} days"
             )
 
             throughput_metrics = throughput.compute()

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -262,7 +262,7 @@ def fit(
             fabric.print(
                 f"iter {metrics['iter']} | step {metrics['step']}: loss {metrics['loss']:.4f}, iter time:"
                 f" {metrics['iter_time'] * 1000:.2f} ms{' (optimizer.step),' if not is_accumulating else ','}"
-                f" remaining days: {remaining_days:.1f} days"
+                f" remaining time: {remaining_days:.1f} days"
             )
 
             throughput_metrics = throughput.compute()

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -243,7 +243,7 @@ def fit(
                 samples=(state["iter_num"] * train.micro_batch_size),
                 lengths=(state["iter_num"] * train.micro_batch_size * model.max_seq_length),
             )
-            remaining_days = (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"]) / 1440
+            remaining_days = (t1 - total_t0) / (state["iter_num"] - initial_iter) * (max_iters - state["iter_num"]) / 86400
             metrics = {
                 "loss": loss,
                 "iter": state["iter_num"],

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -4,7 +4,6 @@ import math
 import os
 import time
 import pprint
-from datetime import timedelta
 from functools import partial
 from pathlib import Path
 from typing import Optional, Tuple, Union


### PR DESCRIPTION
The remaining time in the pretraining script is printed like:
`remaining time: 35780 days, 3:14:59`

Pretraining happens on the time scale of days and weeks. This should just show X days.
It also cannot really be accurate to the minute, so the added information is only noise.

This PR also logs remaining days now (seconds was useless for the human).