### PR TITLE
Fix dtype mismatch when merging LoRA checkpoints

### DIFF
--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -43,7 +43,7 @@ def merge_lora(
     fabric = L.Fabric(devices=1, precision=precision, accelerator="cpu")
     config = Config.from_file(checkpoint_dir / "model_config.yaml", **lora_params)
 
-    with fabric.init_module(), torch.device("meta"):
+    with fabric.init_module():
         model = GPT(config)
 
     lora_path = checkpoint_dir / "lit_model.pth.lora"
@@ -52,7 +52,7 @@ def merge_lora(
 
     # Merge LoRA weights into the base model
     pretrained_checkpoint.update(lora_checkpoint.get("model", lora_checkpoint))
-    model.load_state_dict(pretrained_checkpoint, assign=True)
+    model.load_state_dict(pretrained_checkpoint)
     merge_lora_weights(model)
 
     # Remove LoRA parameters and the LoRA linear substring


### PR DESCRIPTION
This partially reverts #1189 which added `assign=True`. The problem is that the base model checkpoints come in a different precision than what we use for finetuning. So if the LoRA weights are stored in bfloat16, but the pretrained weights are stored in float16, we get errors because with assign we don't copy/cast the tensors to the same dtype:

```
⚡ ~ litgpt merge_lora --checkpoint_dir out/qlora-llama2-7b/final 
Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/bin/litgpt", line 8, in <module>
    sys.exit(main())
  File "/teamspace/studios/this_studio/llm-finetune/litgpt/litgpt/__main__.py", line 129, in main
    fn(**kwargs)
  File "/teamspace/studios/this_studio/llm-finetune/litgpt/litgpt/scripts/merge_lora.py", line 56, in merge_lora
    merge_lora_weights(model)
  File "/teamspace/studios/this_studio/llm-finetune/litgpt/litgpt/lora.py", line 746, in merge_lora_weights
    module.merge()
  File "/teamspace/studios/this_studio/llm-finetune/litgpt/litgpt/lora.py", line 400, in merge
    super().merge()
  File "/teamspace/studios/this_studio/llm-finetune/litgpt/litgpt/lora.py", line 164, in merge
    raise NotImplementedError(
NotImplementedError: Cannot merge the pretrained weights of type torch.float16 and LoRA weights of type torch.bfloat16
```
