### PR TITLE
Replace UV with regular pip

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -39,14 +39,14 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Install uv
-      run: pip install uv
+        cache: 'pip'
+        cache-dependency-path: |
+          pyproject.toml
 
     - name: Install minimal dependencies
       run: |
-        uv pip install --system .
-        uv pip list
+        pip install .
+        pip list
         # make sure all modules are still importable with only the minimal dependencies available
         modules=$(
           find litgpt -type f -name "*.py" | \
@@ -58,8 +58,8 @@ jobs:
 
     - name: Install all dependencies
       run: |
-        uv pip install --system '.[all,test]'
-        uv pip list
+        pip install '.[all,test]'
+        pip list
 
     - name: Run tests
       run: |


### PR DESCRIPTION
Hi there 👋 

Currently we have a problem with installing packages with UV in CI for Python 3.9. 
More specifically it cannot find a version of boto3/botocore to install: 
- selects a candidate version
- fails to install it
- selects an older version
- fail to install it
- select an older version
- ...

Instead of trying to mitigate it, I think it's better to temporary roll back to a regular `pip install`.