### PR TITLE
Rewrite finetune command if subcommand is not provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ litgpt download --repo_id microsoft/phi-2
 # 2) Finetune the model
 curl -L https://huggingface.co/datasets/medalpaca/medical_meadow_health_advice/raw/main/medical_meadow_health_advice.json -o my_custom_dataset.json
 
-litgpt finetune lora \
+litgpt finetune \
   --checkpoint_dir checkpoints/microsoft/phi-2 \
   --data JSON \
   --data.json_path my_custom_dataset.json \
@@ -267,7 +267,7 @@ Browse all training recipes [here](config_hub).
 ### Example
 
 ```bash
-litgpt finetune lora \
+litgpt finetune \
   --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/finetune/llama-2-7b/lora.yaml
 ```
 
@@ -422,7 +422,7 @@ seed: 1337
 Override any parameter in the CLI:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune \
   --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/finetune/llama-2-7b/lora.yaml \
   --lora_r 4
 ```

--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -41,6 +41,7 @@ def _new_parser(**kwargs: Any) -> "ArgumentParser":
 
 
 def _rewrite_argv_for_default_subcommand(parser_data: dict, command: str, subcommand: str) -> None:
+    """Rewrites the `sys.argv` such that `litgpt command` defaults to `litgpt command subcommand`."""
     if (
         len(sys.argv) > 2
         and sys.argv[1] == command

--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -1,4 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+import sys
 
 from typing import TYPE_CHECKING, Any
 
@@ -37,6 +38,16 @@ def _new_parser(**kwargs: Any) -> "ArgumentParser":
         "-c", "--config", action=ActionConfigFile, help="Path to a configuration file in json or yaml format."
     )
     return parser
+
+
+def _rewrite_argv_for_default_subcommand(parser_data: dict, command: str, subcommand: str) -> None:
+    if (
+        len(sys.argv) > 2
+        and sys.argv[1] == command
+        and sys.argv[2] not in parser_data[command].keys()
+        and not any(h in sys.argv for h in ["-h", "--help"])
+    ):
+        sys.argv.insert(2, subcommand)
 
 
 def main() -> None:
@@ -86,6 +97,8 @@ def main() -> None:
 
     set_docstring_parse_options(attribute_docstrings=True)
     set_config_read_mode(urls_enabled=True)
+
+    _rewrite_argv_for_default_subcommand(parser_data, "finetune", "lora")
 
     root_parser = _new_parser(prog="litgpt")
 

--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -42,12 +42,7 @@ def _new_parser(**kwargs: Any) -> "ArgumentParser":
 
 def _rewrite_argv_for_default_subcommand(parser_data: dict, command: str, subcommand: str) -> None:
     """Rewrites the `sys.argv` such that `litgpt command` defaults to `litgpt command subcommand`."""
-    if (
-        len(sys.argv) > 2
-        and sys.argv[1] == command
-        and sys.argv[2] not in parser_data[command].keys()
-        and not any(h in sys.argv for h in ["-h", "--help"])
-    ):
+    if len(sys.argv) > 2 and sys.argv[1] == command and sys.argv[2] not in parser_data[command].keys():
         sys.argv.insert(2, subcommand)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,3 +61,13 @@ def test_cli():
                         Optional[int], default: 3000000000000)"""
         in out
     )
+
+
+def test_rewrite_finetune_command():
+    out1 = StringIO()
+    with pytest.raises(SystemExit), redirect_stdout(out1), mock.patch("sys.argv", ["litgpt", "fineune", "-h"]):
+        main()
+    out2 = StringIO()
+    with pytest.raises(SystemExit), redirect_stdout(out2), mock.patch("sys.argv", ["litgpt", "fineune", "lora", "-h"]):
+        main()
+    assert out1.getvalue() == out2.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,18 +23,7 @@ def test_cli():
     chat                Chat with a model."""
         in out
     )
-    assert ("""evaluate            Evaluate a model with the LM Evaluation Harness.""") in out
-
-    out = StringIO()
-    with pytest.raises(SystemExit), redirect_stdout(out), mock.patch("sys.argv", ["litgpt", "finetune", "-h"]):
-        main()
-    out = out.getvalue()
-    assert (
-        """Available subcommands:
-    lora                Finetune a model with LoRA.
-    full                Finetune a model."""
-        in out
-    )
+    assert """evaluate            Evaluate a model with the LM Evaluation Harness.""" in out
 
     out = StringIO()
     with pytest.raises(SystemExit), redirect_stdout(out), mock.patch("sys.argv", ["litgpt", "finetune", "lora", "-h"]):


### PR DESCRIPTION
This PR is a hack to add a default for the `litgpt finetune` command as a short-term solution. The default was chosen to be lora. In other words

```
litgpt finetune [args]
```
is now equivalent to
```
litgpt finetune lora [args]
```
and the other subcommands still exist. 