### PR TITLE
Pin litdata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ all = [
     "sentencepiece>=0.2.0",      # llama-based models
     "tokenizers>=0.15.2",        # pythia, falcon, redpajama
     "requests>=2.31.0",          # litgpt.data
-    "litdata>=0.2.6",            # litgpt.data
+    "litdata==0.2.6",            # litgpt.data
     "litserve>=0.1.0",           # litgpt.deploy
     "zstandard>=0.22.0",         # litgpt.data.prepare_slimpajama.py
     "pandas>=1.9.0",             # litgpt.data.prepare_starcoder.py


### PR DESCRIPTION
Seems like the LitData 0.2.7 release made some changes that messes with out tests. Let's pin it to 0.2.6 until we have time to investigate what's causing the discrepancies.