### PR TITLE
Smarter `thunder.jit` decisions

### DIFF
--- a/extensions/thunder/strategies/thunder_fsdp.py
+++ b/extensions/thunder/strategies/thunder_fsdp.py
@@ -54,12 +54,54 @@ class ThunderFSDPStrategy(ParallelStrategy, _Sharded):
         cluster_environment: Optional[ClusterEnvironment] = None,
         checkpoint_io: Optional[CheckpointIO] = None,
         precision: Optional[Precision] = None,
+        jit: bool = True,
+        executors: Optional[Tuple[Union["Executor", str], ...]] = None,
         sharding_strategy: "_FSDP_TYPE" = "ZERO3",
         bucketing_strategy: "_BUCKETING_STRATEGY" = "NONE",
-        executors: Optional[Tuple[Union["Executor", str], ...]] = None,
         state_dict_type: Literal["full", "sharded"] = "sharded",
         **kwargs: Any,
     ):
+        r"""Strategy for Fully Sharded Data Parallel provided by Lightning Thunder.
+
+        .. warning::  This is an :ref:`experimental <versioning:Experimental API>` feature.
+
+        Fully Sharded Training shards the entire model across all available GPUs, allowing you to scale model
+        size, whilst using efficient communication to reduce overhead. In practice, this means we can remain
+        at parity with PyTorch DDP, whilst scaling our model sizes dramatically.
+
+        Arguments:
+            jit: Whether to automatically call ``thunder.jit(model)`` if necessary. Disable this if you are manually
+                jitting a function that includes the model.
+
+            executors: The list of Thunder executors to enable. They can be either string aliases for the executors
+                or the actual executor instances.
+
+            sharding_strategy: Select whether to shard model parameters, gradients, optimizer states, or a combination
+                of them:
+
+                - ``"ZERO3"``: Shards model parameters, gradients, and optimizer states (default).
+                - ``"ZERO2"``: Shards gradients and optimizer states only. Model parameters get replicated.
+
+                Also accepts a :class:`thunder.distributed.FSDPType` enum value.
+
+            bucketing_strategy: Enables combining the collective operations for sets of layers.
+
+                - ``"NONE"``: No bucketing (default).
+                - ``"LAYER"``: Create buckets per layer class.
+                - ``"BLOCK"``: Create buckets per layer block.
+
+                Also accepts a :class:`thunder.distributed.FSDPBucketingStrategy` enum value.
+
+            state_dict_type: The format in which the state of the model and optimizers gets saved into the checkpoint.
+
+                - ``"full"``: The full weights and optimizer states get assembled on rank 0 and saved to a single file
+                  (default).
+                - ``"sharded"``: Each rank saves its shard of weights and optimizer states to a file. The checkpoint is
+                  a folder with as many files as the world size.
+
+            \**kwargs: See available parameters in :func:`thunder.distributed.fsdp`.
+
+        """
         if not _TORCH_GREATER_EQUAL_2_2:
             raise ImportError("Thunder's FSDP strategy requires PyTorch 2.2 or higher.")
         if not _THUNDER_AVAILABLE:
@@ -77,6 +119,9 @@ class ThunderFSDPStrategy(ParallelStrategy, _Sharded):
             if isinstance(bucketing_strategy, str)
             else bucketing_strategy
         )
+        if not jit and executors is not None:
+            raise ValueError(f"Passing executors={executors} doesn't have an effect with `jit={jit}`")
+        self.jit = jit
         self.executors = _validate_executors(executors)
         self._state_dict_type = state_dict_type
         self._fsdp_kwargs = kwargs
@@ -115,16 +160,32 @@ class ThunderFSDPStrategy(ParallelStrategy, _Sharded):
     def setup_module(self, module: Module) -> Module:
         import thunder
 
-        module = thunder.distributed.fsdp(
-            module,
-            device=self.root_device,
-            sharding_strategy=self.sharding_strategy,
-            bucketing_strategy=self.bucketing_strategy,
-            **self._fsdp_kwargs,
-        )
-
-        # NOTE @IvanYaschuck says that `fsdp(jit(model))` could be supported in the future so that the user owns the `jit` call.
-        # we would still `jit(fsdp(undo_jit(jit(model))))` internally
+        if (cd := thunder.compile_data(module)) is not None:
+            # the module was already jitted
+            if thunder.compile_stats(module).last_traces is not None:
+                raise RuntimeError(
+                    "You already called `thunder.jit()` and generated an execution trace. It's too late to apply the"
+                    " FSDP transform."
+                )
+            # modify the reference
+            cd.fn = thunder.distributed.fsdp(
+                cd.fn,
+                device=self.root_device,
+                sharding_strategy=self.sharding_strategy,
+                bucketing_strategy=self.bucketing_strategy,
+                **self._fsdp_kwargs,
+            )
+            return module
+        else:
+            module = thunder.distributed.fsdp(
+                module,
+                device=self.root_device,
+                sharding_strategy=self.sharding_strategy,
+                bucketing_strategy=self.bucketing_strategy,
+                **self._fsdp_kwargs,
+            )
+        if not self.jit:
+            return module
         return thunder.jit(module, executors=self.executors)
 
     @override

