### PR TITLE
Fix race condition when accessing `len(dataloader)` from LitData

### DIFF
--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -333,6 +333,7 @@ def fit(
 
 @torch.no_grad()
 def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max_iters: int) -> torch.Tensor:
+    fabric.barrier()
     fabric.print("Validating ...")
     model.eval()
 
@@ -347,6 +348,7 @@ def validate(fabric: L.Fabric, model: nn.Module, val_dataloader: DataLoader, max
         losses[k] = loss
 
     model.train()
+    fabric.barrier()
     return losses.mean()
 
 


### PR DESCRIPTION
I found a nasty race condition when you access `len(dataloader)` in the pretraining script.
Doesn't happen on single GPU, and is rare on multi-GPU. Found on 8xH100 very it is very likely to happen due to 8 GPUs. Also only happens when the /cache dir is empty and it's downloading chunks for the first time.

In this PR rewrote the validation loop so that it doesn't access `len(datalaoder)`. After this fix, I will work on a minimal repro for litdata to investigate.