### PR TITLE
LoRA test: check that all the tensors are materialized.

### DIFF
--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -758,3 +758,13 @@ def test_lora_model_fsdp_init():
     model = fabric.setup(model)
     y = model(x)
     assert y.shape == torch.Size([2, 8, 512])
+
+    # verify that all the parameters, buffers and other attributes aren't on `meta` device
+    for m in model.modules():
+        for p_name, parameter in m.named_parameters():
+            assert not parameter.is_meta, f"Parameter `{p_name}` isn't materialized."
+        for b_name, buffer in m._buffers.items():
+            assert not buffer.is_meta, f"Buffer `{b_name}` isn't materialized."
+        for attr_name, attr_value in m.__dict__.items():
+            if isinstance(attr_value, torch.Tensor):
+                assert not attr_value.is_meta, f"Attribute `{attr_name}` isn't materialized."


### PR DESCRIPTION
Hi there 👋 

As @awaelchli [suggested](https://github.com/Lightning-AI/litgpt/pull/770#discussion_r1591600891), this PR extends the test for LoRA to make sure that all the tensors (parameters, buffers, attributes) are materialized.
With just a forward pass we depend on the config: if LoRA is applied to all matrices (Q, K and V), then we don't need `zero_pad` method during a forward pass and thus might not notice that `lora_ind` inside the method is a non-materialized tensor.