### PR TITLE
Update weight initialization logic for faster init in pretrain

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For added convenience, you can also manually override config file setting via th
 
 
 ```bash
-litgpt finetune lora
+litgpt finetune lora \
   --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/finetune/llama-2-7b/lora.yaml \
   --lora_r 4
 ```

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -400,7 +400,7 @@ def patch_reset_parameters(model: GPT, n_layer: int, n_embd: int) -> None:
 
     for mod in model.modules():
         if isinstance(mod, (LLaMAMLP, CausalSelfAttention)):
-            mod.proj.reset_parameters = partial(init_proj_linear, mod)
+            mod.proj.reset_parameters = partial(init_proj_linear, mod.proj)
 
 
 def init_out_dir(out_dir: Path) -> Path:

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -387,7 +387,7 @@ def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None
 
     def init_weights(module, std):
         nn.init.normal_(module.weight, mean=0.0, std=std)
-        if getattr(module, "bias") is not None:
+        if getattr(module, "bias", None) is not None:
             nn.init.zeros_(module.bias)
 
     for mod in model.modules():

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -391,15 +391,13 @@ def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None
             nn.init.zeros_(module.bias)
 
     for mod in model.modules():
-        if isinstance(mod, nn.Embedding):
-            mod.reset_parameters = partial(init_weights, mod, math.sqrt(2.0 / 5 / n_embd))
-        elif isinstance(mod, nn.Linear):
-            mod.reset_parameters = partial(init_weights, mod, math.sqrt(2.0 / 5 / n_embd))
+        if isinstance(mod, (nn.Embedding, nn.Linear)):
+            mod.reset_parameters = partial(init_weights, mod, std=math.sqrt(2.0 / 5 / n_embd))
 
     # need a separate loop because `mod.proj` below is a `nn.Linear` too
     for mod in model.modules():
         if isinstance(mod, (LLaMAMLP, CausalSelfAttention)):
-            mod.proj.reset_parameters = partial(init_weights, mod.proj, (1 / math.sqrt(n_embd) / n_layer))
+            mod.proj.reset_parameters = partial(init_weights, mod.proj, std=(1 / math.sqrt(n_embd) / n_layer))
 
 
 def init_out_dir(out_dir: Path) -> Path:

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -382,8 +382,8 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
 
 
 def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None:
