### PR TITLE
Print conversion target dir

### DIFF
--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -347,7 +347,7 @@ def convert_hf_checkpoint(
             hf_weights = lazy_load(bin_file)
             copy_fn(sd, hf_weights, saver=saver, dtype=dtype)
         gc.collect()
-        print("Saving converted checkpoint")
+        print(f"Saving converted checkpoint to {checkpoint_dir}")
         saver.save(sd)
 
 


### PR DESCRIPTION
Suppose a new user runs `litgpt download` ... They won't necessarily know where the model files are saved, and they might have to go to the docs or read the `--help` outputs to find out:

```
...
Loading 'gpt_neox.layers.4.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.weight' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.bias' into RAM
Loading 'gpt_neox.layers.5.attention.dense.weight' into RAM
Loading 'gpt_neox.layers.5.attention.dense.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.final_layer_norm.weight' into RAM
Loading 'gpt_neox.final_layer_norm.bias' into RAM
Loading 'embed_out.weight' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.weight' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.bias' into RAM
Loading 'gpt_neox.layers.5.attention.dense.weight' into RAM
Loading 'gpt_neox.layers.5.attention.dense.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.final_layer_norm.weight' into RAM
Loading 'gpt_neox.final_layer_norm.bias' into RAM
Loading 'embed_out.weight' into RAM
Saving converted checkpoint
```

To make it a bit easier for new users, this PR simply prints the destination on the last line:

```
...
Loading 'gpt_neox.layers.4.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.4.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.input_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.weight' into RAM
Loading 'gpt_neox.layers.5.post_attention_layernorm.bias' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.weight' into RAM
Loading 'gpt_neox.layers.5.attention.query_key_value.bias' into RAM
Loading 'gpt_neox.layers.5.attention.dense.weight' into RAM
Loading 'gpt_neox.layers.5.attention.dense.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_h_to_4h.bias' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.weight' into RAM
Loading 'gpt_neox.layers.5.mlp.dense_4h_to_h.bias' into RAM
Loading 'gpt_neox.final_layer_norm.weight' into RAM
Loading 'gpt_neox.final_layer_norm.bias' into RAM
Loading 'embed_out.weight' into RAM
Saving converted checkpoint to checkpoints/EleutherAI/pythia-14m
```