### PR TITLE
Require tokenizer_dir

### DIFF
--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -69,6 +69,8 @@ def setup(
     elif model_config is None and model_name is None:
         model_name = "tiny-llama-1.1b"
     config = Config.from_name(model_name) if model_config is None else model_config
+    if tokenizer_dir is None:
+        raise ValueError(f"Provide a valid --tokenizer_dir. Got '{tokenizer_dir}'.")
     devices = parse_devices(devices)
     out_dir = init_out_dir(out_dir)
     # in case the dataset requires the Tokenizer


### PR DESCRIPTION
I think that the `--tokenizer_dir` is required. Right now, if you don't provide one, you get either 

- an `AttributeError: 'NoneType' object has no attribute 'encode'` if you pretrain on Alpaca
- an `  File "/teamspace/studios/this_studio/lit-gpt/litgpt/data/tinystories.py", line 50, in prepare_data
    assert self.tokenizer is not None` if you pretrain on TinyStories