### PR TITLE
Gemma 7B x LoRA fix

### DIFF
--- a/litgpt/adapter_v2.py
+++ b/litgpt/adapter_v2.py
@@ -99,6 +99,8 @@ class GPT(BaseModel):
             mask = None
 
         x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
+        if self.config.scale_embeddings:
+            x = x * (self.config.n_embd**0.5)
         for block in self.transformer.h:
             x = block(x, cos, sin, mask, input_pos)
         x = self.transformer.ln_f(x)

--- a/litgpt/lora.py
+++ b/litgpt/lora.py
@@ -239,7 +239,7 @@ class LoRAQKVLinear(LoRALinear):
             enable_q, enable_k, enable_v = enable_lora
             # qkv_shapes will be used to split a tensor with weights correctly
             qkv_shapes = (
-                # if `head_size` is explicitly specified in the config, `n_emd` (or `in_features`)
+                # if `head_size` is explicitly specified in the config, `n_embd` (or `in_features`)
                 # might not be equal to `head_size * n_head`, thus we use it directly here
                 head_size * n_head * enable_q,
                 head_size * n_query_groups * enable_k,

--- a/litgpt/lora.py
+++ b/litgpt/lora.py
@@ -185,6 +185,7 @@ class LoRAQKVLinear(LoRALinear):
         in_features: int,
         out_features: int,
         # ↓ the remaining part is for LoRA
+        head_size: int,
         n_head: int,
         n_query_groups: int,
         r: int = 0,
@@ -204,6 +205,7 @@ class LoRAQKVLinear(LoRALinear):
         Args:
             in_features: number of input features of the pretrained weights
             out_features: number of output features of the pretrained weights
+            head_size: size of a single attention head
             n_head: number of attention heads
             n_query_groups: number of query groups (see diagram in `litgpt/config.py`)
             r: rank of the weight update matrices. To make sense of using LoRA the rank should be smaller than the rank of
@@ -234,12 +236,13 @@ class LoRAQKVLinear(LoRALinear):
         if r > 0 and any(enable_lora):
             self.lora_A = nn.Parameter(torch.zeros((r * sum(enable_lora), in_features)))  # (4, 128)
             enable_q, enable_k, enable_v = enable_lora
-            self.kv_embd_size = self.linear.in_features // (n_head // n_query_groups)
             # qkv_shapes will be used to split a tensor with weights correctly
             qkv_shapes = (
-                self.linear.in_features * enable_q,
-                self.kv_embd_size * enable_k,
-                self.kv_embd_size * enable_v,
+                # if `head_size` is explicitly specified in the config, `n_emd` (or `in_features`)
+                # might not be equal to `head_size * n_head`, thus we use it directly here
+                head_size * n_head * enable_q,
+                head_size * n_query_groups * enable_k,
+                head_size * n_query_groups * enable_v,
             )
             self.qkv_shapes = [s for s in qkv_shapes if s]
             self.lora_B = nn.Parameter(torch.zeros(sum(self.qkv_shapes), r))  # (256, 2))
@@ -594,6 +597,7 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             enable_lora=(config.lora_query, config.lora_key, config.lora_value),
             bias=config.bias,
             # for MQA/GQA support
+            head_size=config.head_size,
             n_head=config.n_head,
             n_query_groups=config.n_query_groups,
         )

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -234,7 +234,7 @@ def test_lora_init_when_linear_overridden():
     original_linear = torch.nn.Linear
     # Our bnb does this sort of monkey patching
     torch.nn.Linear = MyLinear
-    layer = LoRAQKVLinear(1, 1, 1, 1)
+    layer = LoRAQKVLinear(1, 1, 1, 1, 1)
     assert isinstance(layer.linear, original_linear)
     torch.nn.Linear = original_linear
 
@@ -324,6 +324,7 @@ def test_lora_gpt_query_groups_merge_and_forward_no_exception(n_query_groups, ap
 
 
 @torch.inference_mode()
+@pytest.mark.parametrize("head_size", (1, 2, 4))
 @pytest.mark.parametrize("n_head", (1, 2, 3, 6, 12))
 @pytest.mark.parametrize(
     "enable_lora",
@@ -337,9 +338,11 @@ def test_lora_gpt_query_groups_merge_and_forward_no_exception(n_query_groups, ap
         (True, True, True),
     ],
 )
-def test_lora_qkv_linear_compare_conv1d(n_head, enable_lora):
+def test_lora_qkv_linear_compare_conv1d(head_size, n_head, enable_lora):
     C = 12
-    layer = LoRAQKVLinear(C, 3 * C, n_head=n_head, n_query_groups=n_head, r=2, enable_lora=enable_lora)
+    layer = LoRAQKVLinear(
+        C, 3 * C, head_size=head_size, n_head=n_head, n_query_groups=n_head, r=2, enable_lora=enable_lora
+    )
     x = torch.randn((1, 1, C))
     a = F.linear(x, layer.lora_A).transpose(-2, -1)  # after_A
     b = layer.lora_B.data.unsqueeze(-1)
@@ -371,7 +374,8 @@ def test_lora_linear_weights_merged_status(rank, expected_merged):
     ((0, True, False), (1, True, True), (0, False, False), (1, False, False)),
 )
 def test_lora_qkv_linear_weights_merged_status(rank, enable_lora, expected_merged):
-    layer = LoRAQKVLinear(10, 3 * 10, n_head=2, n_query_groups=2, r=rank, enable_lora=enable_lora)
+    C = 10
+    layer = LoRAQKVLinear(C, 3 * C, head_size=5, n_head=2, n_query_groups=2, r=rank, enable_lora=enable_lora)
     assert not layer.merged
     layer.merge()
     assert layer.merged == expected_merged
@@ -576,6 +580,7 @@ def test_against_hf_gemma(model_name):
         head_size=4,
         intermediate_size=86,
         lora_r=1,
+        lora_query=True,
         lora_key=True,
         lora_value=True,
     )


### PR DESCRIPTION
Hi there 👋 

This PR fixes an issue with Gemma 7B variant and LoRA. The problem is that for the 7B variant `n_emd` != `head_size` * `n_head` and thus that caused an error when calculating the shape for `lora_B`.

Fixes #1124