### PR TITLE
Add deploy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ litgpt chat \
 
 Specialize an already pretrained model by training on custom data:
 
-```
+```bash
 mkdir -p custom_texts
 curl https://www.gutenberg.org/cache/epub/24440/pg24440.txt --output custom_texts/book1.txt
 curl https://www.gutenberg.org/cache/epub/26393/pg26393.txt --output custom_texts/book2.txt

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ litgpt chat \
   --checkpoint_dir out/phi-2-lora/final
 ```
 
+&nbsp;
+
 ### Pretrain an LLM   
 Train an LLM from scratch on your own data via pretraining:
 
@@ -131,6 +133,8 @@ litgpt pretrain \
 litgpt chat \
   --checkpoint_dir out/custom-model/final
 ```
+
+&nbsp;
 
 ### Continue pretraining an LLM       
 This is another way of finetuning that specialize an already pretrained model by training on custom data:    

--- a/README.md
+++ b/README.md
@@ -133,8 +133,20 @@ litgpt chat \
 Deploy a LitGPT model using [LitServe](https://github.com/Lightning-AI/litserve):
 
 ```python
+from pathlib import Path
+
+import lightning as L
+import torch
 from litserve import LitAPI, LitServer
-...
+
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.tokenizer import Tokenizer
+from litgpt.generate.base import generate
+from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
+from litgpt.scripts.download import download_from_hub
+from litgpt.utils import load_checkpoint
+
 
 # STEP 1: DEFINE YOUR MODEL API
 class SimpleLitAPI(LitAPI):
@@ -143,19 +155,56 @@ class SimpleLitAPI(LitAPI):
         # Setup the model so it can be called in `predict`.
         repo_id = "microsoft/phi-2"
         checkpoint_dir = Path(f"checkpoints/{repo_id}")
-        ...
- 
+
+        if not checkpoint_dir.exists():
+            download_from_hub(repo_id=repo_id)
+
+        config = Config.from_file(checkpoint_dir / "model_config.yaml")
+
+        device = torch.device(device)
+        torch.set_float32_matmul_precision("high")
+        fabric = L.Fabric(accelerator=device.type, devices=[device.index], precision="bf16-true")
+
+        checkpoint_path = checkpoint_dir / "lit_model.pth"
+
+        self.tokenizer = Tokenizer(checkpoint_dir)
+        self.prompt_style = (
+            load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) 
+            else PromptStyle.from_config(config)
+        )
+
+        with fabric.init_module(empty_init=True):
+            model = GPT(config)
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+        model.eval()
+
+        self.model = fabric.setup_module(model)
+
+        load_checkpoint(fabric, self.model, checkpoint_path)
+
+        self.device = fabric.device
 
     def decode_request(self, request):
         # Convert the request payload to your model input.
         prompt = request["prompt"]
-        ...
+        prompt = self.prompt_style.apply(prompt)
+        encoded = self.tokenizer.encode(prompt, device=self.device)
         return encoded
 
     def predict(self, inputs):
         # Run the model on the input and return the output.
-        ...
-        y = generate(...)
+        prompt_length = inputs.size(0)
+        max_returned_tokens = prompt_length + 30
+
+        y = generate(
+            self.model, inputs, max_returned_tokens, temperature=0.8,
+            top_k=200, eos_id=self.tokenizer.eos_id
+        )
+
+        for block in self.model.transformer.h:
+            block.attn.kv_cache.reset_parameters()
         return y
 
     def encode_response(self, output):
@@ -173,8 +222,15 @@ if __name__ == "__main__":
 ```python
 # STEP 3: USE THE SERVER
 import requests, json
-response = requests.post("http://127.0.0.1:8000/predict", 
-json={"prompt": "Fix typos in the following sentence: Exampel input"})
+
+response = requests.post(
+    "http://127.0.0.1:8000/predict", 
+    json={"prompt": "Fix typos in the following sentence: Exampel input"}
+)
+
+decoded_string = response.content.decode("utf-8")
+output_str = json.loads(decoded_string)["output"]
+print(output_str)
 ```
 
 &nbsp;

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -9,7 +9,10 @@ import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 
-from litgpt import GPT, Config, PromptStyle, Tokenizer
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.prompts import PromptStyle
+from litgpt.tokenizer import Tokenizer
 from litgpt.generate.base import next_token
 from litgpt.prompts import has_prompt_style, load_prompt_style
 from litgpt.scripts.merge_lora import merge_lora

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -11,7 +11,10 @@ import torch._dynamo.config
 import torch._inductor.config
 from lightning.fabric.plugins import BitsandbytesPrecision
 
-from litgpt import GPT, Config, PromptStyle, Tokenizer
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.prompts import PromptStyle
+from litgpt.tokenizer import Tokenizer
 from litgpt.prompts import has_prompt_style, load_prompt_style
 from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
 

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import torch
 from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedTensor
 
-from litgpt import Config
+from litgpt.config import Config
 from litgpt.utils import incremental_save, lazy_load, save_config
 
 

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -493,8 +493,10 @@ if __name__ == "__main__":
 ```python
 # STEP 3: USE THE SERVER
 import requests, json
-response = requests.post("http://127.0.0.1:8000/predict", 
-json={"prompt": "Fix typos in the following sentence: Exampel input"})
+response = requests.post(
+    "http://127.0.0.1:8000/predict", 
+    json={"prompt": "Fix typos in the following sentence: Exampel input"}
+)
 ```
 
 &nbsp;

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -1,0 +1,136 @@
+# Deploy and Serve LLMs
+
+This document shows how you can serve a LitGPT for deployment. 
+
+&nbsp;
+## Serve an LLM with LitServe
+
+This section illustrates how we can set up an inference server for a phi-2 LLM using [LitServe](https://github.com/Lightning-AI/litserve).
+
+[LitServe](https://github.com/Lightning-AI/litserve) is an inference server for AI/ML models that is minimal and highly scalable.
+
+You can install LitServe as follows:
+
+```bash
+pip install litserve
+```
+
+&nbsp;
+### Step 1: Create a server.py file
+
+First, copy the following code into a file called `server.py`:
+
+```python
+from pathlib import Path
+
+import lightning as L
+import torch
+from litserve import LitAPI, LitServer
+
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.tokenizer import Tokenizer
+from litgpt.generate.base import generate
+from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
+from litgpt.scripts.download import download_from_hub
+from litgpt.utils import load_checkpoint
+
+
+# DEFINE YOUR MODEL API
+class SimpleLitAPI(LitAPI):
+
+    def setup(self, device):
+        # Setup the model so it can be called in `predict`.
+        repo_id = "microsoft/phi-2"
+        checkpoint_dir = Path(f"checkpoints/{repo_id}")
+
+        if not checkpoint_dir.exists():
+            download_from_hub(repo_id=repo_id)
+
+        config = Config.from_file(checkpoint_dir / "model_config.yaml")
+
+        device = torch.device(device)
+        torch.set_float32_matmul_precision("high")
+        fabric = L.Fabric(accelerator=device.type, devices=[device.index], precision="bf16-true")
+
+        checkpoint_path = checkpoint_dir / "lit_model.pth"
+
+        self.tokenizer = Tokenizer(checkpoint_dir)
+        self.prompt_style = (
+            load_prompt_style(checkpoint_dir) if has_prompt_style(checkpoint_dir) else PromptStyle.from_config(config)
+        )
+
+        with fabric.init_module(empty_init=True):
+            model = GPT(config)
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+        model.eval()
+
+        self.model = fabric.setup_module(model)
+
+        load_checkpoint(fabric, self.model, checkpoint_path)
+
+        self.device = fabric.device
+
+    def decode_request(self, request):
+        # Convert the request payload to your model input.
+        prompt = request["prompt"]
+        prompt = self.prompt_style.apply(prompt)
+        encoded = self.tokenizer.encode(prompt, device=self.device)
+        return encoded
+
+    def predict(self, inputs):
+        # Run the model on the input and return the output.
+        prompt_length = inputs.size(0)
+        max_returned_tokens = prompt_length + 30
+
+        y = generate(self.model, inputs, max_returned_tokens, temperature=0.8, top_k=200, eos_id=self.tokenizer.eos_id)
+
+        for block in self.model.transformer.h:
+            block.attn.kv_cache.reset_parameters()
+        return y
+
+    def encode_response(self, output):
+        # Convert the model output to a response payload.
+        decoded_output = self.tokenizer.decode(output)
+        return {"output": decoded_output}
+
+
+# START THE SERVER
+if __name__ == "__main__":
+    server = LitServer(SimpleLitAPI(), accelerator="cuda", devices=1)
+    server.run(port=8000)
+```
+
+&nbsp;
+## Step 2: Start the inference server
+
+After you saved the code from step 1 in a `server.py` file, start the inference server from your command line terminal:
+
+```bash
+python server.py
+```
+
+&nbsp;
+## Step 3: Query the inference server
+
+You can now send requests to the inference server you started in step 2. For example, in a new Python session, we can send requests to the inference server as follows:
+
+
+```python
+import requests, json
+response = requests.post("http://127.0.0.1:8000/predict", 
+json={"prompt": "Fix typos in the following sentence: Exampel input"})
+
+decoded_string = response.content.decode("utf-8")
+output_str = json.loads(decoded_string)["output"]
+print(output_str)
+```
+
+Executing the code above prints the following output:
+
+```
+Instruct:Fix typos in the following sentence: Exampel input
+Output: Example input.
+```

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -131,6 +131,6 @@ print(output_str)
 Executing the code above prints the following output:
 
 ```
-Instruct:Fix typos in the following sentence: Exampel input
+Instruct: Fix typos in the following sentence: Exampel input
 Output: Example input.
 ```

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -120,8 +120,11 @@ You can now send requests to the inference server you started in step 2. For exa
 
 ```python
 import requests, json
-response = requests.post("http://127.0.0.1:8000/predict", 
-json={"prompt": "Fix typos in the following sentence: Exampel input"})
+
+response = requests.post(
+    "http://127.0.0.1:8000/predict", 
+    json={"prompt": "Fix typos in the following sentence: Exampel input"}
+)
 
 decoded_string = response.content.decode("utf-8")
 output_str = json.loads(decoded_string)["output"]


### PR DESCRIPTION
The tricky part adding a simple deploy example is that 

1. the outputs are printed inline. 
2. Also, each time someone makes a request the model is loaded into memory, which is not very efficient.

Maybe the best way to address both points above is to define a new convenience function to LitGPT that keeps the model loaded like in `chat` but then also yields the text outputs generated by the model. Or something like that. 

Any ideas or suggestions here @awaelchli and @carmocca ?

Fixes #1259