### PR TITLE
lit_config.json -> model_config.yaml

### DIFF
--- a/eval/lm_eval_harness.py
+++ b/eval/lm_eval_harness.py
@@ -157,7 +157,7 @@ def run_eval_harness(
     check_valid_checkpoint_dir(checkpoint_dir)
     tokenizer = Tokenizer(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -132,7 +132,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -1,6 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import json
+import yaml
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -107,29 +107,29 @@ class Config:
         return cls(**conf_dict)
 
     @classmethod
-    def from_json(cls, path: Union[str, Path], **kwargs: Any) -> Self:
+    def from_file(cls, path: Union[str, Path], **kwargs: Any) -> Self:
         with open(path, encoding="utf-8") as fp:
-            json_kwargs = json.load(fp)
-        json_kwargs.update(kwargs)
-        return cls(**json_kwargs)
+            file_kwargs = yaml.safe_load(fp)
+        file_kwargs.update(kwargs)
+        return cls(**file_kwargs)
 
     @classmethod
     def from_checkpoint(cls, path: Path, **kwargs: Any) -> Self:
-        """Automatically load `lit_config.json` and if it doesn't exist - a matching config from `litgpt/config.py`."""
-        if (config_path := path / "lit_config.json").is_file():
-            return cls.from_json(config_path, **kwargs)
+        """Automatically load `model_config.yaml` and if it doesn't exist - a matching config from `litgpt/config.py`."""
+        if (config_path := path / "model_config.yaml").is_file():
+            return cls.from_file(config_path, **kwargs)
         if (model_name := path.name) in name_to_config:
             return cls.from_name(model_name, **kwargs)
-        raise FileNotFoundError(f"For {str(path)!r} neither 'lit_config.json' nor matching config exists.")
+        raise FileNotFoundError(f"For {str(path)!r} neither 'model_config.yaml' nor matching config exists.")
 
     @property
     def mlp_class(self) -> Type:
-        # `self.mlp_class_name` cannot be the type to keep the config json serializable
+        # `self.mlp_class_name` cannot be the type to keep the config serializable
         return getattr(litgpt.model, self.mlp_class_name)
 
     @property
     def norm_class(self) -> Type:
-        # `self.norm_class_name` cannot be the type to keep the config json serializable
+        # `self.norm_class_name` cannot be the type to keep the config serializable
         if self.norm_class_name == "RMSNorm":
             from functools import partial
 

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -61,7 +61,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -61,7 +61,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -134,7 +134,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -60,7 +60,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = finetuned_path
 

--- a/litgpt/generate/lora.py
+++ b/litgpt/generate/lora.py
@@ -70,8 +70,8 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(
-        checkpoint_dir / "lit_config.json",
+    config = Config.from_file(
+        checkpoint_dir / "model_config.yaml",
         lora_r=lora_r,
         lora_alpha=lora_alpha,
         lora_dropout=lora_dropout,

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -159,7 +159,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/litgpt/generate/tp.py
+++ b/litgpt/generate/tp.py
@@ -138,7 +138,7 @@ def main(
 
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     model_file = "lit_model.pth"
     checkpoint_path = checkpoint_dir / model_file

--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -1,11 +1,12 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 import importlib
-import json
 import re
 from abc import abstractmethod
 from json import dumps
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Type, Tuple, Union
+
+import yaml
 
 from litgpt.config import Config
 
@@ -338,13 +339,13 @@ def save_prompt_style(style: Union[str, PromptStyle], checkpoint_dir: Path) -> N
     cls = type(style)
     # Allow saving the full module path for user-defined prompt classes
     config = {"class_path": f"{cls.__module__}.{cls.__name__}"}
-    with open(checkpoint_dir / "prompt_style.json", "w") as file:
-        json.dump(config, file)
+    with open(checkpoint_dir / "prompt_style.yaml", "w") as file:
+        yaml.dump(config, file)
 
 
 def load_prompt_style(checkpoint_dir: Path) -> PromptStyle:
-    with open(checkpoint_dir / "prompt_style.json", "r") as file:
-        config = json.load(file)
+    with open(checkpoint_dir / "prompt_style.yaml", "r") as file:
+        config = yaml.safe_load(file)
     # Support loading the full module path for user-defined prompt classes
     full_module_path, cls_name = config["class_path"].rsplit(".", 1)
     module = importlib.import_module(full_module_path)
@@ -353,4 +354,4 @@ def load_prompt_style(checkpoint_dir: Path) -> PromptStyle:
 
 
 def has_prompt_style(checkpoint_dir: Path) -> bool:
-    return (checkpoint_dir / "prompt_style.json").is_file()
+    return (checkpoint_dir / "prompt_style.yaml").is_file()

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -241,7 +241,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     """Convert a LitGPT trained checkpoint into a Hugging Face Transformers checkpoint."""
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     output_dir.mkdir(parents=True, exist_ok=True)
     output_path = output_dir / "model.pth"

--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -43,7 +43,7 @@ def merge_lora(
     precision = precision if precision is not None else lora_precision
 
     fabric = L.Fabric(devices=1, precision=precision)
-    config = Config.from_json(checkpoint_dir / "lit_config.json", **lora_params)
+    config = Config.from_file(checkpoint_dir / "model_config.yaml", **lora_params)
 
     with fabric.init_module(empty_init=True):
         model = GPT(config)

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -1,7 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 """Utility functions for training and inference."""
-import json
 import math
 import pickle
 import shutil
@@ -15,6 +14,7 @@ import lightning as L
 import torch
 import torch.nn as nn
 import torch.utils._device
+import yaml
 from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.load import _lazy_load as lazy_load
@@ -50,7 +50,7 @@ def check_valid_checkpoint_dir(checkpoint_dir: Path, lora: bool = False) -> None
     model_filename = "lit_model.pth.lora" if lora else "lit_model.pth"
     files = {
         model_filename: (checkpoint_dir / model_filename).is_file(),
-        "lit_config.json": (checkpoint_dir / "lit_config.json").is_file(),
+        "model_config.yaml": (checkpoint_dir / "model_config.yaml").is_file(),
         "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file()
         or (checkpoint_dir / "tokenizer.model").is_file(),
         "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
@@ -379,7 +379,7 @@ class CycleIterator:
 def copy_config_files(source_dir: Path, out_dir: Path) -> None:
     """Copies the specified configuration and tokenizer files into the output directory."""
 
-    config_files = ["generation_config.json", "lit_config.json"]
+    config_files = ["generation_config.json", "model_config.yaml"]
     tokenizer_files = ["tokenizer.json", "tokenizer.model",  "tokenizer_config.json"]
 
     for file_name in config_files + tokenizer_files:
@@ -410,8 +410,8 @@ def save_hyperparameters(function: callable, checkpoint_dir: Path) -> None:
 
 def save_config(config: "Config", checkpoint_dir: Path) -> None:
     config_dict = asdict(config)
-    with open(checkpoint_dir / "lit_config.json", "w") as json_config:
-        json.dump(config_dict, json_config)
+    with open(checkpoint_dir / "model_config.yaml", "w") as fp:
+        yaml.dump(config_dict, fp)
 
 
 def parse_devices(devices: Union[str, int]) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def fake_checkpoint_dir(tmp_path):
     checkpoint_dir = tmp_path / "checkpoints" / "tmp"
     checkpoint_dir.mkdir(parents=True)
     (checkpoint_dir / "lit_model.pth").touch()
-    (checkpoint_dir / "lit_config.json").touch()
+    (checkpoint_dir / "model_config.yaml").touch()
     (checkpoint_dir / "tokenizer.json").touch()
     (checkpoint_dir / "tokenizer_config.json").touch()
     return checkpoint_dir

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -94,7 +94,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
-            "prompt_style.json",
+            "prompt_style.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -90,7 +90,7 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
     for checkpoint_dir in checkpoint_dirs:
         assert {p.name for p in (out_dir / checkpoint_dir).iterdir()} == {
             "lit_model.pth",
-            "lit_config.json",
+            "model_config.yaml",
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -117,7 +117,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
-            "prompt_style.json",
+            "prompt_style.yaml",
         }
     assert (out_dir / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -113,7 +113,7 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
     for checkpoint_dir in checkpoint_dirs:
         assert {p.name for p in (out_dir / checkpoint_dir).iterdir()} == {
             "lit_model.pth",
-            "lit_config.json",
+            "model_config.yaml",
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -86,7 +86,7 @@ def test_main(mocked_input, stop_iteration, fake_checkpoint_dir, monkeypatch, te
     # these values will be iteratively provided for each `input()` call
     mocked_input.side_effect = ["Hello", stop_iteration]
 
-    config_path = fake_checkpoint_dir / "lit_config.json"
+    config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
     config_path.write_text(json.dumps(config))
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,6 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import json
 import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -11,6 +10,7 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 import torch
+import yaml
 
 
 @pytest.mark.parametrize(
@@ -88,7 +88,7 @@ def test_main(mocked_input, stop_iteration, fake_checkpoint_dir, monkeypatch, te
 
     config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
-    config_path.write_text(json.dumps(config))
+    config_path.write_text(yaml.dump(config))
 
     load_mock = Mock()
     load_mock.return_value = load_mock

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,7 +65,7 @@ def test_from_checkpoint(tmp_path):
     from litgpt import Config
 
     # 1. Neither `lit_config.py` nor matching config exists.
-    with pytest.raises(FileNotFoundError, match="neither 'lit_config.json' nor matching config exists"):
+    with pytest.raises(FileNotFoundError, match="neither 'model_config.yaml' nor matching config exists"):
         Config.from_checkpoint(tmp_path / "non_existing_checkpoint")
 
     # 2. If `lit_config.py` doesn't exists, but there is a matching config in `litgpt/config.py`.
@@ -76,7 +76,7 @@ def test_from_checkpoint(tmp_path):
 
     # 3. If only `lit_config.py` exists.
     config_data = {"name": "pythia-14m", "block_size": 24, "n_layer": 2}
-    with open(tmp_path / "lit_config.json", "w") as file:
+    with open(tmp_path / "model_config.yaml", "w") as file:
         json.dump(config_data, file)
     config = Config.from_checkpoint(tmp_path)
     assert config.name == "pythia-14m"
@@ -85,7 +85,7 @@ def test_from_checkpoint(tmp_path):
 
     # 4. Both `lit_config.py` and a matching config exist, but `lit_config.py` supersedes matching config
     (tmp_path / "pythia-14m").mkdir()
-    with open(tmp_path / "pythia-14m/lit_config.json", "w") as file:
+    with open(tmp_path / "pythia-14m/model_config.yaml", "w") as file:
         json.dump(config_data, file)
     config = Config.from_checkpoint(tmp_path / "pythia-14m")
     assert config.name == "pythia-14m"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 # support running without installing as a package
 wd = Path(__file__).parent.parent.resolve()
@@ -77,7 +78,7 @@ def test_from_checkpoint(tmp_path):
     # 3. If only `lit_config.py` exists.
     config_data = {"name": "pythia-14m", "block_size": 24, "n_layer": 2}
     with open(tmp_path / "model_config.yaml", "w") as file:
-        json.dump(config_data, file)
+        yaml.dump(config_data, file)
     config = Config.from_checkpoint(tmp_path)
     assert config.name == "pythia-14m"
     assert config.block_size == 24
@@ -86,7 +87,7 @@ def test_from_checkpoint(tmp_path):
     # 4. Both `lit_config.py` and a matching config exist, but `lit_config.py` supersedes matching config
     (tmp_path / "pythia-14m").mkdir()
     with open(tmp_path / "pythia-14m/model_config.yaml", "w") as file:
-        json.dump(config_data, file)
+        yaml.dump(config_data, file)
     config = Config.from_checkpoint(tmp_path / "pythia-14m")
     assert config.name == "pythia-14m"
     assert config.block_size == 24

--- a/tests/test_convert_hf_checkpoint.py
+++ b/tests/test_convert_hf_checkpoint.py
@@ -113,10 +113,10 @@ def test_convert_hf_checkpoint(tmp_path):
         convert_hf_checkpoint(checkpoint_dir=tmp_path, model_name="pythia-14m")
     load.assert_called_with(bin_file)
 
-    assert {p.name for p in tmp_path.glob("*")} == {"foo.bin", "lit_config.json", "lit_model.pth"}
+    assert {p.name for p in tmp_path.glob("*")} == {"foo.bin", "model_config.yaml", "lit_model.pth"}
 
     # ensure that the config dict can be loaded
     from litgpt import Config
 
-    config = Config.from_json(tmp_path / "lit_config.json")
+    config = Config.from_file(tmp_path / "model_config.yaml")
     assert isinstance(config, Config)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -9,6 +9,8 @@ from urllib.request import urlretrieve
 
 import pytest
 import torch
+import yaml
+
 from conftest import RunIf
 
 wd = Path(__file__).parent.parent.absolute()
@@ -24,7 +26,7 @@ def test_convert_lit_checkpoint(tmp_path):
     config_path = tmp_path / "model_config.yaml"
     torch.save(ours_model.state_dict(), checkpoint_path)
     with open(config_path, "w") as fp:
-        json.dump(asdict(ours_config), fp)
+        yaml.dump(asdict(ours_config), fp)
     output_dir = tmp_path / "out_dir"
 
     convert_lit_checkpoint(checkpoint_path.parent, output_dir)

--- a/tests/test_convert_lit_checkpoint.py
+++ b/tests/test_convert_lit_checkpoint.py
@@ -21,14 +21,14 @@ def test_convert_lit_checkpoint(tmp_path):
     ours_config = Config.from_name("Llama-2-7b-hf", block_size=8, n_layer=2, n_embd=32, n_head=2, padding_multiple=128)
     ours_model = GPT(ours_config)
     checkpoint_path = tmp_path / "lit_model.pth"
-    config_path = tmp_path / "lit_config.json"
+    config_path = tmp_path / "model_config.yaml"
     torch.save(ours_model.state_dict(), checkpoint_path)
     with open(config_path, "w") as fp:
         json.dump(asdict(ours_config), fp)
     output_dir = tmp_path / "out_dir"
 
     convert_lit_checkpoint(checkpoint_path.parent, output_dir)
-    assert set(os.listdir(tmp_path)) == {"lit_model.pth", "lit_config.json", "out_dir"}
+    assert set(os.listdir(tmp_path)) == {"lit_model.pth", "model_config.yaml", "out_dir"}
     assert os.path.isfile(output_dir / "model.pth")
 
     # check checkpoint is unwrapped

--- a/tests/test_convert_pretrained_checkpoint.py
+++ b/tests/test_convert_pretrained_checkpoint.py
@@ -19,7 +19,7 @@ def test_convert_pretrained_checkpoint(tmp_path, fake_checkpoint_dir):
     convert_pretrained_checkpoint(checkpoint_dir=fake_checkpoint_dir, output_dir=(tmp_path / "converted"))
 
     assert set(os.listdir(tmp_path / "converted")) == {
-        "lit_model.pth", "lit_config.json", "tokenizer_config.json", "tokenizer.json"
+        "lit_model.pth", "model_config.yaml", "tokenizer_config.json", "tokenizer.json"
     }
     converted_checkpoint = torch.load(tmp_path / "converted" / "lit_model.pth")
     assert list(converted_checkpoint.keys()) == ["some.module.weight", "some.other.module.weight"]

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -50,7 +50,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     for checkpoint_dir in checkpoint_dirs:
         assert set(os.listdir(out_dir / checkpoint_dir)) == {
             "lit_model.pth",
-            "lit_config.json",
+            "model_config.yaml",
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",

--- a/tests/test_full.py
+++ b/tests/test_full.py
@@ -54,7 +54,7 @@ def test_full_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
-            "prompt_style.json",
+            "prompt_style.yaml",
         }
     assert (out_dir / "logs" / "csv" / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -49,7 +49,7 @@ def test_generate(max_seq_length):
 def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
     import litgpt.generate.base as generate
 
-    config_path = fake_checkpoint_dir / "lit_config.json"
+    config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
     config_path.write_text(json.dumps(config))
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -11,6 +11,7 @@ from unittest.mock import ANY, Mock, call
 
 import pytest
 import torch
+import yaml
 
 
 @pytest.mark.parametrize(
@@ -51,7 +52,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
 
     config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
-    config_path.write_text(json.dumps(config))
+    config_path.write_text(yaml.dump(config))
 
     module_mock = Mock()
     module_mock.config.block_size = 128

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -10,6 +10,7 @@ from unittest.mock import ANY, Mock, call
 
 import pytest
 import torch
+import yaml
 
 
 @pytest.mark.parametrize("version", ("v1", "v2"))
@@ -21,7 +22,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, version, tensor_like):
 
     config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
-    config_path.write_text(json.dumps(config))
+    config_path.write_text(yaml.dump(config))
 
     monkeypatch.setattr(generate, "lazy_load", Mock())
     monkeypatch.setattr(generate.GPT, "load_state_dict", Mock())

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -19,7 +19,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, version, tensor_like):
     else:
         import litgpt.generate.adapter_v2 as generate
 
-    config_path = fake_checkpoint_dir / "lit_config.json"
+    config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {"block_size": 128, "vocab_size": 50, "n_layer": 2, "n_head": 4, "n_embd": 8, "rotary_percentage": 1}
     config_path.write_text(json.dumps(config))
 

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -18,7 +18,7 @@ import torch
 def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
     import litgpt.generate.lora as generate
 
-    config_path = fake_checkpoint_dir / "lit_config.json"
+    config_path = fake_checkpoint_dir / "model_config.yaml"
     config = {
         "block_size": 128,
         "vocab_size": 50,

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -1,6 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import json
 import os
 import subprocess
 import sys
@@ -12,6 +11,7 @@ from unittest.mock import ANY, Mock, call
 
 import pytest
 import torch
+import yaml
 
 
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})

--- a/tests/test_generate_lora.py
+++ b/tests/test_generate_lora.py
@@ -30,7 +30,7 @@ def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
         "lora_value": False,
         "lora_projection": True,
     }
-    config_path.write_text(json.dumps(config))
+    config_path.write_text(yaml.dump(config))
 
     monkeypatch.setattr(generate, "lazy_load", Mock())
     monkeypatch.setattr(generate.GPT, "load_state_dict", Mock())

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -282,7 +282,7 @@ def test_base_with_sequentially(tmp_path):
     checkpoint_dir = tmp_path / "EleutherAI/pythia-14m"
     # save the config
     config = Config.from_name("pythia-14m")
-    (checkpoint_dir / "lit_config.json").write_text(json.dumps(asdict(config)))
+    (checkpoint_dir / "model_config.yaml").write_text(json.dumps(asdict(config)))
     # create a state dict to load from
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -1,7 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import itertools
-import json
 import subprocess
 import sys
 from collections import defaultdict
@@ -11,8 +10,10 @@ from re import escape
 
 import pytest
 import torch
-from conftest import RunIf
+import yaml
 from lightning import Fabric
+
+from conftest import RunIf
 
 
 @pytest.mark.parametrize(
@@ -282,7 +283,7 @@ def test_base_with_sequentially(tmp_path):
     checkpoint_dir = tmp_path / "EleutherAI/pythia-14m"
     # save the config
     config = Config.from_name("pythia-14m")
-    (checkpoint_dir / "model_config.yaml").write_text(json.dumps(asdict(config)))
+    (checkpoint_dir / "model_config.yaml").write_text(yaml.dump(asdict(config)))
     # create a state dict to load from
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 

--- a/tests/test_generate_tp.py
+++ b/tests/test_generate_tp.py
@@ -1,4 +1,3 @@
-import json
 import subprocess
 import sys
 from dataclasses import asdict, replace
@@ -7,6 +6,8 @@ from unittest.mock import Mock
 
 import pytest
 import torch
+import yaml
+
 from conftest import RunIf
 from test_generate_sequentially import find_forward_hooks
 
@@ -116,7 +117,7 @@ def test_tp(tmp_path):
     checkpoint_dir = tmp_path / "EleutherAI/pythia-14m"
     # save the config
     config = Config.from_name("pythia-14m")
-    (checkpoint_dir / "model_config.yaml").write_text(json.dumps(asdict(config)))
+    (checkpoint_dir / "model_config.yaml").write_text(yaml.dump(asdict(config)))
     # create a state dict to load from
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 

--- a/tests/test_generate_tp.py
+++ b/tests/test_generate_tp.py
@@ -116,7 +116,7 @@ def test_tp(tmp_path):
     checkpoint_dir = tmp_path / "EleutherAI/pythia-14m"
     # save the config
     config = Config.from_name("pythia-14m")
-    (checkpoint_dir / "lit_config.json").write_text(json.dumps(asdict(config)))
+    (checkpoint_dir / "model_config.yaml").write_text(json.dumps(asdict(config)))
     # create a state dict to load from
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -1,6 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import json
 import subprocess
 import sys
 from pathlib import Path
@@ -8,6 +7,7 @@ from unittest.mock import ANY, Mock
 
 import datasets
 import pytest
+import yaml
 from lightning import Fabric
 
 

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -61,7 +61,7 @@ def test_eval_script(tmp_path, fake_checkpoint_dir, monkeypatch):
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
     with open(fake_checkpoint_dir / "model_config.yaml", "w") as fp:
-        json.dump(model_config, fp)
+        yaml.dump(model_config, fp)
     monkeypatch.setattr(module, "load_checkpoint", Mock())
 
     tokenizer_mock = Mock()

--- a/tests/test_lm_eval_harness.py
+++ b/tests/test_lm_eval_harness.py
@@ -60,7 +60,7 @@ def test_eval_script(tmp_path, fake_checkpoint_dir, monkeypatch):
     import eval.lm_eval_harness as module
 
     model_config = dict(block_size=128, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
-    with open(fake_checkpoint_dir / "lit_config.json", "w") as fp:
+    with open(fake_checkpoint_dir / "model_config.yaml", "w") as fp:
         json.dump(model_config, fp)
     monkeypatch.setattr(module, "load_checkpoint", Mock())
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -224,7 +224,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",
-            "prompt_style.json",
+            "prompt_style.yaml",
         }
     assert (out_dir / "logs" / "csv" / "version_0" / "metrics.csv").is_file()
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -220,7 +220,7 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
     for checkpoint_dir in checkpoint_dirs:
         assert {p.name for p in (out_dir / checkpoint_dir).iterdir()} == {
             "lit_model.pth.lora",
-            "lit_config.json",
+            "model_config.yaml",
             "tokenizer_config.json",
             "tokenizer.json",
             "hyperparameters.yaml",

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -30,7 +30,7 @@ def test_merge_lora(tmp_path, fake_checkpoint_dir):
 
     # Create a fake pretrained checkpoint
     config = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
-    with open(pretrained_checkpoint_dir / "lit_config.json", "w") as fp:
+    with open(pretrained_checkpoint_dir / "model_config.yaml", "w") as fp:
         json.dump(config, fp)
     base_model = GPT.from_name("pythia-14m", **config)
     state_dict = base_model.state_dict()
@@ -46,13 +46,13 @@ def test_merge_lora(tmp_path, fake_checkpoint_dir):
     hparams = dict(checkpoint_dir=str(pretrained_checkpoint_dir), **lora_kwargs)
     with open(lora_checkpoint_dir / "hyperparameters.yaml", "w") as file:
         yaml.dump(hparams, file)
-    shutil.copyfile(pretrained_checkpoint_dir / "lit_config.json", lora_checkpoint_dir / "lit_config.json")
+    shutil.copyfile(pretrained_checkpoint_dir / "model_config.yaml", lora_checkpoint_dir / "model_config.yaml")
 
     assert set(os.listdir(tmp_path)) == {"lora", "pretrained"}
     merge_lora(lora_checkpoint_dir)
     assert set(os.listdir(tmp_path)) == {"lora", "pretrained"}
     assert set(os.listdir(lora_checkpoint_dir)) == {
-        "lit_config.json",
+        "model_config.yaml",
         "lit_model.pth",
         "lit_model.pth.lora",
         "tokenizer.json",

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -31,7 +31,7 @@ def test_merge_lora(tmp_path, fake_checkpoint_dir):
     # Create a fake pretrained checkpoint
     config = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
     with open(pretrained_checkpoint_dir / "model_config.yaml", "w") as fp:
-        json.dump(config, fp)
+        yaml.dump(config, fp)
     base_model = GPT.from_name("pythia-14m", **config)
     state_dict = base_model.state_dict()
     assert len(state_dict) == 40

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -50,7 +50,7 @@ def test_pretrain(_, tmp_path):
         assert all((out_dir / p).is_dir() for p in checkpoint_dirs)
         for checkpoint_dir in checkpoint_dirs:
             # the `tokenizer_dir` is None by default, so only 'lit_model.pth' shows here
-            assert set(os.listdir(out_dir / checkpoint_dir)) == {"lit_model.pth", "lit_config.json"}
+            assert set(os.listdir(out_dir / checkpoint_dir)) == {"lit_model.pth", "model_config.yaml"}
 
         assert (out_dir / "logs" / "tensorboard" / "version_0").is_dir()
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,5 +1,8 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 import json
+
+import yaml
+
 from litgpt.prompts import PromptStyle
 
 
@@ -98,8 +101,8 @@ def test_save_load_prompt_style(tmp_path):
     assert not has_prompt_style(checkpoint_dir)
     save_prompt_style("alpaca", checkpoint_dir)
     assert has_prompt_style(checkpoint_dir)
-    with open(checkpoint_dir / "prompt_style.json", "r") as file:
-        contents = json.load(file)
+    with open(checkpoint_dir / "prompt_style.yaml", "r") as file:
+        contents = yaml.load(file)
     assert contents == {"class_path": "litgpt.prompts.Alpaca"}
     loaded = load_prompt_style(checkpoint_dir)
     assert isinstance(loaded, Alpaca)
@@ -108,8 +111,8 @@ def test_save_load_prompt_style(tmp_path):
     checkpoint_dir = tmp_path / "custom"
     checkpoint_dir.mkdir()
     save_prompt_style(CustomPromptStyle(), checkpoint_dir)
-    with open(checkpoint_dir / "prompt_style.json", "r") as file:
-        contents = json.load(file)
+    with open(checkpoint_dir / "prompt_style.yaml", "r") as file:
+        contents = yaml.load(file)
     assert contents == {"class_path": "test_prompts.CustomPromptStyle"}
     loaded = load_prompt_style(checkpoint_dir)
     assert isinstance(loaded, CustomPromptStyle)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -102,7 +102,7 @@ def test_save_load_prompt_style(tmp_path):
     save_prompt_style("alpaca", checkpoint_dir)
     assert has_prompt_style(checkpoint_dir)
     with open(checkpoint_dir / "prompt_style.yaml", "r") as file:
-        contents = yaml.load(file)
+        contents = yaml.safe_load(file)
     assert contents == {"class_path": "litgpt.prompts.Alpaca"}
     loaded = load_prompt_style(checkpoint_dir)
     assert isinstance(loaded, Alpaca)
@@ -112,7 +112,7 @@ def test_save_load_prompt_style(tmp_path):
     checkpoint_dir.mkdir()
     save_prompt_style(CustomPromptStyle(), checkpoint_dir)
     with open(checkpoint_dir / "prompt_style.yaml", "r") as file:
-        contents = yaml.load(file)
+        contents = yaml.safe_load(file)
     assert contents == {"class_path": "test_prompts.CustomPromptStyle"}
     loaded = load_prompt_style(checkpoint_dir)
     assert isinstance(loaded, CustomPromptStyle)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,7 +43,7 @@ def test_check_valid_checkpoint_dir(tmp_path):
         check_valid_checkpoint_dir(tmp_path)
     out = out.getvalue().strip()
     expected = f"""
---checkpoint_dir '{str(tmp_path.absolute())}' is missing the files: ['lit_model.pth', 'lit_config.json', 'tokenizer.json OR tokenizer.model', 'tokenizer_config.json'].
+--checkpoint_dir '{str(tmp_path.absolute())}' is missing the files: ['lit_model.pth', 'model_config.yaml', 'tokenizer.json OR tokenizer.model', 'tokenizer_config.json'].
 Find download instructions at https://github.com/Lightning-AI/litgpt/blob/main/tutorials
 
 See all download options by running:
@@ -223,7 +223,7 @@ def test_copy_config_files(fake_checkpoint_dir, tmp_path):
 
     copy_config_files(fake_checkpoint_dir, tmp_path)
     expected = {
-        "lit_config.json",
+        "model_config.yaml",
         "tokenizer_config.json",
         "tokenizer.json",
     }

--- a/tutorials/convert_hf_checkpoint.md
+++ b/tutorials/convert_hf_checkpoint.md
@@ -14,7 +14,7 @@ checkpoints/
     └── pythia-14m/
         ├── config.json
         ├── generation_config.json
-        ├── lit_config.json        # LitGPT specific file
+        ├── model_config.yaml      # LitGPT specific file
         ├── lit_model.pth          # LitGPT specific file
         ├── pytorch_model.bin
         ├── tokenizer.json
@@ -46,7 +46,7 @@ ls checkpoints/EleutherAI/pythia-14m
         └── tokenizer_config.json
 ```
 
-The required files `lit_config.json` and `lit_model.pth` files can then be manually generated via the `litgpt/scripts/convert_hf_checkpoint.py` script:
+The required files `model_config.yaml` and `lit_model.pth` files can then be manually generated via the `litgpt/scripts/convert_hf_checkpoint.py` script:
 
 ```bash
 litgpt convert to_litgpt \

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -164,7 +164,7 @@ litgpt convert pretrained_checkpoint \
 After conversion, the output folder will contain these files:
 ```
 checkpoints/tiny-llama/final
-├── lit_config.json
+├── model_config.yaml
 ├── lit_model.pth
 ├── tokenizer_config.json
 ├── tokenizer.json

--- a/xla/generate/adapter.py
+++ b/xla/generate/adapter.py
@@ -67,7 +67,7 @@ def main(
 ) -> None:
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json", adapter_start_layer=0)
+    config = Config.from_file(checkpoint_dir / "model_config.yaml", adapter_start_layer=0)
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/xla/generate/base.py
+++ b/xla/generate/base.py
@@ -133,7 +133,7 @@ def main(
 ) -> None:
     check_valid_checkpoint_dir(checkpoint_dir)
 
-    config = Config.from_json(checkpoint_dir / "lit_config.json")
+    config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
 

--- a/xla/scripts/prepare_alpaca.py
+++ b/xla/scripts/prepare_alpaca.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional
 
 import torch
+import yaml
 from lightning_utilities.core.imports import RequirementCache
 from lit_gpt.tokenizer import Tokenizer
 from lit_gpt.utils import CLI
@@ -31,8 +32,8 @@ def prepare(
     which stores the preprocessed and tokenized prompts and labels.
     """
     if max_seq_length is None:
-        with open(checkpoint_dir / "lit_config.json", "r", encoding="utf-8") as file:
-            config = json.load(file)
+        with open(checkpoint_dir / "model_config.yaml", "r", encoding="utf-8") as file:
+            config = yaml.load(file)
             max_seq_length = config["block_size"]
 
     destination_path.mkdir(parents=True, exist_ok=True)

--- a/xla/scripts/prepare_alpaca.py
+++ b/xla/scripts/prepare_alpaca.py
@@ -33,7 +33,7 @@ def prepare(
     """
     if max_seq_length is None:
         with open(checkpoint_dir / "model_config.yaml", "r", encoding="utf-8") as file:
-            config = yaml.load(file)
+            config = yaml.safe_load(file)
             max_seq_length = config["block_size"]
 
     destination_path.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Fixes #1052
Fixes #1021

Using "model" to disambiguate from the other config files that we added recently. We might want to still prepend `lit_` to avoid name collisions in the future.