### PR TITLE
Correct an apparent logger output directory bug 

### DIFF
--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -451,9 +451,9 @@ def choose_logger(
     **kwargs: Any,
 ):
     if logger_name == "csv":
-        return CSVLogger(root_dir=(out_dir / "logs"), name="csv", flush_logs_every_n_steps=log_interval, **kwargs)
+        return CSVLogger(root_dir=(out_dir / "logs"), name=name, flush_logs_every_n_steps=log_interval, **kwargs)
     if logger_name == "tensorboard":
-        return TensorBoardLogger(root_dir=(out_dir / "logs"), name="tensorboard", **kwargs)
+        return TensorBoardLogger(root_dir=(out_dir / "logs"), name=name, **kwargs)
     if logger_name == "wandb":
         return WandbLogger(project=name, resume=resume, **kwargs)
     raise ValueError(f"`--logger_name={logger_name}` is not a valid option. Choose from 'csv', 'tensorboard', 'wandb'.")

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -445,7 +445,7 @@ def parse_devices(devices: Union[str, int]) -> int:
 def choose_logger(
     logger_name: Literal["csv", "tensorboard", "wandb"],
     out_dir: Path,
-    name: str,
+    name: str = "csv",
     log_interval: int = 1,
     resume: Optional[bool] = None,
     **kwargs: Any,

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -445,7 +445,7 @@ def parse_devices(devices: Union[str, int]) -> int:
 def choose_logger(
     logger_name: Literal["csv", "tensorboard", "wandb"],
     out_dir: Path,
-    name: str = "csv",
+    name: str,
     log_interval: int = 1,
     resume: Optional[bool] = None,
     **kwargs: Any,


### PR DESCRIPTION
The `name` arg is hardcoded in the main branch. This pr tries to correct it by using the value parsed by the`name` argument.