### PR TITLE
Add safetensors to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ all = [
     "pyarrow",                   # litgpt.data.prepare_starcoder.py
     "tensorboard",               # litgpt.pretrain
     "torchmetrics",              # litgpt.pretrain
+    "safetensors",               # download
     "huggingface_hub[hf_transfer]>=0.21.0"  # download
 ]
 


### PR DESCRIPTION
We need to add safetensors to the requirements for downloading models such as phi-2