### PR TITLE
bump: `lightning ==2.3.0.dev20240324`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { file = "LICENSE" }
 
 dependencies = [
     "torch>=2.2.0",
-    "lightning==2.3.0.dev20240318",
+    "lightning==2.3.0.dev20240324",
     "jsonargparse[signatures]>=4.27.6",
 ]
 


### PR DESCRIPTION
resolves pinned dependencies leaked from `lightning` package, part of https://github.com/Lightning-AI/lightning-thunder/pull/52#issuecomment-2016080745