### PR TITLE
Fix `litgpt evaluate` not using the local checkpoint

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -84,10 +84,9 @@ def convert_and_evaluate(
 
     save_filepath = out_dir / Path("results.json") if save_filepath is None else Path(save_filepath)
 
-    copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
-
     model_path = out_dir / "pytorch_model.bin"
     if not model_path.exists() or force_conversion:
+        copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
         convert_lit_checkpoint(checkpoint_dir=checkpoint_dir, output_dir=out_dir)
     
         # Hack: LitGPT's conversion doesn't save a pickle file that is compatible to be loaded with

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -27,7 +27,7 @@ def prepare_results(results, save_filepath, print_results=True):
 def convert_and_evaluate(
     checkpoint_dir: Path,
     tasks: Optional[str] = None,
-    out_dir: Optional[str] = None,
+    out_dir: Optional[Path] = None,
     force_conversion: bool = False,
     num_fewshot: Optional[int] = None,
     batch_size: int = 1,
@@ -45,9 +45,7 @@ def convert_and_evaluate(
             Saves to `checkpoint_dir`/evaluate by default.
         force_conversion: Set to `True` to reconvert the model and override
             an existing model.pth from a previous evaluation call.
-        tasks: CSV of task names to evaluate.
-           By default, the following tasks are used:
-           "hellaswag,truthfulqa_mc2,mmlu"
+        tasks: CSV of task names to evaluate. Example: "hellaswag,truthfulqa_mc2,mmlu"
         num_fewshot: Number of examples in few-shot context.
         batch_size: Batch size configuration.
         device: Device to use for evaluation, for example, "cuda" or "cuda:0".

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -86,13 +86,20 @@ def convert_and_evaluate(
 
     copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
 
-    model_path = out_dir / "model.pth"
+    model_path = out_dir / "pytorch_model.bin"
     if not model_path.exists() or force_conversion:
         convert_lit_checkpoint(checkpoint_dir=checkpoint_dir, output_dir=out_dir)
+    
+        # Hack: LitGPT's conversion doesn't save a pickle file that is compatible to be loaded with
+        # `torch.load(..., weights_only=True)`, which is a requirement in HFLM.
+        # So we're `torch.load`-ing and `torch.sav`-ing it again to work around this.
+        state_dict = torch.load(out_dir / "model.pth")
+        torch.save(state_dict, model_path)
+        os.remove(out_dir / "model.pth")
 
     from lm_eval.models.huggingface import HFLM
 
-    model = HFLM(pretrained=str(model_path), device=device, batch_size=batch_size, dtype=dtype)
+    model = HFLM(pretrained=str(out_dir), device=device, batch_size=batch_size, dtype=dtype)
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -35,7 +35,7 @@ def convert_and_evaluate(
     dtype: Optional[Union[str, torch.dtype]] = None,
     limit: Optional[float] = None,
     seed: int = 1234,
-    save_filepath: Optional[str] = None,
+    save_filepath: Optional[Path] = None,
 ) -> None:
     """Convert a LitGPT model and run the LM Evaluation Harness
 

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -99,7 +99,7 @@ def convert_and_evaluate(
 
     from lm_eval.models.huggingface import HFLM
 
-    model = HFLM(pretrained=str(out_dir), device=device, batch_size=batch_size, dtype=dtype)
+    model = HFLM(pretrained=str(out_dir.resolve()), device=device, batch_size=batch_size, dtype=dtype)
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -4,7 +4,6 @@ import json
 import os
 from pathlib import Path
 from typing import Optional, Union
-import yaml
 import torch
 
 from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint
@@ -84,11 +83,6 @@ def convert_and_evaluate(
     out_dir.mkdir(parents=True, exist_ok=True)
 
     save_filepath = out_dir / Path("results.json") if save_filepath is None else Path(save_filepath)
-    config_filepath = checkpoint_dir/"model_config.yaml"
-
-    with open(config_filepath, encoding="utf-8") as f:
-        config_dict = yaml.safe_load(f)
-    repo_id = f"{config_dict['hf_config']['org']}/{config_dict['hf_config']['name']}"
 
     copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
 
@@ -98,8 +92,7 @@ def convert_and_evaluate(
 
     from lm_eval.models.huggingface import HFLM
 
-    state_dict = torch.load(model_path)
-    model = HFLM(repo_id, state_dict=state_dict, device=device, batch_size=batch_size, dtype=dtype)
+    model = HFLM(pretrained=str(model_path), device=device, batch_size=batch_size, dtype=dtype)
 
     os.environ["TOKENIZERS_PARALLELISM"] = "false"
 

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -392,7 +392,7 @@ class CycleIterator:
 def copy_config_files(source_dir: Path, out_dir: Path) -> None:
     """Copies the specified configuration and tokenizer files into the output directory."""
 
-    config_files = ["generation_config.json", "model_config.yaml"]
+    config_files = ["config.json", "generation_config.json", "model_config.yaml"]
     tokenizer_files = ["tokenizer.json", "tokenizer.model", "tokenizer_config.json"]
 
     for file_name in config_files + tokenizer_files:

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -17,26 +17,36 @@ import yaml
 import litgpt.eval.evaluate as module
 from litgpt import GPT, Config
 from litgpt.scripts.download import download_from_hub
-from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint
 
 
-def test_evaluate_script(tmp_path):
-    download_from_hub(repo_id="EleutherAI/pythia-14m", checkpoint_dir=tmp_path)
-    checkpoint_dir = tmp_path / "EleutherAI" / "pythia-14m"
-    convert_hf_checkpoint(checkpoint_dir=checkpoint_dir)
-    
+@pytest.mark.xfail(
+    raises=(datasets.builder.DatasetGenerationError, NotImplementedError),
+    strict=False,
+    match="Loading a dataset cached in a LocalFileSystem is not supported",
+)
+def test_evaluate_script(tmp_path, monkeypatch):
+    ours_config = Config.from_name("pythia-14m")
+    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
+    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
+    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
+    ours_model = GPT(ours_config)
+    checkpoint_path = tmp_path / "lit_model.pth"
+    torch.save(ours_model.state_dict(), checkpoint_path)
+    config_path = tmp_path / "model_config.yaml"
+    with open(config_path, "w", encoding="utf-8") as fp:
+        yaml.dump(asdict(ours_config), fp)
+
+    fn_kwargs = dict(
+        checkpoint_dir=tmp_path,
+        out_dir=tmp_path / "out_dir",
+        device=None,
+        dtype=torch.float32,
+        limit=5,
+        tasks="mathqa"
+    )
     stdout = StringIO()
     with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
-        module.convert_and_evaluate(
-            checkpoint_dir=checkpoint_dir,
-            out_dir=tmp_path / "out_dir",
-            device=None,
-            dtype=torch.float32,
-            limit=5,
-            tasks="mathqa"
-        )
-        
-    assert (tmp_path / "out_dir" / "results.json").is_file()
+        module.convert_and_evaluate(**fn_kwargs)
     stdout = stdout.getvalue()
     assert "mathqa" in stdout
     assert "Metric" in stdout

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -40,6 +40,8 @@ def test_evaluate_script(tmp_path):
             limit=5,
             tasks="mathqa"
         )
+        
+    assert (tmp_path / "out_dir" / "results.json").is_file()
     stdout = stdout.getvalue()
     assert "mathqa" in stdout
     assert "Metric" in stdout

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -27,7 +27,7 @@ def test_evaluate_script(tmp_path):
         yaml.dump(asdict(ours_config), fp)
 
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]), mock.patch("huggingface_hub.snapshot_download"):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
         module.convert_and_evaluate(
             checkpoint_dir=checkpoint_dir,
             out_dir=tmp_path / "out_dir",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -17,36 +17,29 @@ import yaml
 import litgpt.eval.evaluate as module
 from litgpt import GPT, Config
 from litgpt.scripts.download import download_from_hub
+from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint
 
 
-@pytest.mark.xfail(
-    raises=(datasets.builder.DatasetGenerationError, NotImplementedError),
-    strict=False,
-    match="Loading a dataset cached in a LocalFileSystem is not supported",
-)
-def test_evaluate_script(tmp_path, monkeypatch):
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
-
-    fn_kwargs = dict(
-        checkpoint_dir=tmp_path,
-        out_dir=tmp_path / "out_dir",
-        device=None,
-        dtype=torch.float32,
-        limit=5,
-        tasks="mathqa"
-    )
+# @pytest.mark.xfail(
+#     raises=(datasets.builder.DatasetGenerationError, NotImplementedError),
+#     strict=False,
+#     match="Loading a dataset cached in a LocalFileSystem is not supported",
+# )
+def test_evaluate_script(tmp_path):
+    download_from_hub(repo_id="EleutherAI/pythia-14m", checkpoint_dir=tmp_path)
+    checkpoint_dir = tmp_path / "EleutherAI" / "pythia-14m"
+    convert_hf_checkpoint(checkpoint_dir=checkpoint_dir)
+    
     stdout = StringIO()
     with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
-        module.convert_and_evaluate(**fn_kwargs)
+        module.convert_and_evaluate(
+            checkpoint_dir=checkpoint_dir,
+            out_dir=tmp_path / "out_dir",
+            device=None,
+            dtype=torch.float32,
+            limit=5,
+            tasks="mathqa"
+        )
     stdout = stdout.getvalue()
     assert "mathqa" in stdout
     assert "Metric" in stdout

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -40,6 +40,7 @@ def test_evaluate_script(tmp_path):
     assert (tmp_path / "out_dir" / "results.json").is_file()
     assert "mathqa" in stdout
     assert "Metric" in stdout
+    assert "Loading checkpoint shards" not in stdout
 
 
 @pytest.mark.parametrize("mode", ["file", "entrypoint"])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,6 +1,5 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-import shutil
 import subprocess
 import sys
 from contextlib import redirect_stdout
@@ -9,7 +8,6 @@ from io import StringIO
 from pathlib import Path
 from unittest import mock
 
-import datasets
 import pytest
 import torch
 import yaml
@@ -19,35 +17,27 @@ from litgpt import GPT, Config
 from litgpt.scripts.download import download_from_hub
 
 
-@pytest.mark.xfail(
-    raises=(datasets.builder.DatasetGenerationError, NotImplementedError),
-    strict=False,
-    match="Loading a dataset cached in a LocalFileSystem is not supported",
-)
-def test_evaluate_script(tmp_path, monkeypatch):
+def test_evaluate_script(tmp_path):
     ours_config = Config.from_name("pythia-14m")
     download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
+    checkpoint_dir = tmp_path / "EleutherAI" / "pythia-14m"
     ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
+    torch.save(ours_model.state_dict(), checkpoint_dir / "lit_model.pth")
+    with open( checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
         yaml.dump(asdict(ours_config), fp)
 
-    fn_kwargs = dict(
-        checkpoint_dir=tmp_path,
-        out_dir=tmp_path / "out_dir",
-        device=None,
-        dtype=torch.float32,
-        limit=5,
-        tasks="mathqa"
-    )
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
-        module.convert_and_evaluate(**fn_kwargs)
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]), mock.patch("huggingface_hub.snapshot_download"):
+        module.convert_and_evaluate(
+            checkpoint_dir=checkpoint_dir,
+            out_dir=tmp_path / "out_dir",
+            device=None,
+            dtype=torch.float32,
+            limit=5,
+            tasks="mathqa"
+        )
     stdout = stdout.getvalue()
+    assert (tmp_path / "out_dir" / "results.json").is_file()
     assert "mathqa" in stdout
     assert "Metric" in stdout
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -20,11 +20,6 @@ from litgpt.scripts.download import download_from_hub
 from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint
 
 
-# @pytest.mark.xfail(
-#     raises=(datasets.builder.DatasetGenerationError, NotImplementedError),
-#     strict=False,
-#     match="Loading a dataset cached in a LocalFileSystem is not supported",
-# )
 def test_evaluate_script(tmp_path):
     download_from_hub(repo_id="EleutherAI/pythia-14m", checkpoint_dir=tmp_path)
     checkpoint_dir = tmp_path / "EleutherAI" / "pythia-14m"


### PR DESCRIPTION
Fixes #1349

I found that the `litgpt evaluate` command ignores the provided checkpoint dir and *silently* downloads the model from HF. Since the download speeds in Studios is so fast, I didn't notice this. The only hint that this is happening is when I saw #1349 but I interpreted this first as it just wanting to download a missing config file. Later when I looked at the benchmark numbers and saw that LoRA, QLoRA and full finetuning returned all had the same eval benchmark numbers, I was led down this rabbit hole.

The fix is to correctly pass the pretrained checkpoint file to the HFLM class. 
Tied to this is the problem that the huggingface state dict loader forces `weights_only=True`, which our checkpoints don't support because they are saved using pickle in the incremental saver. So I had to also include a workaround for this.

 