--- a/extensions/thunder/strategies/thunder_fsdp.py
+++ b/extensions/thunder/strategies/thunder_fsdp.py
@@ -165,7 +165,7 @@ class ThunderFSDPStrategy(ParallelStrategy, _Sharded):
             if thunder.compile_stats(module).last_traces is not None:
                 raise RuntimeError(
                     "You already called `thunder.jit()` and generated an execution trace. It's too late to apply the"
-                    " FSDP transform."
+                    " FSDP transform. Remove the `forward` call before `fabric.setup()`"
                 )
             # modify the reference
             cd.fn = thunder.distributed.fsdp(

--- a/tests/test_thunder_ddp.py
+++ b/tests/test_thunder_ddp.py
@@ -70,7 +70,7 @@ def test_jit_before_setup(jit):
     fmodel = fabric.setup(tmodel)
     fmodel(x)
 
-    assert "all_reduce" in thunder.last_backward_traces(tmodel)[-1]
+    assert "all_reduce" in thunder.last_backward_traces(tmodel)[-1].python()
 
 
 @RunIf(min_cuda_gpus=1, thunder=True)

--- a/tests/test_thunder_ddp.py
+++ b/tests/test_thunder_ddp.py
@@ -10,13 +10,19 @@ from lightning import Fabric
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
+from extensions.thunder.strategies.thunder_ddp import ThunderDDPStrategy
+
+
+@RunIf(thunder=True)
+def test_thunder_strategy_input_parsing():
+    with pytest.raises(ValueError, match="doesn't have an effect with `jit=False"):
+        ThunderDDPStrategy(jit=False, executors=("python",))
+
 
 @RunIf(min_cuda_gpus=2, thunder=True, standalone=True)
 @pytest.mark.parametrize("strategy", ["ddp", "thunder_ddp"])
 def test_no_backward_sync(strategy):
     if strategy == "thunder_ddp":
-        from extensions.thunder.strategies.thunder_ddp import ThunderDDPStrategy
-
         strategy = ThunderDDPStrategy()
 
     fabric = Fabric(devices=2, accelerator="cuda", strategy=strategy)
@@ -47,3 +53,37 @@ def test_no_backward_sync(strategy):
             #   rank0       rank1     allreduce1    rank0 rank1 allreduce2
             assert model.weight.grad.item() == (9.0 if i == 3 else 22.5)
             model.weight.grad = None
+
+
+@RunIf(min_cuda_gpus=2, thunder=True, standalone=True)
+@pytest.mark.parametrize("jit", (False, True))
+def test_jit_before_setup(jit):
+    import thunder
+
+    fabric = Fabric(devices=2, accelerator="cuda", strategy=ThunderDDPStrategy(jit=jit))
+    fabric.launch()
+
+    x = torch.randn(1, 1, device=fabric.device)
+    model = torch.nn.Linear(1, 2, bias=False, device=fabric.device)
+
+    tmodel = thunder.jit(model)
+    fmodel = fabric.setup(tmodel)
+    fmodel(x)
+
+    assert "all_reduce" in thunder.last_backward_traces(tmodel)[-1]
+
+
+@RunIf(min_cuda_gpus=1, thunder=True)
+def test_setup_already_traced():
+    import thunder
+
+    device = torch.device("cuda")
+    x = torch.randn(1, 1, device=device)
+    model = torch.nn.Linear(1, 2, bias=False, device=device)
+
+    strategy = ThunderDDPStrategy()
+
+    tmodel = thunder.jit(model)
+    tmodel(x)
+    with pytest.raises(RuntimeError, match="already called"):
+        strategy.setup_module(tmodel)

--- a/tests/test_thunder_fsdp.py
+++ b/tests/test_thunder_fsdp.py
@@ -329,7 +329,7 @@ def test_jit_before_setup(jit):
     fmodel = fabric.setup(tmodel)
     fmodel(x)
 
-    assert "all_gather" in thunder.last_traces(tmodel)[-1]
+    assert "all_gather" in thunder.last_traces(tmodel)[-1].python()
 
 
 @RunIf(min_cuda_gpus=1, thunder=True)

--- a/tests/test_thunder_fsdp.py
+++ b/tests/test_thunder_fsdp.py
@@ -309,3 +309,39 @@ def test_save_load_sharded_checkpoint(tmp_path):
         actual["buf"] = actual["buf"].to(device="cpu")
         torch.testing.assert_close(actual, expected)
     assert state["primitive"] == 123
+
+
+@RunIf(min_cuda_gpus=2, thunder=True, standalone=True)
+@pytest.mark.parametrize("jit", (False, True))
+def test_jit_before_setup(jit):
+    import thunder
+    from extensions.thunder.strategies import ThunderFSDPStrategy
+
+    fabric = Fabric(devices=2, accelerator="cuda", strategy=ThunderFSDPStrategy(jit=jit))
+    fabric.launch()
+
+    x = torch.randn(1, 1, device=fabric.device)
+    model = torch.nn.Linear(1, 2, bias=False, device=fabric.device)
+    
+    tmodel = thunder.jit(model)
+    fmodel = fabric.setup(tmodel)
+    fmodel(x)
+
+    assert "all_gather" in thunder.last_traces(tmodel)[-1]
+
+
+@RunIf(min_cuda_gpus=1, thunder=True)
+def test_setup_already_traced():
+    import thunder
+    from extensions.thunder.strategies import ThunderFSDPStrategy
+
+    device = torch.device("cuda")
+    x = torch.randn(1, 1, device=device)
+    model = torch.nn.Linear(1, 2, bias=False, device=device)
+
+    strategy = ThunderFSDPStrategy()
+
+    tmodel = thunder.jit(model)
+    tmodel(x)
+    with pytest.raises(RuntimeError, match="already called"):
+        strategy.setup_module(tmodel)


### PR DESCRIPTION
Adds support for:

## Have the user call `thunder.jit` but still use the strategy

```python
fabric = Fabric(strategy=ThunderFSDPStrategy())
model = MyModel()
model = thunder.jit(model)
model = fabric.setup(model)  # this is now smart enough to know that model was already jitted
```

### PoC:

```python
import os
import thunder
import torch
import torch.distributed as torch_dist

world_size = int(os.environ.get("WORLD_SIZE", 1))
local_rank = int(os.environ.get("LOCAL_RANK", 0))
global_rank = int(os.environ.get("RANK", 0))
if world_size > 1:
    torch_dist.init_process_group(backend="nccl")
    pg = torch_dist.distributed_c10d._get_default_group()
device = torch.device("cuda", local_rank)
torch.cuda.set_device(device)

model = torch.nn.Linear(5, 10, bias=False, device=device)
x = torch.randn(2, 5, device=device)

def fwd_loss(m, x):
    return m(x).sum()

model = thunder.jit(model)
model._lc_cd.fn = thunder.distributed.fsdp(model._lc_cd.fn)

out = fwd_loss(model, x)

print(out)
if local_rank == 0:
    print("FN", thunder.last_traces(model)[-1].python())
```

## Have the user compile an arbitrary function that includes the model

```python
def fwd_loss(m, x):
    return m(x).sum()

fabric = Fabric(strategy=ThunderFSDPStrategy(jit=False))
model = MyModel()
model = thunder.jit(fwd_and_loss)
model = fabric.setup(model)
fwd_and_loss(model, ...)
```

Thunder doesn't support jitting twice here, so the user needs to disable the strategy's `jit` call since fabric doesn't know anything about `fwd_and_loss`

### PoC:

```python
import os
import thunder
import torch
import torch.distributed as torch_dist

world_size = int(os.environ.get("WORLD_SIZE", 1))
local_rank = int(os.environ.get("LOCAL_RANK", 0))
global_rank = int(os.environ.get("RANK", 0))
if world_size > 1:
    torch_dist.init_process_group(backend="nccl")
    pg = torch_dist.distributed_c10d._get_default_group()
device = torch.device("cuda", local_rank)
torch.cuda.set_device(device)

model = torch.nn.Linear(5, 10, bias=False, device=device)
x = torch.randn(2, 5, device=device)

def fwd_loss(m, x):
    return m(x).sum()

fwd_loss = thunder.jit(fwd_loss)
model = thunder.distributed.fsdp(model)

out = fwd_loss(model, x)

print(out)
if local_rank == 0:
    print("FN", thunder.last_traces(fwd_loss)[-1].python())
```