### PR TITLE
Reduce microbatch size

### DIFF
--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -46,8 +46,8 @@ def setup(
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
-        global_batch_size=128,
-        micro_batch_size=4,
+        global_batch_size=16,
+        micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
         learning_rate=1e-3,

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -46,8 +46,8 @@ def setup(
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
-        global_batch_size=128,
-        micro_batch_size=4,
+        global_batch_size=16,
+        micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
         learning_rate=1e-3,

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -44,7 +44,7 @@ def setup(
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
-        global_batch_size=64,
+        global_batch_size=16,
         micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -56,8 +56,8 @@ def setup(
     train: TrainArgs = TrainArgs(
         save_interval=1000,
         log_interval=1,
-        global_batch_size=128,
-        micro_batch_size=4,
+        global_batch_size=16,
+        micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
         learning_rate=3e-4,


### PR DESCRIPTION
I was going through old issues, and we discussed lowering the micro batch size to 1 a while back in #678 to make the finetuning defaults more compatible with more models and GPUs out there. This will of course increase the runtime, but given that VRAM is usually the bigger bottleneck, I think it's a worthwhile change. Especially now that we have the config files in the `config_hub`, we also have good recommendations for hparams that work well for specific models so I think lowering resource needs is maybe preferred here.


Fixes #678