### PR TITLE
Fix optimizer init with fused=True

### DIFF
--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -514,5 +514,7 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
         optimizer_cls = getattr(torch.optim, optimizer)
         optimizer = optimizer_cls(model_parameters, **kwargs)
     else:
-        optimizer = instantiate_class(model_parameters, optimizer, **kwargs)
+        optimizer = dict(optimizer)  # copy
+        optimizer["init_args"].update(kwargs)
+        optimizer = instantiate_class(model_parameters, optimizer)
     return optimizer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -340,16 +340,13 @@ def test_instantiate_bnb_optimizer_with_invalid_str(model_parameters):
 
 
 def test_instantiate_torch_optimizer_with_str(model_parameters):
-    with mock.patch("litgpt.utils.instantiate_class") as mock_instantiate_class:
-        mock_instantiate_class.return_value = torch.optim.Adam(model_parameters, lr=0.01)
-        optimizer = instantiate_torch_optimizer("Adam", model_parameters, lr=0.01)
-        assert isinstance(optimizer, torch.optim.Adam)
-        assert optimizer.param_groups[0]["lr"] == 0.01
+    optimizer = instantiate_torch_optimizer("Adam", model_parameters, lr=0.01)
+    assert isinstance(optimizer, torch.optim.Adam)
+    assert optimizer.param_groups[0]["lr"] == 0.01
 
 
 def test_instantiate_torch_optimizer_with_class(model_parameters):
-    with mock.patch("litgpt.utils.instantiate_class") as mock_instantiate_class:
-        mock_instantiate_class.return_value = torch.optim.Adam(model_parameters, lr=0.02)
-        optimizer = instantiate_torch_optimizer(torch.optim.Adam, model_parameters, lr=0.02)
-        assert isinstance(optimizer, torch.optim.Adam)
-        assert optimizer.param_groups[0]["lr"] == 0.02
+    optimizer = instantiate_torch_optimizer({"class_path": "torch.optim.Adam", "init_args": {"lr": 123}}, model_parameters, lr=0.02)
+    assert isinstance(optimizer, torch.optim.Adam)
+    # init args gets overridden
+    assert optimizer.param_groups[0]["lr"] == 0.02


### PR DESCRIPTION
cc @rasbt 

Avoids

```python
Traceback (most recent call last):
  File "/home/carlos/nightly-env/bin/litgpt", line 8, in <module>
    sys.exit(main())
  File "/home/carlos/lit-parrot/litgpt/__main__.py", line 150, in main
    fn(**kwargs)
  File "/home/carlos/lit-parrot/litgpt/pretrain.py", line 122, in setup
    main(
  File "/home/carlos/lit-parrot/litgpt/pretrain.py", line 179, in main
    optimizer = instantiate_torch_optimizer(optimizer, model.parameters(), **extra_kwargs)
  File "/home/carlos/lit-parrot/litgpt/utils.py", line 517, in instantiate_torch_optimizer
    optimizer = instantiate_class(model_parameters, optimizer, **kwargs)
TypeError: instantiate_class() got an unexpected keyword argument 'fused'
```