### PR TITLE
Fix bnb issue

### DIFF
--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -39,7 +39,10 @@ def num_parameters(module: nn.Module, requires_grad: Optional[bool] = None) -> i
         if requires_grad is None or p.requires_grad == requires_grad:
             if hasattr(p, "quant_state"):
                 # bitsandbytes 4bit layer support
-                total += math.prod(p.quant_state.shape)
+                if isinstance(p.quant_state, list):
+                    total += math.prod(p.quant_state[1])
+                else:
+                    total += math.prod(p.quant_state.shape)
             else:
                 total += p.numel()
     return total


### PR DESCRIPTION
I have no idea why it's happening, but when running even with the previously working tinyllama qlora checkpoint, I am not getting a BnB-related error (that's in bnb 0.41.0):

```
⚡ phi2-checkpoint ~/lit-gpt git checkout -b 'fix-bnb'
⚡ phi2-checkpoint ~/lit-gpt litgpt finetune lora --config config_hub/finetune/tiny-llama/qlora.yaml      
{'checkpoint_dir': PosixPath('checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T'),
 'data': Alpaca2k(mask_prompt=False,
                  val_split_fraction=0.03847,
                  prompt_style=<litgpt.prompts.Alpaca object at 0x7f912ec7a6e0>,
                  ignore_index=-100,
                  seed=42,
                  num_workers=4,
                  download_dir=PosixPath('data/alpaca2k')),
 'devices': 1,
 'eval': EvalArgs(interval=100, max_new_tokens=100, max_iters=100),
 'logger_name': 'csv',
 'lora_alpha': 16,
 'lora_dropout': 0.05,
 'lora_head': True,
 'lora_key': True,
 'lora_mlp': True,
 'lora_projection': True,
 'lora_query': True,
 'lora_r': 32,
 'lora_value': True,
 'out_dir': PosixPath('out/finetune/qlora-tiny-llama-1.1b'),
 'precision': 'bf16-true',
 'quantize': 'bnb.nf4',
 'seed': 1337,
 'train': TrainArgs(save_interval=800,
                    log_interval=1,
                    global_batch_size=8,
                    micro_batch_size=8,
                    lr_warmup_steps=10,
                    epochs=3,
                    max_tokens=None,
                    max_steps=None,
                    max_seq_length=512,
                    tie_embeddings=None,
                    learning_rate=0.0002,
                    weight_decay=0.0,
                    beta1=0.9,
                    beta2=0.95,
                    max_norm=None,
                    min_lr=6e-05)}
Seed set to 1337
Number of trainable parameters: 26,320,896
Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/bin/litgpt", line 8, in <module>
    sys.exit(main())
  File "/teamspace/studios/this_studio/lit-gpt/litgpt/__main__.py", line 129, in main
    fn(**kwargs)
  File "/teamspace/studios/this_studio/lit-gpt/litgpt/finetune/lora.py", line 138, in setup
    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 866, in launch
    return self._wrap_and_launch(function, self, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 952, in _wrap_and_launch
    return to_run(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 957, in _wrap_with_setup
    return to_run(*args, **kwargs)
  File "/teamspace/studios/this_studio/lit-gpt/litgpt/finetune/lora.py", line 171, in main
    fabric.print(f"Number of non trainable parameters: {num_parameters(model, requires_grad=False):,}")
  File "/teamspace/studios/this_studio/lit-gpt/litgpt/utils.py", line 42, in num_parameters
    total += math.prod(p.quant_state.shape)
AttributeError: 'list' object has no attribute 'shape'
⚡ phi2-checkpoint ~/lit-gpt 
```

I am getting this for other models as well. Turns out `p.quant_state` is a list with the shape information in second place:

```
[tensor([0.0220, 0.0217, 0.0217,  ..., 0.0221, 0.0210, 0.0217], device='cuda:0'), torch.Size([5632, 2048]), torch.float16, 64, None, 'nf4', tensor([-1.0000, -0.6953, -0.5234, -0.3945, -0.2852, -0.1846, -0.0908,  0.0000,
         0.0796,  0.1611,  0.2461,  0.3379,  0.4414,  0.5625,  0.7227,  1.0000],
```

So this is a workaround. 

Does anyone know why this is happening now and if there's perhaps a better way to fix this?