### PR TITLE
Fix weight initialization for single device pretraining

### DIFF
--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -154,7 +154,7 @@ def main(
     with fabric.init_module(empty_init=True):
         model = GPT(config)
     
-    init_weights(fabric, model, n_layer=config.n_layer, n_embd=config.n_embd)
+    initialize_weights(fabric, model, n_layer=config.n_layer, n_embd=config.n_embd)
 
     if train.tie_embeddings:
         model.transformer.wte.weight = model.lm_head.weight
@@ -382,7 +382,7 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
     return min_lr + coeff * (learning_rate - min_lr)
 
 
-def init_weights(fabric: L.Fabric, model: GPT, n_layer: int, n_embd: int) -> None:
+def initialize_weights(fabric: L.Fabric, model: GPT, n_layer: int, n_embd: int) -> None:
     """GPT-NeoX weight initialization (https://arxiv.org/abs/2204.06745)."""
     # Adapted from https://github.com/jzhang38/TinyLlama
 

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -32,6 +32,7 @@ from litgpt.utils import (
     parse_devices,
     save_config,
     save_hyperparameters,
+    reset_parameters,
 )
 
 
@@ -153,7 +154,7 @@ def main(
     with fabric.init_module(empty_init=True):
         model = GPT(config)
     
-    prepare_weight_initialization(model, n_layer=config.n_layer, n_embd=config.n_embd)
+    init_weights(fabric, model, n_layer=config.n_layer, n_embd=config.n_embd)
 
     if train.tie_embeddings:
         model.transformer.wte.weight = model.lm_head.weight
@@ -381,7 +382,7 @@ def get_lr(learning_rate: float, it: int, warmup_iters: int, max_iters: int, min
     return min_lr + coeff * (learning_rate - min_lr)
 
 
-def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None:
+def init_weights(fabric: L.Fabric, model: GPT, n_layer: int, n_embd: int) -> None:
     """GPT-NeoX weight initialization (https://arxiv.org/abs/2204.06745)."""
     # Adapted from https://github.com/jzhang38/TinyLlama
 
@@ -398,6 +399,9 @@ def prepare_weight_initialization(model: GPT, n_layer: int, n_embd: int) -> None
     for mod in model.modules():
         if isinstance(mod, (LLaMAMLP, CausalSelfAttention)):
             mod.proj.reset_parameters = partial(init_weights, mod.proj, std=(1 / math.sqrt(n_embd) / n_layer))
+
+    if not isinstance(fabric.strategy, FSDPStrategy):
+        reset_parameters(model)
 
 
 def init_out_dir(out_dir: Path) -> Path:

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -45,6 +45,13 @@ def num_parameters(module: nn.Module, requires_grad: Optional[bool] = None) -> i
     return total
 
 
+def reset_parameters(module: nn.Module) -> None:
+    """Calls `reset_parameters` on the module and all its submodules."""
+    for mod in module.modules():
+        if callable(getattr(mod, "reset_parameters", None)):
+            mod.reset_parameters()
+
+
 def check_valid_checkpoint_dir(checkpoint_dir: Path, lora: bool = False) -> None:
     model_filename = "lit_model.pth.lora" if lora else "lit_model.pth"
     files = {

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -11,6 +11,7 @@ import pytest
 import torch
 from conftest import RunIf
 from torch.utils.data import DataLoader
+from lightning.fabric.strategies import SingleDeviceStrategy, FSDPStrategy
 
 
 @RunIf(min_cuda_gpus=2, standalone=True)
@@ -102,3 +103,20 @@ def test_init_out_dir(tmp_path):
     with mock.patch.dict(os.environ, {"LIGHTNING_ARTIFACTS_DIR": "prefix"}):
         assert init_out_dir(relative_path) == Path("prefix") / relative_path
         assert init_out_dir(absolute_path) == absolute_path
+
+
+@pytest.mark.parametrize(("strategy", "expected"), [(SingleDeviceStrategy, True), (FSDPStrategy, False)])
+def test_initialize_weights(strategy, expected):
+    from litgpt.pretrain import initialize_weights
+
+    fabric_mock = Mock()
+    fabric_mock.strategy = Mock(spec=strategy)
+
+    class Model(torch.nn.Module):
+        pass
+
+    model = Model()
+    model.reset_parameters = Mock()
+
+    initialize_weights(fabric_mock, model, n_layer=2, n_embd=8)
+    model.reset_parameters.call_count == int(expected)

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -112,11 +112,18 @@ def test_initialize_weights(strategy, expected):
     fabric_mock = Mock()
     fabric_mock.strategy = Mock(spec=strategy)
 
-    class Model(torch.nn.Module):
+    class Child(torch.nn.Module):
         pass
 
-    model = Model()
+    class Parent(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.child = Child()
+
+    model = Parent()
     model.reset_parameters = Mock()
+    model.child.reset_parameters = Mock()
 
     initialize_weights(fabric_mock, model, n_layer=2, n_embd=8)
     assert model.reset_parameters.call_count == int(expected)
+    assert model.child.reset_parameters.call_count == int(expected)

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -119,4 +119,4 @@ def test_initialize_weights(strategy, expected):
     model.reset_parameters = Mock()
 
     initialize_weights(fabric_mock, model, n_layer=2, n_embd=8)
-    model.reset_parameters.call_count == int(expected)
+    assert model.reset_parameters.call_count == int(expected)


### PR DESCRIPTION
The weight initialization currently only applies if FSDP is used, which is the normal use case. But for debugging and small models, it could make sense to run pretraining on a single GPU.

Fixes #1150