### PR TITLE
Custom dataset for finetuning snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,13 @@ For more information, refer to the [download](tutorials/download_model_weights.m
 litgpt download --repo_id microsoft/phi-2
 
 # 2) Finetune the model
+curl -L https://huggingface.co/datasets/medalpaca/medical_meadow_health_advice/raw/main/medical_meadow_health_advice.json -o my_custom_dataset.json
+
 litgpt finetune lora \
   --checkpoint_dir checkpoints/microsoft/phi-2 \
-  --data Alpaca2k \
+  --data JSON \
+  --data.json_path my_custom_dataset.json \
+  --val_split_fraction 0.1 \
   --out_dir out/phi-2-lora
 
 # 3) Chat with the model


### PR DESCRIPTION
This replaces Alpaca with a "custom" dataset upon request. Custom in a sense that it shows that a user could bring their own files given that they formatted correctly. The model trains well here with default settings:

```bash
Epoch 1 | iter 1 step 0 | loss train: 3.136, val: n/a | iter time: 366.52 ms
Epoch 1 | iter 2 step 0 | loss train: 3.313, val: n/a | iter time: 128.25 ms
Epoch 1 | iter 3 step 0 | loss train: 3.208, val: n/a | iter time: 125.93 ms
Epoch 1 | iter 4 step 0 | loss train: 3.239, val: n/a | iter time: 125.72 ms
Epoch 1 | iter 5 step 0 | loss train: 3.261, val: n/a | iter time: 134.85 ms
Epoch 1 | iter 6 step 0 | loss train: 3.133, val: n/a | iter time: 132.94 ms
Epoch 1 | iter 7 step 0 | loss train: 3.167, val: n/a | iter time: 123.77 ms
Epoch 1 | iter 8 step 0 | loss train: 3.147, val: n/a | iter time: 124.59 ms
Epoch 1 | iter 9 step 0 | loss train: 3.170, val: n/a | iter time: 124.48 ms
...
Epoch 1 | iter 3489 step 218 | loss train: 0.883, val: 0.938 | iter time: 119.18 ms
Epoch 1 | iter 3490 step 218 | loss train: 0.927, val: 0.938 | iter time: 128.42 ms
Epoch 1 | iter 3491 step 218 | loss train: 0.923, val: 0.938 | iter time: 119.51 ms
Epoch 1 | iter 3492 step 218 | loss train: 0.982, val: 0.938 | iter time: 121.26 ms
```