### PR TITLE
Fix logging of val loss

### DIFF
--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -226,7 +226,6 @@ def fit(
                     state["iter_num"] * train.micro_batch_size * model.config.block_size * fabric.world_size
                 ),
                 "learning_rate": scheduler.get_last_lr()[0],
-                "val_loss": val_loss,
             }
             if isinstance(val_loss, torch.Tensor):
                 val_loss = f"{val_loss:.3f}"

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -247,7 +247,6 @@ def fit(
                     iter_num * train.micro_batch_size * model.config.block_size * fabric.world_size
                 ),
                 "learning_rate": scheduler.get_last_lr()[0],
-                "val_loss": val_loss,
             }
             if isinstance(val_loss, torch.Tensor):
                 val_loss = f"{val_loss:.3f}"


### PR DESCRIPTION
My suggestion in https://github.com/Lightning-AI/litgpt/pull/1055 was missed. We can't log "n/a" as a scalar. Also, the val loss is already logged, we don't need to log it twice.