### PR TITLE
GemmaMLP: add missing approximation for LoRA and AdapterV2 variants

### DIFF
--- a/litgpt/adapter_v2.py
+++ b/litgpt/adapter_v2.py
@@ -181,6 +181,8 @@ class LLaMAMLP(litgpt.model.LLaMAMLP):
         self.fc_2 = AdapterV2Linear(config.n_embd, config.intermediate_size, bias=config.bias)
         self.proj = AdapterV2Linear(config.intermediate_size, config.n_embd, bias=config.bias)
 
+        self.config = config
+
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""
         mapping = {
@@ -199,7 +201,7 @@ class GemmaMLP(LLaMAMLP):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_fc_1 = self.fc_1(x)
         x_fc_2 = self.fc_2(x)
-        x = torch.nn.functional.gelu(x_fc_1) * x_fc_2
+        x = torch.nn.functional.gelu(x_fc_1, approximate=self.config.gelu_approximate) * x_fc_2
         return self.proj(x)
 
 

--- a/litgpt/lora.py
+++ b/litgpt/lora.py
@@ -686,6 +686,8 @@ class LLaMAMLP(litgpt.model.LLaMAMLP):
             lora_dropout=config.lora_dropout,
         )
 
+        self.config = config
+
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""
         mapping = {
@@ -704,7 +706,7 @@ class GemmaMLP(LLaMAMLP):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_fc_1 = self.fc_1(x)
         x_fc_2 = self.fc_2(x)
-        x = torch.nn.functional.gelu(x_fc_1) * x_fc_2
+        x = torch.nn.functional.gelu(x_fc_1, approximate=self.config.gelu_approximate) * x_fc_2
         return self.proj(x)
 
 

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -556,7 +556,7 @@ def test_against_hf_mixtral():
 
 
 @torch.inference_mode()
-@pytest.mark.xfail(reason=AssertionError, match="Tensor-likes are not close")
+@pytest.mark.xfail(raises=AssertionError, match="Tensor-likes are not close")
 @pytest.mark.parametrize("model_name", ["gemma-2b", "gemma-7b"])
 def test_against_hf_gemma(model_name):
     device = torch.device("cpu")

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -15,6 +15,7 @@ from lightning.fabric.plugins.precision.bitsandbytes import _BITSANDBYTES_AVAILA
 from lightning.fabric.wrappers import _FabricOptimizer
 from torch._dynamo.backends import debugging
 from torch.nn import functional as F
+from transformers.models.gemma import GemmaConfig, GemmaForCausalLM
 from transformers.models.mixtral import MixtralConfig, MixtralForCausalLM
 
 import litgpt.config as config_module
@@ -548,6 +549,48 @@ def test_against_hf_mixtral():
 
     # test end to end
     x = torch.tensor([[9856, 23, 491, 1536, 304], [23, 345, 65, 123, 321]], dtype=torch.int32, device=device)
+    assert x.size(1) == T
+    ours_y = ours_model(x)
+    theirs_y = theirs_model(x)["logits"].to(dtype)  # HF converts logits to float
+    torch.testing.assert_close(ours_y, theirs_y)
+
+
+@torch.inference_mode()
+@pytest.mark.xfail(reason=AssertionError, match="Tensor-likes are not close")
+@pytest.mark.parametrize("model_name", ["gemma-2b", "gemma-7b"])
+def test_against_hf_gemma(model_name):
+    device = torch.device("cpu")
+    dtype = torch.float32
+    T = 5
+    ours_config = Config.from_name(model_name, n_layer=2, n_head=16, n_embd=32, intermediate_size=86)
+    theirs_config = GemmaConfig(
+        vocab_size=ours_config.padded_vocab_size,
+        hidden_size=ours_config.n_embd,
+        head_dim=ours_config.head_size,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
+        intermediate_size=ours_config.intermediate_size,
+        max_position_embeddings=T,
+        rms_norm_eps=ours_config.norm_eps,
+        num_key_value_heads=ours_config.n_query_groups,
+        rope_theta=ours_config.rope_base,
+        attention_bias=ours_config.bias,
+        tie_word_embeddings=True,
+        hidden_act="gelu_pytorch_tanh",
+    )
+    assert ours_config.intermediate_size == theirs_config.intermediate_size
+
+    theirs_model = GemmaForCausalLM(theirs_config).to(device)
+    theirs_state_dict = theirs_model.state_dict()
+    # Gemma weights are shipped without `lm_head.weight`
+    theirs_state_dict.pop("lm_head.weight")
+    state_dict = {}
+    copy_weights_hf_llama(ours_config, {}, state_dict, theirs_state_dict)
+    ours_model = LoRAGPT(ours_config).to(device)
+    ours_model.load_state_dict(state_dict)
+
+    # test end to end
+    x = torch.tensor([[9856, 23, 491, 1536, 304]], dtype=torch.int32, device=device)
     assert x.size(1) == T
     ours_y = ours_model(x)
     theirs_y = theirs_model(x)["logits"].to(dtype)  # HF converts logits to float


### PR DESCRIPTION
Hi there 👋 

In #1004 I added GeLU approximation only to the base implementation and totally forgot about LoRA and AdapterV2 variants.

In added tests there is a `pytest.mark.xfail` because I couldn't fine the reason, at least for now.
When I moved all the tests from `tests/test_model.py` into LoRA and AdapterV2 tests (and replaced base GPT with the corresponding variant) all the tests passed, except for Gemma.

Later I'll come back to the test, most likely after #1031.