### PR TITLE
Temporarily skip thunder test due to timeout

### DIFF
--- a/tests/test_thunder_fsdp.py
+++ b/tests/test_thunder_fsdp.py
@@ -261,9 +261,10 @@ def distributed_ckpt_to_regular(path):
     return state_dict
 
 
-@pytest.skip("Temporarily disabled, often exceeds 5 min timeout")
 @RunIf(min_cuda_gpus=2, thunder=True, standalone=True)
 def test_save_load_sharded_checkpoint(tmp_path):
+    pytest.skip("Temporarily disabled, often exceeds 5 min timeout")
+
     strategy = ThunderFSDPStrategy(state_dict_type="sharded", broadcast_from=0)
     fabric = Fabric(accelerator="cuda", devices=2, strategy=strategy)
     fabric.launch()

--- a/tests/test_thunder_fsdp.py
+++ b/tests/test_thunder_fsdp.py
@@ -261,6 +261,7 @@ def distributed_ckpt_to_regular(path):
     return state_dict
 
 
+@pytest.skip("Temporarily disabled, often exceeds 5 min timeout")
 @RunIf(min_cuda_gpus=2, thunder=True, standalone=True)
 def test_save_load_sharded_checkpoint(tmp_path):
     strategy = ThunderFSDPStrategy(state_dict_type="sharded", broadcast_from=0)


### PR DESCRIPTION
This PR skips `test_save_load_sharded_checkpoint` in order to unblock CI.

Opened #1303 to look into making the test faster.