### PR TITLE
Fix README.md alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Uses the latest state-of-the-art techniques:
 
 <pre>
-                     ✅ flash attention       ✅ fp4/8/16/32          ✅ LoRA, QLoRA, Adapter (v1, v2)
+             ✅ flash attention       ✅ fp4/8/16/32          ✅ LoRA, QLoRA, Adapter (v1, v2)
 ✅ FSDP                  ✅ 1-1000+ GPUs/TPUs    ✅ 20+ LLMs
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Uses the latest state-of-the-art techniques:
 
 <pre>
-             ✅ flash attention       ✅ fp4/8/16/32          ✅ LoRA, QLoRA, Adapter (v1, v2)
+             ✅ flash attention       ✅ fp4/8/16/32          ✅ LoRA, QLoRA, Adapter
 ✅ FSDP                  ✅ 1-1000+ GPUs/TPUs    ✅ 20+ LLMs
 </pre>
 


### PR DESCRIPTION
For some reason, it now looks different in the actual readme vs the previewed readme.

Preview:

<img width="909" alt="Screenshot 2024-05-24 at 1 58 32 PM" src="https://github.com/Lightning-AI/litgpt/assets/5618407/da7de914-720e-4f94-a890-577de10eb751">

Actual:
<img width="645" alt="Screenshot 2024-05-24 at 1 57 42 PM" src="https://github.com/Lightning-AI/litgpt/assets/5618407/d120acaa-7862-4065-8bfc-702ff6286240">

Kind of frustrating. I will try to fix it, and if doesn't work then undo it.

