### PR TITLE
ignore external links

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,5 +27,5 @@ jobs:
 
     - name: Check links
       run: |
-        pytest --check-links README.md --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding"
-        pytest --check-links tutorials --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding"
+        pytest --check-links README.md --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding,https://falconllm.tii.ae"
+        pytest --check-links tutorials --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding,https://falconllm.tii.ae"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,5 +27,5 @@ jobs:
 
     - name: Check links
       run: |
-        pytest --check-links README.md --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding,https://falconllm.tii.ae"
-        pytest --check-links tutorials --check-links-ignore "https://stability.ai/blog/stablecode-llm-generative-ai-coding,https://falconllm.tii.ae"
+        pytest --check-links README.md --check-links-ignore "http*"
+        pytest --check-links tutorials --check-links-ignore "http*"


### PR DESCRIPTION
The intention for this was mainly to check for broken internal links. External links can sometimes time out or be subject to GitHub rate limiting, so let's ignore those.