### PR TITLE
Tokenizer: `add_prefix_space` shouldn't affect  `self.use_bos`

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -73,11 +73,11 @@ class Tokenizer:
             return False
         with open(tokenizer_config_path, encoding="utf-8") as fp:
             config = json.load(fp)
-        if any(config.get(check, False) for check in ("add_bos_token", "add_prefix_space")):
-            return True
-        # for examples that also use the Llama tokenizer, but do not have or set add_bos_token to True.
+        if "add_bos_token" in config:
+            return config["add_bos_token"]
+        # if `add_bos_token` isn't in the config file, but LLaMA tokenizer is used - return True.
         # ex: https://huggingface.co/stabilityai/StableBeluga2/blob/main/tokenizer_config.json#L2
-        return config.get("add_bos_token") is None and config.get("tokenizer_class") == "LlamaTokenizer"
+        return config.get("tokenizer_class") == "LlamaTokenizer"
 
     def encode(
         self,


### PR DESCRIPTION
H there 👋 

In the `litgpt/tokenizer.py::check_if_bos_token_used` the function returns True if `add_prefix_space` is True (even if `add_bos_token` is False):
https://github.com/Lightning-AI/litgpt/blob/b7defe49cc5f8ff5bd991ca610148a3a4447ee0f/litgpt/tokenizer.py#L71-L77

which isn't a correct behavior, since `add_prefix_space` according to [docs](https://huggingface.co/docs/transformers/en/model_doc/roberta#transformers.RobertaTokenizer.add_prefix_space):
> Whether or not to add an initial space to the input. This allows to treat the leading word just as any other word.

For example:

```python
from transformers import RobertaTokenizer

tokenizer = RobertaTokenizer.from_pretrained("FacebookAI/roberta-base")

print(tokenizer("Hello world")["input_ids"])
>>> [0, 31414, 232, 2]
print(tokenizer(" Hello world")["input_ids"])
>>> [0, 20920, 232, 2]
tokenizer.add_prefix_space = True
print(tokenizer("Hello world")["input_ids"])
>>> [0, 20920, 232, 2]
```

----

This should help #1282 