### PR TITLE
Rerun test_tokenizer on fail

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -11,6 +11,7 @@ import litgpt.config as config_module
 from litgpt.tokenizer import Tokenizer
 
 
+@pytest.mark.flaky(reruns=5)
 @pytest.mark.parametrize("config", config_module.configs, ids=[c["hf_config"]["name"] for c in config_module.configs])
 def test_tokenizer_against_hf(config):
     access_token = os.getenv("HF_TOKEN")


### PR DESCRIPTION
Hi there 👋 

`test_tokenizer_against_hf` might be flaky due to connection issues.
This PR adds a decorator that reruns the test in case of a failure for a total of 5 attempts.