### PR TITLE
Update prepare_dataset.md to add required val_split_fraction to JSON approach

### DIFF
--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -334,6 +334,7 @@ Then simply run any of the finetuning scripts with this input:
 litgpt finetune lora \
   --data JSON \
   --data.json_path path/to/your/data.json \
+  --val_split_fraction 0.1 \
   --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
 ```
 


### PR DESCRIPTION
Looks like the JSON data approach requires specifying `--val_split_fraction`. Just added this to the example.