### PR TITLE
Add huggingface_hub as an 'all' dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ all = [
     "tensorboard",               # litgpt.pretrain
     "torchmetrics",              # litgpt.pretrain
     "lm_eval @ git+https://github.com/EleutherAI/lm-evaluation-harness.git@115206dc89dad67b8b",
+    "huggingface_hub[hf_transfer]>=0.21.0"  # download
 ]
 
 [build-system]


### PR DESCRIPTION
After https://github.com/Lightning-AI/litgpt/pull/1080, we don't have a tutorial where we recommend installing `huggingface_hub`. So I should add it as a requirement.