### PR TITLE
Add whitespace after "Instruct:"

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -251,7 +251,7 @@ class Phi1(PromptStyle):
 
 class Phi2(PromptStyle):
     def apply(self, prompt: str, **kwargs: str) -> str:
-        return f"Instruct:{prompt}\nOutput:"
+        return f"Instruct: {prompt}\nOutput:"
 
 
 class TinyLlama(PromptStyle):


### PR DESCRIPTION
In `generate/base.py`, the output is 

```
Instruct:Fix typos in the following sentence: Exampel input
Output: Example input.
```

which looks a bit ugly.