### PR TITLE
Add support for GaLore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ test = [
     "lightning-thunder; python_version >= '3.10'",
 ]
 all = [
+    "galore-torch",              # galore
     "bitsandbytes==0.42.0",      # quantization
     "sentencepiece",             # llama-based models
     "tokenizers",                # pythia, falcon, redpajama


### PR DESCRIPTION
The current implementation adds GaLore to the full finetuning script. 


## Example

```
litgpt finetune full --checkpoint_dir checkpoints/EleutherAI/pythia-160m --data Alpaca2k --train.max_steps 5 

# Training time: 14.13s
# Memory used: 3.44 GB

litgpt finetune full --checkpoint_dir checkpoints/EleutherAI/pythia-160m --data Alpaca2k --train.max_steps 5  --use_galore true


# Training time: 23.59s
# Memory used: 3.44 GB
```

## Discuss

We could also add it to LoRA
- this would require a check that GaLore is only used when QLoRA is disabled
- we can actually use it with some bnb precision settings (this would be supported according to them via `GaloreAdamW8Bit`)

I specified the galore args similar to what we do with lora. But since this is more an addon to existing methods like `full` and `lora` , should we maybe make this part of `TrainArgs`?

We can also think about making a dedicated subcommand like for qlora in the future. Ie.., 


```
litgpt finetune full --config ... 

litgpt finetune lora --config ... 

litgpt finetune qlora --config ... [in progress]

litgpt finetune galore --config ... [maybe in future]
```

## Todos

- [ ] Add Galore for full finetuning
- [ ] Check if default args are good
- [ ] Add docstrings
- [ ] Discuss if we use TrainArgs (see above)
- [ ] Add Galore for lora finetuning
- [ ] Throw error if galore and qlora are used at the same time if Qlora is not 8bit
- [ ] Add galore for pretraining
- [ ] Add tests
- [ ] Add GaLore package to the acknowledgements section
- [ ] Add documentation
- [ ] Add configs YAMLs and benchmarks


