### PR TITLE
Add prompt style mapping for llama3

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -318,6 +318,7 @@ prompt_styles: Dict[str, Type[PromptStyle]] = {
     "tinyllama": TinyLlama,
     "gemma": Gemma,
     "h2oai": H2Oai,
+    "llama3": Llama3,
 }
 
 


### PR DESCRIPTION
The file `/litgpt/prompts.py` was missing the mapping between the `llama3` model name and the `Llama3` PromptStyle class in the variable `prompt_styles`.