### PR TITLE
Increase timeout 5 --> 10 minutes for standalone Azure tests

### DIFF
--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -66,4 +66,4 @@ jobs:
       env:
         PL_RUN_CUDA_TESTS: "1"
       displayName: "Standalone tests"
-      timeoutInMinutes: "5"
+      timeoutInMinutes: "10"


### PR DESCRIPTION
Hi there 👋 

CI workflow for GPU relates tests might fail occasionally due to timeout.
The reason is added tests for Thunder integration.

As a workaround, this PR increases timeout from 5 to 10 minutes.

