### PR TITLE
Downgrade ligthning to before bitsandbytes upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { file = "LICENSE" }
 
 dependencies = [
     "torch>=2.2.0",
-    "lightning @ git+https://github.com/Lightning-AI/lightning@f23b3b1e7fdab1d325f79f69a28706d33144f27e",
+    "lightning @ git+https://github.com/Lightning-AI/lightning@b19c3a961c79028d7c39a4f1ff1c2df991406d1d",
     # TODO: install from PyPI when https://github.com/omni-us/jsonargparse/pull/466 is released
     "jsonargparse[signatures] @ git+https://github.com/omni-us/jsonargparse",
 ]

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,19 +1,10 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-# this file is just to validate on the CI logs that these tests were run
+from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILABLE
+
 from conftest import RunIf
 
 
 @RunIf(min_cuda_gpus=1)
-def test_runif_min_cuda_gpus():
-    assert True
-
-
-@RunIf(min_cuda_gpus=1, standalone=True)
-def test_runif_min_cuda_gpus_standalone():
-    assert True
-
-
-@RunIf(standalone=True)
-def test_runif_standalone():
-    assert True
+def test_gpu_ci_installs_bitsandbytes():
+    assert _BITSANDBYTES_AVAILABLE, str(_BITSANDBYTES_AVAILABLE)

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -689,8 +689,8 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
         },
     }
 
-    assert {p.name for p in tmp_path.rglob("*.pth")} == {"lit_model.pth"}
-    state_dict = torch.load(tmp_path / "final" / "lit_model.pth")
+    assert {p.name for p in tmp_path.rglob("*.lora")} == {"lit_model.pth.lora"}
+    state_dict = torch.load(tmp_path / "final" / "lit_model.pth.lora")
     assert len(state_dict) == 1
     dtype_to_name = {"torch.float16": set()}
     for name, layer in state_dict["model"].items():


### PR DESCRIPTION
This is the commit before https://github.com/Lightning-AI/pytorch-lightning/pull/19520

There are some issues with upgrading bitsandbytes. We currently pin 0.41.0. https://github.com/Lightning-AI/litgpt/pull/946 Attempts to upgrade it.

0.42.0 fails with:

```python
/__w/7/s/tests/test_lora.py:693: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/local/lib/python3.10/dist-packages/torch/serialization.py:998: in load
    with _open_file_like(f, 'rb') as opened_file:
/usr/local/lib/python3.10/dist-packages/torch/serialization.py:445: in _open_file_like
    return _open_file(name_or_buffer, mode)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch.serialization._open_file object at 0x7f1180ba65f0>
name = PosixPath('/tmp/pytest-of-root/pytest-0/test_lora_bitsandbytes0/final/lit_model.pth')
mode = 'rb'

    def __init__(self, name, mode):
>       super().__init__(open(name, mode))
E       FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pytest-of-root/pytest-0/test_lora_bitsandbytes0/final/lit_model.pth'

/usr/local/lib/python3.10/dist-packages/torch/serialization.py:426: FileNotFoundError
```

0.43.0 fails with

```python
        if A.dtype == torch.float32:
            if quant_type == 'fp4':
                lib.cquantize_blockwise_fp32_fp4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
            else:
                lib.cquantize_blockwise_fp32_nf4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
        elif A.dtype == torch.float16:
            if quant_type == 'fp4':
                lib.cquantize_blockwise_fp16_fp4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
            else:
                lib.cquantize_blockwise_fp16_nf4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
        elif A.dtype == torch.bfloat16:
            if quant_type == 'fp4':
                lib.cquantize_blockwise_bf16_fp4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
            else:
                lib.cquantize_blockwise_bf16_nf4(get_ptr(None), get_ptr(A), get_ptr(absmax), get_ptr(out), ct.c_int32(blocksize), ct.c_int(n))
        else:
>           raise ValueError(f"Blockwise quantization only supports 16/32-bit floats, but got {A.dtype}")
E           ValueError: Blockwise quantization only supports 16/32-bit floats, but got torch.uint8

/home/carlos/nightly-env/lib/python3.10/site-packages/bitsandbytes/functional.py:1009: ValueError
```