### PR TITLE
Add general purpose LitData streaming data module

### DIFF
--- a/litgpt/data/__init__.py
+++ b/litgpt/data/__init__.py
@@ -1,6 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-from litgpt.data.base import LitDataModule, SFTDataset, get_sft_collate_fn
+from litgpt.data.base import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.data.alpaca import Alpaca
 from litgpt.data.alpaca_2k import Alpaca2k
 from litgpt.data.alpaca_gpt4 import AlpacaGPT4
@@ -9,6 +9,7 @@ from litgpt.data.deita import Deita
 from litgpt.data.dolly import Dolly
 from litgpt.data.flan import FLAN
 from litgpt.data.lima import LIMA
+from litgpt.data.lit_data import LitData
 from litgpt.data.longform import LongForm
 from litgpt.data.tinyllama import TinyLlama
 from litgpt.data.tinystories import TinyStories
@@ -24,7 +25,8 @@ __all__ = [
     "FLAN",
     "JSON",
     "LIMA",
-    "LitDataModule",
+    "LitData",
+    "DataModule",
     "LongForm",
     "OpenWebText",
     "SFTDataset",

--- a/litgpt/data/alpaca.py
+++ b/litgpt/data/alpaca.py
@@ -9,7 +9,7 @@ from typing import Optional, Union
 import torch
 from torch.utils.data import random_split, DataLoader
 from lightning_utilities.core.imports import RequirementCache
-from litgpt.data import SFTDataset, get_sft_collate_fn, LitDataModule
+from litgpt.data import SFTDataset, get_sft_collate_fn, DataModule
 from litgpt.prompts import PromptStyle
 from litgpt.tokenizer import Tokenizer
 
@@ -17,7 +17,7 @@ _URL = "https://raw.githubusercontent.com/tloen/alpaca-lora/main/alpaca_data_cle
 
 
 @dataclass
-class Alpaca(LitDataModule):
+class Alpaca(DataModule):
     """Alpaca data module for supervised finetuning."""
 
     mask_prompt: bool = False

--- a/litgpt/data/base.py
+++ b/litgpt/data/base.py
@@ -12,7 +12,7 @@ from litgpt import Tokenizer
 from litgpt.prompts import PromptStyle
 
 
-class LitDataModule(LightningDataModule):
+class DataModule(LightningDataModule):
     """Base class for all data modules in LitGPT."""
 
     @abstractmethod

--- a/litgpt/data/deita.py
+++ b/litgpt/data/deita.py
@@ -9,12 +9,12 @@ import torch
 from torch.utils.data import DataLoader
 
 from litgpt import PromptStyle
-from litgpt.data import LitDataModule, SFTDataset, get_sft_collate_fn
+from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.tokenizer import Tokenizer
 
 
 @dataclass
-class Deita(LitDataModule):
+class Deita(DataModule):
     """Deita data module for supervised finetuning."""
 
     mask_prompt: bool = False

--- a/litgpt/data/flan.py
+++ b/litgpt/data/flan.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from litgpt import PromptStyle
-from litgpt.data import SFTDataset, get_sft_collate_fn, LitDataModule
+from litgpt.data import SFTDataset, get_sft_collate_fn, DataModule
 from litgpt.data.alpaca import download_if_missing
 from litgpt.tokenizer import Tokenizer
 
@@ -19,7 +19,7 @@ _URL = "https://huggingface.co/datasets/Muennighoff/flan/resolve/main"
 # TODO: Including all subsets, FLAN is too large to be loaded in memory. Switch the implementation to cache
 #   on disk or use Lightning Data
 @dataclass
-class FLAN(LitDataModule):
+class FLAN(DataModule):
     """FLAN data module for supervised finetuning."""
 
     mask_prompt: bool = False

--- a/litgpt/data/json_data.py
+++ b/litgpt/data/json_data.py
@@ -9,12 +9,12 @@ import torch
 from torch.utils.data import random_split, DataLoader
 
 from litgpt import PromptStyle
-from litgpt.data import SFTDataset, get_sft_collate_fn, LitDataModule
+from litgpt.data import SFTDataset, get_sft_collate_fn, DataModule
 from litgpt.tokenizer import Tokenizer
 
 
 @dataclass
-class JSON(LitDataModule):
+class JSON(DataModule):
     """Loads JSON or JSONL data for supervised finetuning."""
 
     json_path: Path

--- a/litgpt/data/lima.py
+++ b/litgpt/data/lima.py
@@ -9,12 +9,12 @@ import torch
 from torch.utils.data import random_split, DataLoader
 
 from litgpt import PromptStyle
-from litgpt.data import LitDataModule, SFTDataset, get_sft_collate_fn
+from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.tokenizer import Tokenizer
 
 
 @dataclass
-class LIMA(LitDataModule):
+class LIMA(DataModule):
     """LIMA data module for supervised finetuning."""
 
     mask_prompt: bool = False

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -1,0 +1,52 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Union, Optional
+
+from torch.utils.data import DataLoader
+
+from litgpt import Tokenizer
+from litgpt.data import DataModule
+
+
+@dataclass
+class LitData(DataModule):
+    """Loads data using LitData's StreamingDataset given a path to a folder of preprocessed data (chunks)."""
+
+    data_path: Union[str, Path] = Path("data/")
+    """The path to the data directory containing the preprocessed chunks for the streaming dataset
+    The path can also be a remote path (e.g., s3://)."""
+    seed: int = 42
+    """The random seed for shuffling the dataset."""
+    num_workers: int = 8
+    """How many DataLoader processes to use for loading."""
+
+    batch_size: int = field(init=False, repr=False, default=1)
+    seq_length: int = field(init=False, repr=False, default=2048)
+
+    def connect(
+        self,
+        tokenizer: Optional[Tokenizer] = None,
+        batch_size: int = 1,
+        max_seq_length: Optional[int] = None
+    ) -> None:
+        self.batch_size = batch_size
+        self.seq_length = max_seq_length + 1  # Increase by one because we need the next token as well
+
+    def train_dataloader(self) -> DataLoader:
+        from litdata.streaming import StreamingDataset, TokensLoader
+
+        dataset = StreamingDataset(
+            input_dir=str(self.data_path),
+            item_loader=TokensLoader(block_size=self.seq_length),
+            shuffle=True,
+            drop_last=True,
+        )
+
+        train_dataloader = DataLoader(
+            dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True)
+        return train_dataloader
+
+    def val_dataloader(self) -> DataLoader:
+        # TODO: Return a validation loader
+        return self.train_dataloader()

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -2,7 +2,7 @@
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Union, Optional
+from typing import Union, Optional, Tuple
 
 from torch.utils.data import DataLoader
 
@@ -17,7 +17,7 @@ class LitData(DataModule):
     data_path: Union[str, Path] = Path("data/")
     """The path to the data directory containing the preprocessed chunks for the streaming dataset
     The path can also be a remote path (e.g., s3://)."""
-    split_names: Optional[tuple[str, str]] = None
+    split_names: Optional[Tuple[str, str]] = None
     """Optional tuple for names of subfolders for training and validation under ``data_path``. If not provided,
     all data under data_path will be used for training, and the validation dataloader will be identical to the
     train dataloader."""

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -16,7 +16,8 @@ class LitData(DataModule):
 
     data_path: Union[str, Path] = Path("data/")
     """The path to the data directory containing the preprocessed chunks for the streaming dataset
-    The path can also be a remote path (e.g., s3://)."""
+    The path can also be a remote path (e.g., s3://). See also ``split_names`` if this path contains subfolders
+    for training- and validation splits."""
     split_names: Optional[Tuple[str, str]] = None
     """Optional tuple for names of subfolders for training and validation under ``data_path``. If not provided,
     all data under data_path will be used for training, and the validation dataloader will be identical to the

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -29,6 +29,12 @@ class LitData(DataModule):
     batch_size: int = field(init=False, repr=False, default=1)
     seq_length: int = field(init=False, repr=False, default=2048)
 
+    def __post_init__(self) -> None:
+        if self.split_names is not None and len(self.split_names) != 2:
+            raise ValueError(
+                "If provided `split_names` must be a tuple of two strings, for example: ('train', 'val')."
+            )
+
     def connect(
         self,
         tokenizer: Optional[Tokenizer] = None,
@@ -39,11 +45,11 @@ class LitData(DataModule):
         self.seq_length = max_seq_length + 1  # Increase by one because we need the next token as well
 
     def train_dataloader(self) -> DataLoader:
-        input_dir = os.path.join(self.data_path / self.split_names[0]) if self.split_names else str(self.data_path)
+        input_dir = os.path.join(self.data_path, self.split_names[0]) if self.split_names else str(self.data_path)
         return self._dataloader(input_dir=input_dir, train=True)
 
     def val_dataloader(self) -> DataLoader:
-        input_dir = os.path.join(self.data_path / self.split_names[1]) if self.split_names else str(self.data_path)
+        input_dir = os.path.join(self.data_path, self.split_names[1]) if self.split_names else str(self.data_path)
         return self._dataloader(input_dir=input_dir, train=False)
 
     def _dataloader(self, input_dir: str, train: bool):

--- a/litgpt/data/longform.py
+++ b/litgpt/data/longform.py
@@ -9,7 +9,7 @@ import torch
 from torch.utils.data import DataLoader
 
 from litgpt import PromptStyle
-from litgpt.data import SFTDataset, get_sft_collate_fn, LitDataModule
+from litgpt.data import SFTDataset, get_sft_collate_fn, DataModule
 from litgpt.data.alpaca import download_if_missing
 from litgpt.tokenizer import Tokenizer
 
@@ -18,7 +18,7 @@ _URL = "https://raw.githubusercontent.com/akoksal/LongForm/main/dataset"
 
 
 @dataclass
-class LongForm(LitDataModule):
+class LongForm(DataModule):
     """LongForm data module for supervised finetuning."""
 
     mask_prompt: bool = False

--- a/litgpt/data/openwebtext.py
+++ b/litgpt/data/openwebtext.py
@@ -8,11 +8,11 @@ from typing import Union, Optional
 from torch.utils.data import DataLoader
 
 from litgpt import Tokenizer
-from litgpt.data import LitDataModule
+from litgpt.data import DataModule
 
 
 @dataclass
-class OpenWebText(LitDataModule):
+class OpenWebText(DataModule):
     """The OpenWebText data module for pretraining."""
 
     data_path: Union[str, Path] = Path("data/openwebtext")

--- a/litgpt/data/tinyllama.py
+++ b/litgpt/data/tinyllama.py
@@ -6,11 +6,11 @@ from typing import Union, Optional
 from torch.utils.data import DataLoader
 
 from litgpt import Tokenizer
-from litgpt.data import LitDataModule
+from litgpt.data import DataModule
 
 
 @dataclass
-class TinyLlama(LitDataModule):
+class TinyLlama(DataModule):
     """The TinyLlama data module is composed of a mix of SlimPajama and Starcoder data.
 
     Provides training and validation streaming dataloaders that return batches of tokens.

--- a/litgpt/data/tinystories.py
+++ b/litgpt/data/tinystories.py
@@ -16,12 +16,12 @@ from torch.utils.data import ConcatDataset, DataLoader
 from tqdm import tqdm
 
 from litgpt.data.alpaca import download_if_missing
-from litgpt.data.base import LitDataModule
+from litgpt.data.base import DataModule
 from litgpt.tokenizer import Tokenizer
 
 
 @dataclass
-class TinyStories(LitDataModule):
+class TinyStories(DataModule):
     """The TinyStories data module: https://huggingface.co/datasets/roneneldan/TinyStories
 
     Provides training and validation dataloaders that return batches of tokens. Every sample is set to a fixed length.

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -16,7 +16,7 @@ from torch.utils.data import DataLoader
 
 from litgpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
 from litgpt.args import EvalArgs, TrainArgs
-from litgpt.data import Alpaca, LitDataModule
+from litgpt.data import Alpaca, DataModule
 from litgpt.generate.base import generate
 from litgpt.prompts import save_prompt_style
 from litgpt.tokenizer import Tokenizer
@@ -39,7 +39,7 @@ def setup(
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: Union[int, str] = 1,
     seed: int = 1337,
-    data: Optional[LitDataModule] = None,
+    data: Optional[DataModule] = None,
     checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     out_dir: Path = Path("out/finetune/adapter"),
     train: TrainArgs = TrainArgs(
@@ -90,7 +90,7 @@ def setup(
     fabric.launch(main, devices, seed, Config.from_name(name=checkpoint_dir.name), data, checkpoint_dir, out_dir, train, eval)
 
 
-def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: LitDataModule, checkpoint_dir: Path, out_dir: Path, train: TrainArgs, eval: EvalArgs) -> None:
+def main(fabric: L.Fabric, devices: int, seed: int, config: Config, data: DataModule, checkpoint_dir: Path, out_dir: Path, train: TrainArgs, eval: EvalArgs) -> None:
     validate_args(train, eval)
 
     check_valid_checkpoint_dir(checkpoint_dir)
@@ -160,7 +160,7 @@ def fit(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
-    data: LitDataModule,
+    data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
     longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
@@ -239,7 +239,7 @@ def fit(
 # the adapter "kv cache" cannot be initialized under `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: GPT, val_dataloader: DataLoader, tokenizer: Tokenizer, eval: EvalArgs, data: LitDataModule,
+    fabric: L.Fabric, model: GPT, val_dataloader: DataLoader, tokenizer: Tokenizer, eval: EvalArgs, data: DataModule,
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -278,7 +278,7 @@ def get_lr_scheduler(optimizer, warmup_steps: int, max_steps: int):
     return torch.optim.lr_scheduler.SequentialLR(optimizer, [scheduler1, scheduler2], milestones=[warmup_steps])
 
 
-def get_dataloaders(fabric: L.Fabric, data: LitDataModule, tokenizer: Tokenizer, train: TrainArgs) -> Tuple[DataLoader, DataLoader]:
+def get_dataloaders(fabric: L.Fabric, data: DataModule, tokenizer: Tokenizer, train: TrainArgs) -> Tuple[DataLoader, DataLoader]:
     data.connect(tokenizer=tokenizer, batch_size=train.micro_batch_size, max_seq_length=train.max_seq_length)
     with fabric.rank_zero_first():
         data.prepare_data()

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -14,7 +14,7 @@ from torch.utils.data import DataLoader
 from torchmetrics import RunningMean
 
 from litgpt.args import EvalArgs, TrainArgs
-from litgpt.data import Alpaca, LitDataModule
+from litgpt.data import Alpaca, DataModule
 from litgpt.generate.base import generate
 from litgpt.model import GPT, Block, Config
 from litgpt.prompts import save_prompt_style
@@ -40,7 +40,7 @@ def setup(
     precision: Optional[str] = None,
     devices: Union[int, str] = 1,
     resume: Union[bool, Path] = False,
-    data: Optional[LitDataModule] = None,
+    data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -100,7 +100,7 @@ def main(
     resume: Union[bool, Path],
     seed: int,
     config: Config,
-    data: LitDataModule,
+    data: DataModule,
     checkpoint_dir: Path,
     out_dir: Path,
     train: TrainArgs,
@@ -169,7 +169,7 @@ def fit(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
-    data: LitDataModule,
+    data: DataModule,
 ) -> None:
     model = state["model"]
     optimizer = state["optimizer"]
@@ -275,7 +275,7 @@ def fit(
 # FSDP has issues with `inference_mode`
 @torch.no_grad()
 def validate(
-    fabric: L.Fabric, model: GPT, val_dataloader: DataLoader, tokenizer: Tokenizer, eval: EvalArgs, data: LitDataModule,
+    fabric: L.Fabric, model: GPT, val_dataloader: DataLoader, tokenizer: Tokenizer, eval: EvalArgs, data: DataModule,
 ) -> torch.Tensor:
     fabric.print("Validating ...")
     model.eval()
@@ -315,7 +315,7 @@ def get_lr_scheduler(optimizer, warmup_steps: int, max_steps: int):
     return torch.optim.lr_scheduler.SequentialLR(optimizer, [scheduler1, scheduler2], milestones=[warmup_steps])
 
 
-def get_dataloaders(fabric: L.Fabric, data: LitDataModule, tokenizer: Tokenizer, train: TrainArgs) -> Tuple[DataLoader, DataLoader]:
+def get_dataloaders(fabric: L.Fabric, data: DataModule, tokenizer: Tokenizer, train: TrainArgs) -> Tuple[DataLoader, DataLoader]:
     data.connect(tokenizer=tokenizer, batch_size=train.micro_batch_size, max_seq_length=train.max_seq_length)
     with fabric.rank_zero_first():
         data.prepare_data()

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -20,7 +20,7 @@ from typing_extensions import Literal
 
 from litgpt import Tokenizer
 from litgpt.args import EvalArgs, TrainArgs
-from litgpt.data import LitDataModule, TinyLlama
+from litgpt.data import DataModule, TinyLlama
 from litgpt.model import GPT, Block, CausalSelfAttention, Config, LLaMAMLP
 from litgpt.utils import (
     CLI,
@@ -40,7 +40,7 @@ def setup(
     model_config: Optional[Config] = None,
     out_dir: Path = Path("out/pretrain"),
     resume: Union[bool, Path] = False,
-    data: Optional[LitDataModule] = None,
+    data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
@@ -116,7 +116,7 @@ def main(
     seed: int,
     resume: Union[bool, Path],
     config: Config,
-    data: LitDataModule,
+    data: DataModule,
     out_dir: Path,
     tokenizer_dir: Optional[Path],
     tokenizer: Optional[Tokenizer],
@@ -331,7 +331,7 @@ def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max
 
 
 def get_dataloaders(
-    fabric: L.Fabric, data: LitDataModule, tokenizer: Tokenizer, train: TrainArgs, block_size: int
+    fabric: L.Fabric, data: DataModule, tokenizer: Tokenizer, train: TrainArgs, block_size: int
 ) -> Tuple[DataLoader, DataLoader]:
     data.connect(tokenizer=tokenizer, batch_size=train.micro_batch_size, max_seq_length=block_size)
     with fabric.rank_zero_first():

--- a/tests/data/test_lit_data.py
+++ b/tests/data/test_lit_data.py
@@ -1,0 +1,34 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+from unittest import mock
+
+import pytest
+
+from litgpt.data import LitData
+
+
+@mock.patch("litgpt.data.lit_data.LitData._dataloader")
+def test_input_dir_and_splits(dl_mock, tmp_path):
+
+    with pytest.raises(ValueError, match="If provided `split_names` must be a tuple of two strings"):
+        LitData(data_path=tmp_path, split_names=("train",))
+
+    # local dir, no splits
+    data = LitData(data_path=tmp_path)
+    data.train_dataloader()
+    dl_mock.assert_called_with(input_dir=str(tmp_path), train=True)
+    data.val_dataloader()
+    dl_mock.assert_called_with(input_dir=str(tmp_path), train=False)
+
+    # local dir, splits
+    data = LitData(data_path=tmp_path, split_names=("train", "val"))
+    data.train_dataloader()
+    dl_mock.assert_called_with(input_dir=str(tmp_path / "train"), train=True)
+    data.val_dataloader()
+    dl_mock.assert_called_with(input_dir=str(tmp_path / "val"), train=False)
+
+    # remote dir, splits
+    data = LitData(data_path="s3://mydataset/data", split_names=("train", "val"))
+    data.train_dataloader()
+    dl_mock.assert_called_with(input_dir=str("s3://mydataset/data/train"), train=True)
+    data.val_dataloader()
+    dl_mock.assert_called_with(input_dir=str("s3://mydataset/data/val"), train=False)

--- a/tests/data/test_lit_data.py
+++ b/tests/data/test_lit_data.py
@@ -4,8 +4,10 @@ from unittest import mock
 import pytest
 
 from litgpt.data import LitData
+from conftest import RunIf
 
 
+@RunIf(skip_windows=True)  # TODO: Find smarter way to join URL/path to be platform agnostic
 @mock.patch("litgpt.data.lit_data.LitData._dataloader")
 def test_input_dir_and_splits(dl_mock, tmp_path):
 

--- a/tests/data/test_lit_data.py
+++ b/tests/data/test_lit_data.py
@@ -1,13 +1,13 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+import sys
 from unittest import mock
 
 import pytest
 
 from litgpt.data import LitData
-from conftest import RunIf
 
 
-@RunIf(skip_windows=True)  # TODO: Find smarter way to join URL/path to be platform agnostic
+@pytest.mark.skipif(sys.platform == "win32", reason="Needs to implement platform agnostic path/url joining")
 @mock.patch("litgpt.data.lit_data.LitData._dataloader")
 def test_input_dir_and_splits(dl_mock, tmp_path):
 

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -320,7 +320,7 @@ The models in LitGPT expect datasets for instruction finetuning in the following
 
 (Note that depending on the task, the `"input"` text can be an empty string, as shown above.)
 
-You can use your own data in LitGPT by either reading in a JSON file in the format shown above or by implementing a custom `LitDataModule`.
+You can use your own data in LitGPT by either reading in a JSON file in the format shown above or by implementing a custom `DataModule`.
 
 &nbsp;
 
@@ -370,7 +370,7 @@ You can also pass a directory containing a `train.json` and `val.json` to `--dat
 
 &nbsp;
 
-### Preparing Custom Datasets Using LitDataModule
+### Preparing Custom Datasets Using DataModule
 
 If you don't have a JSON file following the format described in the previous section, the easiest way to prepare a new dataset is to copy and modify one of the existing data modules in LitGPT:
 


### PR DESCRIPTION
Adds a datamodule that streams data using LitData's StreamingDataset of an already preprocessed dataset. 

Example:

```py
from litgpt.data import LitData

# stream data that you preprocessed using LitData
LitData(data_path="s3://mydataset")

# using subfolders for train and val
LitData(data_path="s3://mydataset", split_names=("train", "validation"))
```

In this PR, I'm also renaming `LitDataModule` as I found it could be confused to be related to LitData itself, which it isn't.


