### PR TITLE
Avoid remote code warning in evaluation harness

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -99,7 +99,9 @@ def convert_and_evaluate(
     from lm_eval.models.huggingface import HFLM
 
     state_dict = torch.load(model_path)
-    model = HFLM(repo_id, state_dict=state_dict, device=device, batch_size=batch_size, dtype=dtype)
+    model = HFLM(
+        repo_id, state_dict=state_dict, device=device, batch_size=batch_size, dtype=dtype, trust_remote_code=True
+    )
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 


### PR DESCRIPTION
Avoids the following warning:

> /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/datasets/load.py:1461: FutureWarning: The repository for hails/mmlu_no_train contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/hails/mmlu_no_train
> You can avoid this message in future by passing the argument `trust_remote_code=True`.
> Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
>   warnings.warn(

For example when you run `litgpt evaluate --tasks mmlu"`.