### PR TITLE
Readme.mnd - Instruct how to get HF_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,15 @@ Here's an example showing how to use the Phi-2 LLM.
 
 &nbsp;
 
+### Get a Hugging Face access token
+litgpt downloads the models from repositories on Hugging Face, and that's why we 
+need to [get your token](https://huggingface.co/docs/hub/security-tokens) first on their website. You can find all your tokens by visiting https://huggingface.co/settings/tokens
+
+Then, set the `HF_TOKEN=your_token` environment variable or pass --access_token=your_token. 
+
 ```bash
 # 1) Download a pretrained model
-litgpt download --repo_id microsoft/phi-2
+litgpt download --repo_id microsoft/phi-2  # or add --access_token=<your_token>
 
 # 2) Chat with the model
 litgpt chat \


### PR DESCRIPTION
This PR aims to improve the instructions on the README.md about how to use the Hugging Face access token
Although having this setup already is common knowledge to the experienced ML engineer, the new engineer might still need to be told how to do that.

After going through this situation myself ( see [#1363 ] ), I'm making this humble contribution  to the project
adding instructions on the README.md on how to get an Hugging Face access token.

Let me know what do you think.

Cheers.