### PR TITLE
Fix evaluation if device not specified

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -72,6 +72,9 @@ def convert_and_evaluate(
         )
         return
 
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
     checkpoint_dir = Path(checkpoint_dir)
 
     if out_dir is None:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -39,7 +39,7 @@ def test_evaluate_script(tmp_path, monkeypatch):
     fn_kwargs = dict(
         checkpoint_dir=tmp_path,
         out_dir=tmp_path / "out_dir",
-        device="cpu",
+        device=None,
         dtype=torch.float32,
         limit=5,
         tasks="mathqa"


### PR DESCRIPTION
The command we have in the docs fails:


```
litgpt evaluate \
  --checkpoint_dir checkpoints/microsoft/phi-2/ \
  --batch_size 16 \
  --tasks "hellaswag" \
  --out_dir evaluate_model
```

```
Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/bin/litgpt", line 8, in <module>
    sys.exit(main())
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/litgpt/__main__.py", line 143, in main
    fn(**kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/litgpt/eval/evaluate.py", line 99, in convert_and_evaluate
    model = HFLM(repo_id, state_dict=state_dict, device=device, batch_size=batch_size, dtype=dtype)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lm_eval/models/huggingface.py", line 143, in __init__
    assert isinstance(device, str)
AssertionError
```

Because `device=None` is not accepted in `lm_eval` even though the type would suggest it is. This could be considered a bug, but we can choose a good default based on device availability.