### PR TITLE
Fix badge size

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Uses the latest state-of-the-art techniques:
 
 
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)
-![cpu-tests](https://github.com/lightning-AI/lit-stablelm/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/lit-stablelm/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/1077906959069626439?style=plastic)](https://discord.gg/VptPCZkGNa)
+![cpu-tests](https://github.com/lightning-AI/lit-stablelm/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/lit-stablelm/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/1077906959069626439)](https://discord.gg/VptPCZkGNa)
 
 <p align="center">
   <a href="https://lightning.ai/">Lightning.ai</a> •


### PR DESCRIPTION
Fixes the badge (yes, badge not batch size :D).

Before:

<img width="775" alt="Screenshot 2024-04-15 at 11 18 57 AM" src="https://github.com/Lightning-AI/litgpt/assets/5618407/4e5d0f06-7e41-43c0-9b43-9ffedb0ff754">

After:

<img width="792" alt="Screenshot 2024-04-15 at 11 19 08 AM" src="https://github.com/Lightning-AI/litgpt/assets/5618407/5c818f4f-17bd-42cf-ab84-5badca40c5e1">
