### PR TITLE
Only run expensive tests of code files change

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -3,8 +3,18 @@ name: CPU tests
 on:
   push:
     branches: [main, wip]
+    paths:
+      - '**/*.py'
+      - '**/*.ipynb'
+      - '**/*.yaml'
+      - '**/*.sh'
   pull_request:
     branches: [main, "carmocca/*", wip]
+    paths:
+      - '**/*.py'
+      - '**/*.ipynb'
+      - '**/*.yaml'
+      - '**/*.sh'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref }}


### PR DESCRIPTION
Recently, we have been lots of small doc changes, and it's wasteful to run all the expensive tests if we change something in the markdown files like #1365 (also, waiting for those tests to pass is time consuming). 

With the following modification, to the best of my knowledge, the tests would only run if any of the code files are changed. What do you think @carmocca @lantiga @awaelchli ?