-    """GPT-Neox weight initialization (https://arxiv.org/abs/2204.06745)."""
-    # Adapted from https://github.com/jzhang38/TinyLlama/blob/bf12224/lit_gpt/model.py#L40-L54
+    """GPT-NeoX weight initialization (https://arxiv.org/abs/2204.06745)."""
+    # Adapted from https://github.com/jzhang38/TinyLlama
 
     def init_embedding(module):
         nn.init.normal_(module.weight, mean=0.0, std=math.sqrt(2.0 / 5 / n_embd))

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -152,7 +152,7 @@ def main(
     t0 = time.perf_counter()
     with fabric.init_module(empty_init=False):
         model = GPT(config)
-        model.apply(partial(init_weights, n_layer=config.n_layer, n_embd=config.n_embd))
+        patch_reset_parameters(model, n_layer=config.n_layer, n_embd=config.n_embd)
 
     if train.tie_embeddings:
         model.transformer.wte.weight = model.lm_head.weight

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -382,7 +382,7 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
 
 
 def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None:
-    """We are not allowed to use FSDP's `param_init_fn`."""
+    """GPT-Neox weight initialization (https://arxiv.org/abs/2204.06745)."""
     # Adapted from https://github.com/jzhang38/TinyLlama/blob/bf12224/lit_gpt/model.py#L40-L54
 
     def init_embedding(module):

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -150,7 +150,7 @@ def main(
     fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
 
     t0 = time.perf_counter()
-    with fabric.init_module():
+    with fabric.init_module(empty_init=True):
         model = GPT(config)
     
     prepare_weight_initialization(model, n_layer=config.n_layer, n_embd=config.n_embd)

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -150,7 +150,7 @@ def main(
     fabric.seed_everything(seed)  # same seed for every process to init model (FSDP)
 
     t0 = time.perf_counter()
-    with fabric.init_module(empty_init=False):
+    with fabric.init_module(empty_init=True):
         model = GPT(config)
         patch_reset_parameters(model, n_layer=config.n_layer, n_embd=config.n_embd)
 


### PR DESCRIPTION
Enables meta device initialization and patches the `reset_parameter()` methods on the modules that require special initialization. 

Fixes #1131

### Correctness test

In order to verify that my changes are correct and lead to the same initialization as before, I did a statistical test by comparing the weight distribution in a model using the old vs. the new implementation:


```py
import scipy.stats as stats

# The NEW way
fabric.seed_everything(seed)
with fabric.init_module(empty_init=True):
    model1 = GPT(config)
prepare_weight_initialization(model1, n_layer=config.n_layer, n_embd=config.n_embd)
model1 = fabric.setup(model1)
fabric.save("model1.ckpt", {"model": model1})

# The OLD way
fabric.seed_everything(seed)
with fabric.init_module(empty_init=False):
    model2 = GPT(config)
    model2.apply(partial(init_weights, n_layer=config.n_layer, n_embd=config.n_embd))
model2 = fabric.setup(model2)
fabric.save("model2.ckpt", {"model": model2})

# Compare both with Kolmogorov-Smirnov test
if fabric.global_rank == 0:
    m1 = torch.load("model1.ckpt", map_location="cpu")["model"]
    m2 = torch.load("model2.ckpt", map_location="cpu")["model"]
    for (k, t1), (_, t2) in zip(m1.items(), m2.items()):
        # assert torch.allclose(t1, t2)
        print(k, stats.kstest(t1.numpy().flatten(), t2.numpy().flatten()))
fabric.barrier()
```

Note that I can't do `assert torch.all_close()` after running both implementations with the same seed, because the order in which `torch.nn.init` is applied is different between the two implementations.

I get large p-values (>0.05) for the weights, indicating that we can't reject the null-hypothesis and that the distributions are identical:
```
lm_head.weight KstestResult(statistic=0.00018505859375000933, pvalue=0.21170577523412093, statistic_location=-0.008508166, statistic_sign=1)
transformer.wte.weight KstestResult(statistic=0.00013301086425782094, pvalue=0.6079661638843818, statistic_location=-0.007603332, statistic_sign=-1)
transformer.h.0.norm_1.weight KstestResult(statistic=0.0, pvalue=1.0, statistic_location=1.0, statistic_sign=1)
transformer.h.0.attn.attn.weight KstestResult(statistic=0.001164817810058616, pvalue=0.0016267489714413624, statistic_location=0.0013335593, statistic_sign=1)
transformer.h.0.attn.proj.weight KstestResult(statistic=0.0009093284606933594, pvalue=0.062307822621550435, statistic_location=0.00021914368, statistic_sign=-1)
transformer.h.0.norm_2.weight KstestResult(statistic=0.0, pvalue=1.0, statistic_location=1.0, statistic_sign=1)
transformer.h.0.mlp.fc_1.weight KstestResult(statistic=0.0002659017389471108, pvalue=0.8093904351164989, statistic_location=-0.011995676, statistic_sign=-1)
transformer.h.0.mlp.fc_2.weight KstestResult(statistic=0.00038172981955797436, pvalue=0.3699685422638883, statistic_location=0.0050775656, statistic_sign=1)
transformer.h.0.mlp.proj.weight KstestResult(statistic=0.00025653839111328125, pvalue=0.8422111752953825, statistic_location=4.2137613e-05, statistic_sign=-1)
transformer.h.1.norm_1.weight KstestResult(statistic=0.0, pvalue=1.0, statistic_location=1.0, statistic_sign=1)
transformer.h.1.attn.attn.weight KstestResult(statistic=0.0004657745361328347, pvalue=0.6200470857062359, statistic_location=0.008084688, statistic_sign=1)
transformer.h.1.attn.proj.weight KstestResult(statistic=0.0006241798400878906, pvalue=0.3871986466592584, statistic_location=-0.00033434434, statistic_sign=1)
transformer.h.1.norm_2.weight KstestResult(statistic=0.0, pvalue=1.0, statistic_location=1.0, statistic_sign=1)
transformer.h.1.mlp.fc_1.weight KstestResult(statistic=0.0003636100075461446, pvalue=0.43066561500241374, statistic_location=0.0007729053, statistic_sign=1)
transformer.h.1.mlp.fc_2.weight KstestResult(statistic=0.0005398663607509846, pvalue=0.06932135322020994, statistic_location=0.00015185622, statistic_sign=1)
transformer.h.1.mlp.proj.weight KstestResult(statistic=0.0002085945822976054, pvalue=0.9632970158359048, statistic_location=0.001063874, statistic_sign=-1)
transformer.h.2.norm_1.weight KstestResult(statistic=0.0, pvalue=1.0, statistic_location=1.0, statistic_sign=1)
transformer.h.2.attn.attn.weight KstestResult(statistic=0.0004840850830079013, pvalue=0.5705812414128038, statistic_location=0.002112709, statistic_sign=-1)
transformer.h.2.attn.proj.weight KstestResult(statistic=0.0005927085876464844, pvalue=0.45257514125754295, statistic_location=0.0006127164, statistic_sign=1)
...
```
