### PR TITLE
Fix capturing hparams for loggers that don't support serializing non-primitives

### DIFF
--- a/extensions/thunder/pretrain.py
+++ b/extensions/thunder/pretrain.py
@@ -26,6 +26,7 @@ from litgpt.model import GPT, CausalSelfAttention, Config, LLaMAMLP, Block
 from litgpt.utils import (
     CLI,
     CycleIterator,
+    capture_hparams,
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
@@ -97,7 +98,7 @@ def setup(
         executors: If using Thunder, the executors to enable.
         strategy: If desired, the strategy to use.
     """
-    hparams = locals()
+    hparams = capture_hparams()
     data = TinyLlama() if data is None else data
     if model_config is not None and model_name is not None:
         raise ValueError("Only one of `model_name` or `model_config` can be set.")

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -26,6 +26,7 @@ from litgpt.model import GPT, Block, CausalSelfAttention, Config, LLaMAMLP
 from litgpt.utils import (
     CLI,
     CycleIterator,
+    capture_hparams,
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
@@ -87,7 +88,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    hparams = locals()
+    hparams = capture_hparams()
     data = TinyLlama() if data is None else data
     if model_config is not None and model_name is not None:
         raise ValueError("Only one of `model_name` or `model_config` can be set.")

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -413,8 +413,10 @@ def capture_hparams() -> Dict[str, Any]:
     for name, value in locals_of_caller.items():
         if value is None or isinstance(value, (int, float, str, bool, Path)):
             hparams[name] = value
-        if is_dataclass(value):
+        elif is_dataclass(value):
             hparams[name] = asdict(value)
+        else:
+            hparams[name] = str(value)
     return hparams
 
 

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -1,11 +1,12 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 """Utility functions for training and inference."""
+import inspect
 import math
 import pickle
 import shutil
 import sys
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
@@ -402,6 +403,18 @@ def CLI(*args: Any, **kwargs: Any) -> Any:
     kwargs.setdefault("as_positional", False)
 
     return CLI(*args, **kwargs)
+
+
+def capture_hparams():
+    """Captures the local variables ('hyperparameters') from where this function gets called."""
+    caller_frame = inspect.currentframe().f_back
+    locals_of_caller = caller_frame.f_locals
+    hparams = {}
+    for name, value in locals_of_caller.items():
+        if isinstance(value, (int, float, str, bool, Path)):
+            hparams[name] = value
+        if is_dataclass(value):
+            hparams[name] = asdict(value)
 
 
 def save_hyperparameters(function: callable, checkpoint_dir: Path) -> None:

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -405,16 +405,17 @@ def CLI(*args: Any, **kwargs: Any) -> Any:
     return CLI(*args, **kwargs)
 
 
-def capture_hparams():
+def capture_hparams() -> Dict[str, Any]:
     """Captures the local variables ('hyperparameters') from where this function gets called."""
     caller_frame = inspect.currentframe().f_back
     locals_of_caller = caller_frame.f_locals
     hparams = {}
     for name, value in locals_of_caller.items():
-        if isinstance(value, (int, float, str, bool, Path)):
+        if value is None or isinstance(value, (int, float, str, bool, Path)):
             hparams[name] = value
         if is_dataclass(value):
             hparams[name] = asdict(value)
+    return hparams
 
 
 def save_hyperparameters(function: callable, checkpoint_dir: Path) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+from dataclasses import asdict
 
 import os
 from contextlib import redirect_stderr
@@ -18,9 +19,11 @@ from lightning.pytorch.loggers import WandbLogger
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT
+from litgpt.args import TrainArgs
 from litgpt.utils import (
     CLI,
     CycleIterator,
+    capture_hparams,
     check_valid_checkpoint_dir,
     choose_logger,
     chunked_cross_entropy,
@@ -217,6 +220,26 @@ def test_copy_config_files(fake_checkpoint_dir, tmp_path):
     expected = {"model_config.yaml", "tokenizer_config.json", "tokenizer.json"}
     contents = set(os.listdir(tmp_path))
     assert expected.issubset(contents)
+
+
+def test_capture_hparams():
+    integer = 1
+    string = "string"
+    boolean = True
+    none = None
+    path = Path("/path")
+    dataclass = TrainArgs()
+    other = torch.nn.Linear(1, 1)
+    hparams = capture_hparams()
+    assert hparams == {
+        "integer": integer,
+        "string": string,
+        "boolean": boolean,
+        "none": none,
+        "path": path,
+        "dataclass": asdict(dataclass),
+        "other": str(other),
+    }
 
 
 def _test_function(out_dir: Path, foo: bool = False, bar: int = 1):


### PR DESCRIPTION
In the previous version of LitGPT, I added this code to sanitize the hparams for logging:
https://github.com/Lightning-AI/litgpt/blob/8a101b633dfeafd378f8fbaba6a80a4417c33576/pretrain/tinyllama.py#L65
But this code was removed in the new version, causing errors like:

```
TypeError: Object of type PosixPath is not JSON serializable
```
(e.g. with wandb)

I plan to improve this in Lightning's `.log_hyperparameters()` implementation, after which we can remove the function I added here again.