### PR TITLE
WIP: TensorParallel with new strategy

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -68,7 +68,7 @@ def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: A
     return next.to(dtype=x.dtype)
 
 
-@torch.inference_mode()
+@torch.no_grad()
 def generate(
     model: GPT,
     prompt: torch.Tensor,


### PR DESCRIPTION
Shows how the new ModelParallelStrategy could be applied in `generate/tp.py`. 

Some caveats:
- Need to apply quantization in the parallelize function (to be done)
- DTensors don't work with `torch.inference_mode`

There is room to apply more parallelism. For example, the RMSNorm could leverage `SequenceParallel`.