### PR TITLE
Gemma: WTE scaling for Adapter and LoRA

### DIFF
--- a/litgpt/adapter.py
+++ b/litgpt/adapter.py
@@ -66,6 +66,8 @@ class GPT(BaseModel):
             mask = None
 
         x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
+        if self.config.scale_embeddings:
+            x = x * (self.config.n_embd**0.5)
         for block in self.transformer.h:
             x = block(x, cos, sin, mask, input_pos)
         x = self.transformer.ln_f(x)

--- a/litgpt/lora.py
+++ b/litgpt/lora.py
@@ -542,6 +542,8 @@ class GPT(BaseModel):
             mask = None
 
         x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
+        if self.config.scale_embeddings:
+            x = x * (self.config.n_embd**0.5)
         for block in self.transformer.h:
             x = block(x, cos, sin, mask, input_pos)
         x = self.transformer.ln_f(x)

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -209,7 +209,6 @@ def test_against_hf_mixtral():
 
 
 @torch.inference_mode()
-@pytest.mark.xfail(raises=AssertionError, match="Tensor-likes are not close")
 @pytest.mark.parametrize("model_name", ["gemma-2b", "gemma-7b"])
 def test_against_hf_gemma(model_name):
     device = torch.device("cpu")

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -556,7 +556,6 @@ def test_against_hf_mixtral():
 
 
 @torch.inference_mode()
-@pytest.mark.xfail(raises=AssertionError, match="Tensor-likes are not close")
 @pytest.mark.parametrize("model_name", ["gemma-2b", "gemma-7b"])
 def test_against_hf_gemma(model_name):
     device = torch.device("cpu")


### PR DESCRIPTION
Hi there 👋 

Apparently I forgot one more thing: WTE scaling in Adapter and LoRA variants for Gemma model.
That explain why when I did fine-tuning with 2b model the loss started from ~12 (in contrast to ~2 after the fix) and why tests failed.