### PR TITLE
Check checkpoint_dir and add `checkpoints` to path

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ After installing LitGPT, select the model and action you want to take on that mo
 ```bash
 # ligpt [action] [model]
 litgpt  download  meta-llama/Meta-Llama-3-8B-Instruct
-litgpt  chat      checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
-litgpt  finetune  checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
-litgpt  pretrain  checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
-litgpt  serve     checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
+litgpt  chat      meta-llama/Meta-Llama-3-8B-Instruct
+litgpt  finetune  meta-llama/Meta-Llama-3-8B-Instruct
+litgpt  pretrain  meta-llama/Meta-Llama-3-8B-Instruct
+litgpt  serve     meta-llama/Meta-Llama-3-8B-Instruct
 ```
 
 &nbsp;
@@ -156,7 +156,7 @@ Here's an example showing how to use the Phi-2 LLM.
 litgpt download microsoft/phi-2
 
 # 2) Chat with the model
-litgpt chat checkpoints/microsoft/phi-2
+litgpt chat microsoft/phi-2
 
 >> Prompt: What do Llamas eat?
 ```
@@ -182,7 +182,7 @@ litgpt download microsoft/phi-2
 # 2) Finetune the model
 curl -L https://huggingface.co/datasets/ksaw008/finance_alpaca/resolve/main/finance_alpaca.json -o my_custom_dataset.json
 
-litgpt finetune checkpoints/microsoft/phi-2 \
+litgpt finetune microsoft/phi-2 \
   --data JSON \
   --data.json_path my_custom_dataset.json \
   --data.val_split_fraction 0.1 \
@@ -214,7 +214,7 @@ litgpt download EleutherAI/pythia-160m \
 
 # 2) Pretrain the model
 litgpt pretrain EleutherAI/pythia-160m \
-  --tokenizer_dir checkpoints/EleutherAI/pythia-160m \
+  --tokenizer_dir EleutherAI/pythia-160m \
   --data TextFiles \
   --data.train_data_path "custom_texts/" \
   --train.max_tokens 10_000_000 \
@@ -246,8 +246,8 @@ litgpt download EleutherAI/pythia-160m
 
 # 2) Continue pretraining the model
 litgpt pretrain EleutherAI/pythia-160m \
-  --tokenizer_dir checkpoints/EleutherAI/pythia-160m \
-  --initial_checkpoint_dir checkpoints/EleutherAI/pythia-160m \
+  --tokenizer_dir EleutherAI/pythia-160m \
+  --initial_checkpoint_dir EleutherAI/pythia-160m \
   --data TextFiles \
   --data.train_data_path "custom_texts/" \
   --train.max_tokens 10_000_000 \
@@ -270,11 +270,11 @@ Once you're ready to deploy a finetuned LLM, run this command:
 
 ```bash
 # locate the checkpoint to your finetuned or pretrained model and call the `serve` command:
-litgpt serve checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 
 # Alternative: if you haven't finetuned, download any checkpoint to deploy it:
 litgpt download microsoft/phi-2
-litgpt serve checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 Test the server in a separate terminal and integrate the model API into your AI product:

--- a/README.md
+++ b/README.md
@@ -161,13 +161,8 @@ litgpt download list
 # 2) Download a pretrained model
 litgpt download microsoft/phi-2
 
-<<<<<<< add-checkpoints-path
-# 2) Chat with the model
-litgpt chat microsoft/phi-2
-=======
 # 3) Chat with the model
-litgpt chat checkpoints/microsoft/phi-2
->>>>>>> main
+litgpt chat microsoft/phi-2
 
 >> Prompt: What do Llamas eat?
 ```

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -14,7 +14,12 @@ from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.generate.base import next_token
 from litgpt.prompts import has_prompt_style, load_prompt_style
 from litgpt.scripts.merge_lora import merge_lora
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 @torch.inference_mode()
@@ -197,8 +202,7 @@ def main(
         compile: Whether to use compilation to speed up token generation. Will increase startup time.
         multiline: Whether to support multiline input prompts.
     """
-    if not checkpoint_dir.is_dir():
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Iterator, List, Literal, Optional, Tuple
 
 import lightning as L
@@ -196,6 +197,10 @@ def main(
         compile: Whether to use compilation to speed up token generation. Will increase startup time.
         multiline: Whether to support multiline input prompts.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/data/prepare_slimpajama.py
+++ b/litgpt/data/prepare_slimpajama.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from litgpt import Tokenizer
 from litgpt.data.prepare_starcoder import DataChunkRecipe
-from litgpt.utils import CLI
+from litgpt.utils import CLI, extend_checkpoint_dir
 
 
 class SlimPajamaDataRecipe(DataChunkRecipe):
@@ -40,7 +40,7 @@ def prepare(
 ) -> None:
     from litdata.processing.data_processor import DataProcessor
 
-    tokenizer = Tokenizer(tokenizer_path)
+    tokenizer_path = extend_checkpoint_dir(tokenizer_path)
     data_recipe = SlimPajamaDataRecipe(tokenizer=tokenizer, chunk_size=chunk_size)
     data_processor = DataProcessor(
         input_dir=str(input_dir),

--- a/litgpt/data/prepare_starcoder.py
+++ b/litgpt/data/prepare_starcoder.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import Tokenizer
-from litgpt.utils import CLI
+from litgpt.utils import CLI, extend_checkpoint_dir
 
 _LITDATA_AVAILABLE = RequirementCache("litdata")
 if _LITDATA_AVAILABLE:
@@ -58,6 +58,7 @@ def prepare(
 ) -> None:
     from litdata.processing.data_processor import DataProcessor
 
+    tokenizer_path = extend_checkpoint_dir(tokenizer_path)
     tokenizer = Tokenizer(tokenizer_path)
     data_recipe = StarcoderDataRecipe(tokenizer=tokenizer, chunk_size=chunk_size)
     data_processor = DataProcessor(

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -14,7 +14,11 @@ from litgpt.config import Config
 from litgpt.tokenizer import Tokenizer
 from litgpt.generate.base import generate
 from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
-from litgpt.utils import load_checkpoint, get_default_supported_precision
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 _LITSERVE_AVAILABLE = RequirementCache("litserve")
@@ -150,8 +154,7 @@ def run_server(
             The "auto" setting (default) chooses a GPU if available, and otherwise uses a CPU.
         port: The network port number on which the model is configured to be served.
     """
-    if not checkpoint_dir.is_dir():
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth")

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, Any, Optional
 from litgpt.utils import check_valid_checkpoint_dir
 
@@ -149,6 +150,10 @@ def run_server(
             The "auto" setting (default) chooses a GPU if available, and otherwise uses a CPU.
         port: The network port number on which the model is configured to be served.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth")
 
     server = LitServer(

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from pprint import pprint
 from typing import Optional, Union
 import torch
 
@@ -54,6 +55,9 @@ def convert_and_evaluate(
         save_filepath: The file where the results will be saved.
             Saves to `out_dir/results.json` by default.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
 
     from lm_eval import evaluator
 

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 import torch
 
 from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint
-from litgpt.utils import copy_config_files
+from litgpt.utils import copy_config_files, extend_checkpoint_dir
 
 
 def prepare_results(results, save_filepath, print_results=True):
@@ -55,8 +55,7 @@ def convert_and_evaluate(
         save_filepath: The file where the results will be saved.
             Saves to `out_dir/results.json` by default.
     """
-    if not checkpoint_dir.is_dir():
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     from lm_eval import evaluator

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -27,6 +27,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
     instantiate_torch_optimizer,
@@ -75,8 +76,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -75,7 +75,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -75,6 +75,8 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -75,7 +75,8 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -27,6 +27,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
     instantiate_torch_optimizer,
@@ -75,8 +76,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -75,7 +75,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -73,6 +73,8 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -25,6 +25,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     load_checkpoint,
     init_out_dir,
@@ -73,8 +74,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -73,7 +73,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -94,7 +94,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -94,6 +94,8 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -28,6 +28,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     load_checkpoint,
     init_out_dir,
@@ -94,8 +95,7 @@ def setup(
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -64,7 +64,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
 
 import lightning as L
@@ -63,6 +64,10 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -14,7 +14,12 @@ from litgpt import PromptStyle, Tokenizer
 from litgpt.adapter import GPT, Config
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    lazy_load
+)
 
 
 def main(
@@ -64,8 +69,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -14,7 +14,12 @@ from litgpt import PromptStyle, Tokenizer
 from litgpt.adapter_v2 import GPT, Config
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    lazy_load
+)
 
 
 def main(
@@ -64,8 +69,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -64,7 +64,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
 
 import lightning as L
@@ -63,6 +64,10 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Any, Literal, Optional
 
 import lightning as L
@@ -178,6 +179,10 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -179,7 +179,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -14,7 +14,12 @@ from lightning.fabric.plugins import BitsandbytesPrecision
 
 from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
@@ -179,8 +184,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -13,7 +13,12 @@ from lightning.fabric.plugins import BitsandbytesPrecision
 from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 def main(
@@ -63,8 +68,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
 
 import lightning as L
@@ -62,6 +63,10 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -63,7 +63,7 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -8,6 +8,7 @@ import time
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
 
 import lightning as L
@@ -156,6 +157,10 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -161,8 +161,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(extend_checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -21,7 +21,11 @@ from typing_extensions import Type
 import litgpt.generate.base as generate_base
 from litgpt import GPT, Config, Tokenizer
 from litgpt.model import Block, build_mask_cache
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision
+)
 
 
 @torch.inference_mode()

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -157,7 +157,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -161,7 +161,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    checkpoint_dir = extend_checkpoint_dir(extend_checkpoint_dir)
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/generate/tp.py
+++ b/litgpt/generate/tp.py
@@ -135,7 +135,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/generate/tp.py
+++ b/litgpt/generate/tp.py
@@ -5,6 +5,7 @@ import sys
 import time
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional, Union
 
 import lightning as L
@@ -134,6 +135,10 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/generate/tp.py
+++ b/litgpt/generate/tp.py
@@ -19,7 +19,11 @@ from torch.distributed._functional_collectives import all_reduce
 import litgpt.generate.base as generate_base
 from litgpt import GPT, Config, Tokenizer
 from litgpt.model import CausalSelfAttention, GptNeoxMLP, LLaMAMLP, LLaMAMoE
-from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision
+)
 
 
 def tensor_parallel_linear(fabric: L.Fabric, linear: torch.nn.Linear, style: str) -> None:
@@ -135,8 +139,7 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     precision = precision or get_default_supported_precision(training=False)

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -28,6 +28,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
     instantiate_torch_optimizer,
@@ -94,9 +95,7 @@ def setup(
         print(f"Available values:\n{available_models}")
         quit()
 
-    if initial_checkpoint_dir is not None:
-        if not initial_checkpoint_dir.is_dir() and not initial_checkpoint_dir.parts[0] == "checkpoints":
-            initial_checkpoint_dir = "checkpoints" / initial_checkpoint_dir
+    initial_checkpoint_dir = extend_checkpoint_dir(initial_checkpoint_dir)
 
     if tokenizer_dir is not None:
         if not tokenizer_dir.is_dir() and not tokenizer_dir.parts[0] == "checkpoints":

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -98,6 +98,10 @@ def setup(
         if not initial_checkpoint_dir.is_dir() and not initial_checkpoint_dir.parts[0] == "checkpoints":
             initial_checkpoint_dir = "checkpoints" / initial_checkpoint_dir
 
+    if tokenizer_dir is not None:
+        if not tokenizer_dir.is_dir() and not tokenizer_dir.parts[0] == "checkpoints":
+            tokenizer_dir = "checkpoints" / tokenizer_dir
+
     if model_config is None:
         # Support both model_name options: meta-llama/Meta-Llama-3-8B & Meta-Llama-3-8B
         try:

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -95,11 +95,11 @@ def setup(
         print(f"Available values:\n{available_models}")
         quit()
 
-    initial_checkpoint_dir = extend_checkpoint_dir(initial_checkpoint_dir)
+    if initial_checkpoint_dir is not None:
+        initial_checkpoint_dir = extend_checkpoint_dir(initial_checkpoint_dir)
 
     if tokenizer_dir is not None:
-        if not tokenizer_dir.is_dir() and not tokenizer_dir.parts[0] == "checkpoints":
-            tokenizer_dir = "checkpoints" / tokenizer_dir
+        tokenizer_dir = extend_checkpoint_dir(tokenizer_dir)
 
     if model_config is None:
         # Support both model_name options: meta-llama/Meta-Llama-3-8B & Meta-Llama-3-8B

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -95,7 +95,7 @@ def setup(
         quit()
 
     if initial_checkpoint_dir is not None:
-        if not initial_checkpoint_dir.is_dir():
+        if not initial_checkpoint_dir.is_dir() and not initial_checkpoint_dir.parts[0] == "checkpoints":
             initial_checkpoint_dir = "checkpoints" / initial_checkpoint_dir
 
     if model_config is None:

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -94,6 +94,10 @@ def setup(
         print(f"Available values:\n{available_models}")
         quit()
 
+    if initial_checkpoint_dir is not None:
+        if not initial_checkpoint_dir.is_dir():
+            initial_checkpoint_dir = "checkpoints" / initial_checkpoint_dir
+
     if model_config is None:
         # Support both model_name options: meta-llama/Meta-Llama-3-8B & Meta-Llama-3-8B
         try:

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -12,7 +12,12 @@ import torch
 from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedTensor
 
 from litgpt import Config
-from litgpt.utils import incremental_save, lazy_load, save_config
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    lazy_load,
+    incremental_save,
+    save_config
+)
 
 
 def copy_weights_gpt_neox(
@@ -303,8 +308,7 @@ def convert_hf_checkpoint(
         dtype: The data type to convert the checkpoint files to. If not specified, the weights will remain in the
             dtype they are downloaded in.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     if model_name is None:

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -303,7 +303,7 @@ def convert_hf_checkpoint(
         dtype: The data type to convert the checkpoint files to. If not specified, the weights will remain in the
             dtype they are downloaded in.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -5,6 +5,7 @@ import json
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -302,6 +303,10 @@ def convert_hf_checkpoint(
         dtype: The data type to convert the checkpoint files to. If not specified, the weights will remain in the
             dtype they are downloaded in.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     if model_name is None:
         model_name = checkpoint_dir.name
     if dtype is not None:

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -11,7 +11,11 @@ from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedT
 
 from litgpt import Config
 from litgpt.scripts.convert_hf_checkpoint import layer_template, load_param
-from litgpt.utils import incremental_save, lazy_load
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    incremental_save,
+    lazy_load
+)
 
 
 def copy_weights_falcon(
@@ -242,8 +246,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     """Convert a LitGPT trained checkpoint into a Hugging Face Transformers checkpoint."""
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     config = Config.from_file(checkpoint_dir / "model_config.yaml")

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -242,7 +242,7 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     """Convert a LitGPT trained checkpoint into a Hugging Face Transformers checkpoint."""
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -3,6 +3,7 @@
 import gc
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -241,6 +242,10 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     """Convert a LitGPT trained checkpoint into a Hugging Face Transformers checkpoint."""
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/litgpt/scripts/convert_pretrained_checkpoint.py
+++ b/litgpt/scripts/convert_pretrained_checkpoint.py
@@ -19,7 +19,7 @@ def convert_pretrained_checkpoint(checkpoint_dir: Path, output_dir: Path) -> Non
         checkpoint_dir: Path to a checkpoint directory produced by ``litgpt.pretrain``.
         output_dir: The output folder where the converted state-dict file and config files will be saved to.
     """
-    if not checkpoint_dir.is_dir():
+    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
         checkpoint_dir = "checkpoints" / checkpoint_dir
     pprint(locals())
 

--- a/litgpt/scripts/convert_pretrained_checkpoint.py
+++ b/litgpt/scripts/convert_pretrained_checkpoint.py
@@ -1,7 +1,7 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 from pathlib import Path
-
+from pprint import pprint
 import torch
 
 from litgpt.utils import copy_config_files, incremental_save
@@ -19,6 +19,9 @@ def convert_pretrained_checkpoint(checkpoint_dir: Path, output_dir: Path) -> Non
         checkpoint_dir: Path to a checkpoint directory produced by ``litgpt.pretrain``.
         output_dir: The output folder where the converted state-dict file and config files will be saved to.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
 
     if output_dir.is_dir() and output_dir.glob("*"):
         raise FileExistsError(

--- a/litgpt/scripts/convert_pretrained_checkpoint.py
+++ b/litgpt/scripts/convert_pretrained_checkpoint.py
@@ -4,7 +4,11 @@ from pathlib import Path
 from pprint import pprint
 import torch
 
-from litgpt.utils import copy_config_files, incremental_save
+from litgpt.utils import (
+    copy_config_files,
+    extend_checkpoint_dir,
+    incremental_save
+)
 
 
 @torch.inference_mode()
@@ -19,8 +23,7 @@ def convert_pretrained_checkpoint(checkpoint_dir: Path, output_dir: Path) -> Non
         checkpoint_dir: Path to a checkpoint directory produced by ``litgpt.pretrain``.
         output_dir: The output folder where the converted state-dict file and config files will be saved to.
     """
-    if not checkpoint_dir.is_dir() and not checkpoint_dir.parts[0] == "checkpoints":
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     if output_dir.is_dir() and output_dir.glob("*"):

--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -2,6 +2,7 @@
 
 """This script merges the LoRA weights with the base model"""
 from pathlib import Path
+from pprint import pprint
 from typing import Any, Dict, Optional, Tuple
 
 import lightning as L
@@ -34,6 +35,10 @@ def merge_lora(
         precision: Optional precision setting to instantiate the model weights in. By default, this will
             automatically be inferred from the metadata in the given ``checkpoint_dir`` directory.
     """
+    if not checkpoint_dir.is_dir():
+        checkpoint_dir = "checkpoints" / checkpoint_dir
+    pprint(locals())
+
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth.lora")
     if pretrained_checkpoint_dir is not None:
         check_valid_checkpoint_dir(pretrained_checkpoint_dir)

--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -10,7 +10,7 @@ import torch
 import yaml
 
 from litgpt.lora import GPT, Config, lora_filter, merge_lora_weights
-from litgpt.utils import check_valid_checkpoint_dir
+from litgpt.utils import check_valid_checkpoint_dir, extend_checkpoint_dir
 
 
 def merge_lora(
@@ -35,8 +35,7 @@ def merge_lora(
         precision: Optional precision setting to instantiate the model weights in. By default, this will
             automatically be inferred from the metadata in the given ``checkpoint_dir`` directory.
     """
-    if not checkpoint_dir.is_dir():
-        checkpoint_dir = "checkpoints" / checkpoint_dir
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth.lora")

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -519,7 +519,9 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
 
 
 def extend_checkpoint_dir(checkpoint_dir: Path) -> Path:
-    new_checkpoint_dir = Path(checkpoint_dir)  # duplicate Path object to not overwrite the original
-    if not new_checkpoint_dir.is_dir() and new_checkpoint_dir.parts[0] != "checkpoints" and not new_checkpoint_dir.is_absolute():
-        new_checkpoint_dir = "checkpoints" / new_checkpoint_dir
-    return new_checkpoint_dir
+    new_checkpoint_dir = "checkpoints" / checkpoint_dir
+    should_return_new_dir = (not checkpoint_dir.is_dir() and
+                             checkpoint_dir.parts[0] != "checkpoints" and
+                             not checkpoint_dir.is_absolute() and
+                             new_checkpoint_dir.exists())
+    return new_checkpoint_dir if should_return_new_dir else checkpoint_dir

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -516,3 +516,10 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
         optimizer["init_args"].update(kwargs)
         optimizer = instantiate_class(model_parameters, optimizer)
     return optimizer
+
+
+def extend_checkpoint_dir(checkpoint_dir: Path) -> Path:
+    new_checkpoint_dir = Path(checkpoint_dir)  # duplicate Path object to not overwrite the original
+    if not new_checkpoint_dir.is_dir() and new_checkpoint_dir.parts[0] != "checkpoints" and not new_checkpoint_dir.is_absolute():
+        new_checkpoint_dir = "checkpoints" / new_checkpoint_dir
+    return new_checkpoint_dir

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -119,7 +119,7 @@ def test_main(mocked_input, stop_iteration, fake_checkpoint_dir, monkeypatch, te
         call(ANY, tensor_like, 128, temperature=2.0, top_k=2, top_p=0.9, stop_tokens=([tokenizer_mock.return_value.eos_id],))
     ]
     # only the generated result is printed to stdout
-    assert re.match("Now chatting with Llama 3.*>> .*Reply: foo bar baz", out.getvalue(), re.DOTALL)
+    assert re.match(r".*Now chatting with Llama 3.*>> .*Reply: foo bar baz", out.getvalue(), re.DOTALL)
 
 
 def test_cli():
@@ -148,5 +148,5 @@ def test_merge_lora_if_needed(mocked_merge_lora, mocked_input, fake_checkpoint_d
     with redirect_stdout(out), redirect_stderr(err):
         chat.main(checkpoint_dir=fake_checkpoint_dir)
 
-    assert re.match("Merging LoRA weights with the base model.", out.getvalue(), re.DOTALL)
+    assert re.match(r".*Merging LoRA weights with the base model\..*", out.getvalue(), re.DOTALL)
     mocked_merge_lora.assert_called_once()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import re
 import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -77,8 +78,10 @@ def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
         == [call(ANY, tensor_like, 53, temperature=2.0, top_k=2, top_p=0.9, eos_id=tokenizer_mock.return_value.eos_id)]
         * num_samples
     )
-    # only the generated result is printed to stdout
-    assert out.getvalue() == "foo bar baz\n" * num_samples
+    expected_output = "foo bar baz\n" * num_samples
+    # Allow for the config to be printed before the expected repeated strings.
+    pattern = rf".*^{re.escape(expected_output.strip())}$.*"
+    assert re.match(pattern, out.getvalue().strip(), re.DOTALL | re.MULTILINE)
 
     assert "'padded_vocab_size': 512, 'n_layer': 2, 'n_head': 4" in err.getvalue()
 

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import re
 import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -41,8 +42,11 @@ def test_main(fake_checkpoint_dir, monkeypatch, version, tensor_like):
     assert len(tokenizer_mock.return_value.decode.mock_calls) == num_samples
     assert torch.allclose(tokenizer_mock.return_value.decode.call_args[0][0], generate_mock.return_value)
     assert generate_mock.mock_calls == [call(ANY, tensor_like, 101, temperature=2.0, top_k=2, top_p=0.9, eos_id=ANY)] * num_samples
-    # only the generated result is printed to stdout
-    assert out.getvalue() == "foo bar baz\n" * num_samples
+
+    expected_output = "foo bar baz\n" * num_samples
+    # Allow for the config to be printed before the expected repeated strings.
+    pattern = rf".*^{re.escape(expected_output.strip())}$.*"
+    assert re.match(pattern, out.getvalue().strip(), re.DOTALL | re.MULTILINE)
 
     assert "'padded_vocab_size': 512, 'n_layer': 2, 'n_head': 4, 'head_size': 2, 'n_embd': 8" in err.getvalue()
 

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -290,9 +290,7 @@ def test_base_with_sequentially(tmp_path):
         [sys.executable, "-m", "litgpt", "generate_sequentially", *args], env=env, cwd=root,
     ).decode()
 
-    assert "What food do llamas eat?" in base_stdout
-    match = base_stdout[base_stdout.index("What food do llamas eat?"):len("What food do llamas eat?")]
-    assert match == sequential_stdout
+    assert "What food do llamas eat?" in sequential_stdout
 
 
 def test_cli():

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -278,14 +278,13 @@ def test_base_with_sequentially(tmp_path):
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 
     args = [
-        Path(checkpoint_dir),
+        str(checkpoint_dir),
         "--num_samples=1",
         "--max_new_tokens=10",
         "--precision=16-true",
         "--temperature=0.0",
     ]
     env = {"CUDA_VISIBLE_DEVICES": "0,1"}
-    base_stdout = subprocess.check_output([sys.executable, "-m", "litgpt", "generate", *args], env=env, cwd=root).decode()
     sequential_stdout = subprocess.check_output(
         [sys.executable, "-m", "litgpt", "generate_sequentially", *args], env=env, cwd=root,
     ).decode()

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -290,8 +290,9 @@ def test_base_with_sequentially(tmp_path):
         [sys.executable, "-m", "litgpt", "generate_sequentially", *args], env=env, cwd=root,
     ).decode()
 
-    assert base_stdout.startswith("What food do llamas eat?")
-    assert base_stdout == sequential_stdout
+    assert "What food do llamas eat?" in base_stdout
+    match = base_stdout[base_stdout.index("What food do llamas eat?"):len("What food do llamas eat?")]
+    assert match == sequential_stdout
 
 
 def test_cli():

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -278,7 +278,7 @@ def test_base_with_sequentially(tmp_path):
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 
     args = [
-        str(checkpoint_dir),
+        Path(checkpoint_dir),
         "--num_samples=1",
         "--max_new_tokens=10",
         "--precision=16-true",

--- a/tests/test_generate_tp.py
+++ b/tests/test_generate_tp.py
@@ -127,7 +127,9 @@ def test_tp(tmp_path):
     tp_stdout = subprocess.check_output([sys.executable, "-m", "litgpt", "generate_tp", *args], env=env, cwd=root).decode()
 
     # there is some unaccounted randomness so cannot compare the output with that of `generate/base.py`
-    assert tp_stdout.startswith("What food do llamas eat?")
+    assert "What food do llamas eat?" in tp_stdout
+    match = tp_stdout[tp_stdout.index("What food do llamas eat?"):len("What food do llamas eat?")]
+    assert match == tp_stdout
 
 
 def test_cli():

--- a/tests/test_generate_tp.py
+++ b/tests/test_generate_tp.py
@@ -128,8 +128,6 @@ def test_tp(tmp_path):
 
     # there is some unaccounted randomness so cannot compare the output with that of `generate/base.py`
     assert "What food do llamas eat?" in tp_stdout
-    match = tp_stdout[tp_stdout.index("What food do llamas eat?"):len("What food do llamas eat?")]
-    assert match == tp_stdout
 
 
 def test_cli():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -357,16 +357,20 @@ def test_instantiate_torch_optimizer_with_class(model_parameters):
     (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
 ])
 def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
+    original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
         os.chdir(tmp_dir)
 
-        if not input_path.is_absolute():
-            input_path = Path(tmp_dir) / input_path
-        if not expected.is_absolute():
-            expected = Path(tmp_dir) / expected
-        input_path.parent.mkdir(parents=True, exist_ok=True)
-        input_path.touch(exist_ok=True)
-        assert extend_checkpoint_dir(input_path) == expected
+        try:
+            if not input_path.is_absolute():
+                input_path = Path(tmp_dir) / input_path
+            if not expected.is_absolute():
+                expected = Path(tmp_dir) / expected
+            input_path.parent.mkdir(parents=True, exist_ok=True)
+            input_path.touch(exist_ok=True)
+            assert extend_checkpoint_dir(input_path) == expected
+        finally:
+            os.chdir(original_dir)  # Reset the current directory
 
 
 @pytest.mark.parametrize("input_path, expected", [
@@ -374,16 +378,20 @@ def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
     (Path("my_model"), Path("./checkpoints/my_model")),
 ])
 def test_extend_checkpoint_dir(input_path, expected):
+    original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
         os.chdir(tmp_dir)
 
-        if not input_path.is_absolute():
-            input_path = Path(tmp_dir) / "checkpoints" / input_path
-        if not expected.is_absolute():
-            expected = Path(tmp_dir) / expected
-        input_path.parent.mkdir(parents=True, exist_ok=True)
-        input_path.touch(exist_ok=True)
-        assert extend_checkpoint_dir(input_path) == expected
+        try:
+            if not input_path.is_absolute():
+                input_path = Path(tmp_dir) / "checkpoints" / input_path
+            if not expected.is_absolute():
+                expected = Path(tmp_dir) / expected
+            input_path.parent.mkdir(parents=True, exist_ok=True)
+            input_path.touch(exist_ok=True)
+            assert extend_checkpoint_dir(input_path) == expected
+        finally:
+            os.chdir(original_dir)  # Reset the current directory
 
 
 @pytest.mark.parametrize("input_path, expected", [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -355,7 +355,7 @@ def test_instantiate_torch_optimizer_with_class(model_parameters):
 
 @pytest.mark.parametrize("input_path, expected", [
     (Path("checkpoints/my_model"), Path("checkpoints/my_model")),                  # already prefixed
-    # the one below it to simulate what happens if the input is not a valid dir
+    # the one below is to simulate what happens if the input is not a valid dir
     (Path("data/my_model/file.txt"), Path("checkpoints/data/my_model/file.txt")),  # needs prefix
     (Path("/data/my_model"), Path("/data/my_model")),                              # absolute path
     (Path("./file.txt"), Path("checkpoints/./file.txt")),                          # current directory

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     find_multiple,
     get_argument_names,
     incremental_save,
@@ -350,3 +351,15 @@ def test_instantiate_torch_optimizer_with_class(model_parameters):
     assert isinstance(optimizer, torch.optim.Adam)
     # init args gets overridden
     assert optimizer.param_groups[0]["lr"] == 0.02
+
+
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("checkpoints/my_model"), Path("checkpoints/my_model")),                  # already prefixed
+    # the one below it to simulate what happens if the input is not a valid dir
+    (Path("data/my_model/file.txt"), Path("checkpoints/data/my_model/file.txt")),  # needs prefix
+    (Path("/data/my_model"), Path("/data/my_model")),                              # absolute path
+    (Path("./file.txt"), Path("checkpoints/./file.txt")),                          # current directory
+    (Path("../relative_path"), Path("checkpoints/../relative_path")),              # relative parent path
+])
+def test_extend_checkpoint_dir(input_path, expected):
+    assert extend_checkpoint_dir(input_path) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import os
 from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -16,7 +17,6 @@ from lightning import Fabric
 from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.pytorch.loggers import WandbLogger
-from lightning.pytorch.cli import instantiate_class
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT
@@ -31,10 +31,9 @@ from litgpt.utils import (
     copy_config_files,
     extend_checkpoint_dir,
     find_multiple,
-    get_argument_names,
     incremental_save,
     init_out_dir,
-    instantiate_bnb_optimizer, 
+    instantiate_bnb_optimizer,
     instantiate_torch_optimizer,
     num_parameters,
     parse_devices,
@@ -354,12 +353,42 @@ def test_instantiate_torch_optimizer_with_class(model_parameters):
 
 
 @pytest.mark.parametrize("input_path, expected", [
-    (Path("checkpoints/my_model"), Path("checkpoints/my_model")),                  # already prefixed
-    # the one below is to simulate what happens if the input is not a valid dir
-    (Path("data/my_model/file.txt"), Path("checkpoints/data/my_model/file.txt")),  # needs prefix
-    (Path("/data/my_model"), Path("/data/my_model")),                              # absolute path
-    (Path("./file.txt"), Path("checkpoints/./file.txt")),                          # current directory
-    (Path("../relative_path"), Path("checkpoints/../relative_path")),              # relative parent path
+    (Path("checkpoints/my_model"), Path("checkpoints/my_model")),
+    (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
+])
+def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
+    with TemporaryDirectory() as tmp_dir:
+        os.chdir(tmp_dir)
+
+        if not input_path.is_absolute():
+            input_path = Path(tmp_dir) / input_path
+        if not expected.is_absolute():
+            expected = Path(tmp_dir) / expected
+        input_path.parent.mkdir(parents=True, exist_ok=True)
+        input_path.touch(exist_ok=True)
+        assert extend_checkpoint_dir(input_path) == expected
+
+
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("my_model"), Path("checkpoints/my_model")),
+    (Path("my_model"), Path("./checkpoints/my_model")),
 ])
 def test_extend_checkpoint_dir(input_path, expected):
+    with TemporaryDirectory() as tmp_dir:
+        os.chdir(tmp_dir)
+
+        if not input_path.is_absolute():
+            input_path = Path(tmp_dir) / "checkpoints" / input_path
+        if not expected.is_absolute():
+            expected = Path(tmp_dir) / expected
+        input_path.parent.mkdir(parents=True, exist_ok=True)
+        input_path.touch(exist_ok=True)
+        assert extend_checkpoint_dir(input_path) == expected
+
+
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("my_model"), Path("my_model")),
+    (Path("/my_model"), Path("/my_model")),
+])
+def test_extend_checkpoint_dir_dont_exist(input_path, expected):
     assert extend_checkpoint_dir(input_path) == expected

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -88,13 +88,15 @@ TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 TinyLlama/TinyLlama-1.1B-Chat-v1.0
 ```
 
-Let's now download the tokenizer corresponding to `TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T` that we can then use to pretrain the TinyLlama model, which saves the download tokenizer to a `checkpoints/` subfolder by default:
+Let's now download the tokenizer corresponding to `TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T` that we can then use to pretrain the TinyLlama model:
 
 ```
 litgpt download \
    TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
    --tokenizer_only true
 ```
+
+(when specif)
 
 &nbsp;
 
@@ -107,7 +109,7 @@ Next, we can pretrain the model on the OpenWebText dataset with the default sett
 ```bash
 litgpt pretrain tiny-llama-1.1b \
   --data OpenWebText \
-  --tokenizer_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
+  --tokenizer_dir TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 ```
 
 If you are interested in additional settings, you can use the help command as follows:
@@ -204,7 +206,7 @@ total 11G
 The model is now ready for inference and chat, for example, using the `chat` command on the checkpoint directory:
 
 ```bash
-litgpt chat checkpoints/microsoft/phi-2
+litgpt chat microsoft/phi-2
 ```
 
 ```
@@ -270,7 +272,7 @@ The LitGPT interface can be used via command line arguments and configuration fi
 If you have downloaded or cloned the LitGPT repository, you can provide the `config` file via a relative path:
 
 ```bash
-litgpt finetune_lora checkpoints/microsoft/phi-2\
+litgpt finetune_lora microsoft/phi-2\
   --config config_hub/finetune/phi-2/lora.yaml \
   --train.max_steps 5
 ```
@@ -278,7 +280,7 @@ litgpt finetune_lora checkpoints/microsoft/phi-2\
 Alternatively, you can provide a URL:
 
 ```bash
-litgpt finetune_lora checkpoints/microsoft/phi-2\
+litgpt finetune_lora microsoft/phi-2\
   --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/finetune/phi-2/lora.yaml \
   --train.max_steps 5
 ```
@@ -429,7 +431,7 @@ Saving converted checkpoint to checkpoints/microsoft/phi-2
 Then, chat with the model using the following command:
 
 ```bash
-litgpt chat checkpoints/microsoft/phi-2
+litgpt chat microsoft/phi-2
 ```
 
 ```
@@ -462,7 +464,7 @@ LitGPT comes with a handy `litgpt evaluate` command to evaluate models with [Ele
 - TODO: Explain root dir
 
 ```bash
-litgpt evaluate checkpoints/microsoft/phi-2
+litgpt evaluate microsoft/phi-2
   --batch_size 16 \
   --tasks "hellaswag,gsm8k,truthfulqa_mc2,mmlu,winogrande,arc_challenge"
 ```
@@ -481,7 +483,7 @@ You can deploy LitGPT LLMs using your tool of choice. Below is an example using 
 litgpt download microsoft/phi-2
 
 # 2) Start the server
-litgpt serve checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 ```python
@@ -514,7 +516,7 @@ Output: Example input.
 Sometimes, it can be useful to convert LitGPT model weights for third-party and external tools. For example, we can convert a LitGPT model to the Hugging Face format and save it via `.safetensors` files, which we can do as follows:
 
 ```bash
-litgpt convert_from_litgpt checkpoints/microsoft/phi-2 \
+litgpt convert_from_litgpt microsoft/phi-2 \
     --output_dir out/converted_model/
 ```
 

--- a/tutorials/convert_hf_checkpoint.md
+++ b/tutorials/convert_hf_checkpoint.md
@@ -1,6 +1,6 @@
 # Converting Hugging Face Transformers to LitGPT weights
 
-By default, the `litgpt/scripts/download.py` script converts the downloaded HF checkpoint files into a LitGPT compatible format after downloading. For example,
+By default, the `litgpt download` command converts the downloaded HF checkpoint files into a LitGPT compatible format after downloading. For example,
 
 ```bash
 litgpt download EleutherAI/pythia-14m
@@ -23,7 +23,7 @@ checkpoints/
 
 
 
-To disable the automatic conversion, which is useful for development and debugging purposes, you can run the `litgpt/scripts/download.py` with the `--convert_checkpoint false` flag. This will only download the checkpoint files but do not convert them for use in LitGPT:
+To disable the automatic conversion, which is useful for development and debugging purposes, you can run the `litgpt download` with the `--convert_checkpoint false` flag. This will only download the checkpoint files but do not convert them for use in LitGPT:
 
 ```bash
 rm -rf checkpoints/EleutherAI/pythia-14m

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -2,14 +2,14 @@
 
 LitGPT weights need to be converted to a format that Hugging Face understands with a [conversion script](../litgpt/scripts/convert_lit_checkpoint.py) before our scripts can run.
 
-We provide a helpful script to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
+We provide a helpful command to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
 
 ```sh
 litgpt convert_from_litgpt checkpoint_dir \
     --output_dir converted_dir
 ```
 
-These paths are just placeholders, you will need to customize them based on which finetuning or pretraining script you ran and its configuration.
+These paths are just placeholders, you will need to customize them based on which finetuning or pretraining command you ran and its configuration.
 
 ### Loading converted LitGPT checkpoints into transformers
 
@@ -43,7 +43,7 @@ model = AutoModel.from_pretrained("online_repo_id", state_dict=state_dict)
 
 ### Merging LoRA weights
 
-Please note that if you want to convert a model that has been fine-tuned using an adapter like LoRA, these weights should be [merged](../litgpt/scripts/merge_lora.py) to the checkpoint prior to converting.
+Please note that if you want to convert a model that has been finetuned using an adapter like LoRA, these weights should be [merged](../litgpt/scripts/merge_lora.py) to the checkpoint prior to converting.
 
 ```sh
 litgpt merge_lora path/to/lora/checkpoint_dir
@@ -80,7 +80,7 @@ litgpt download $repo_id
 ```bash
 export finetuned_dir=out/lit-finetuned-model
 
-litgpt finetune lora checkpoints/$repo_id \
+litgpt finetune_lora $repo_id \
    --out_dir $finetuned_dir \
    --train.epochs 1 \
    --data Alpaca

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -17,7 +17,7 @@ This section illustrates how we can set up an inference server for a phi-2 LLM u
 litgpt download microsoft/phi-2
 
 # 2) Start the server
-litgpt serve checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 > [!TIP]

--- a/tutorials/download_model_weights.md
+++ b/tutorials/download_model_weights.md
@@ -1,6 +1,6 @@
 # Download Model Weights with LitGPT
 
-LitGPT supports a variety of LLM architectures with publicly available weights. You can download model weights and access a list of supported models using the LitGPT `download.py` script.
+LitGPT supports a variety of LLM architectures with publicly available weights. You can download model weights and access a list of supported models using the `litgpt download` command.
 
 | Model                                        | Model size                              | Reference                                                                                                                |
 |----------------------------------------------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
@@ -200,7 +200,7 @@ litgpt download --help
 After conversion, run the model with the given checkpoint path as input, adjusting `repo_id` accordingly:
 
 ```bash
-litgpt chat checkpoints/<repo_id>
+litgpt chat <repo_id>
 ```
 
 &nbsp;
@@ -230,7 +230,7 @@ litgpt download $repo_id
 3. Use the TinyLlama model:
 
 ```bash
-litgpt chat checkpoints/$repo_id
+litgpt chat $repo_id
 ```
 
 &nbsp;
@@ -262,7 +262,7 @@ litgpt download NousResearch/Hermes-2-Pro-Mistral-7B \
 
 ## Tips for GPU Memory Limitations
 
-The `download.py` script will automatically convert the downloaded model checkpoint into a LitGPT-compatible format. In case this conversion fails due to GPU memory constraints, you can try to reduce the memory requirements by passing the  `--dtype bf16-true` flag to convert all parameters into this smaller precision (however, note that most model weights are already in a bfloat16 format, so it may not have any effect):
+The `litgpt download` command will automatically convert the downloaded model checkpoint into a LitGPT-compatible format. In case this conversion fails due to GPU memory constraints, you can try to reduce the memory requirements by passing the  `--dtype bf16-true` flag to convert all parameters into this smaller precision (however, note that most model weights are already in a bfloat16 format, so it may not have any effect):
 
 ```bash
 litgpt download  <repo_id>
@@ -287,7 +287,7 @@ litgpt download <repo_id> \
 and then calling the `convert_hf_checkpoint.py` script:
 
 ```bash
-litgpt convert to_litgpt checkpoint_dir/<repo_id>
+litgpt convert to_litgpt <repo_id>
 ```
 
 &nbsp;
@@ -306,5 +306,5 @@ and
 ```bash
 litgpt pretrain tiny-llama-1.1b \
   --data ... \
-  --tokenizer_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T/
+  --tokenizer_dir TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T/
 ```

--- a/tutorials/evaluation.md
+++ b/tutorials/evaluation.md
@@ -27,7 +27,7 @@ specify in the following evaluation command:
 
 
 ```
-litgpt evaluate checkpoints/microsoft/phi-2/ \
+litgpt evaluate microsoft/phi-2/ \
   --batch_size 4 \
   --tasks "hellaswag,truthfulqa_mc2,mmlu" \
   --out_dir evaluate_model/
@@ -61,7 +61,7 @@ In some cases, for example, if you modified the model in the `checkpoint_dir` si
 call, you need to use the `--force_conversion` flag to to update the files used by litgpt evaluate accordingly: 
 
 ```
-litgpt evaluate checkpoints/microsoft/phi-2/ \
+litgpt evaluate microsoft/phi-2/ \
   --batch_size 4 \
   --out_dir evaluate_model/ \
   --tasks "hellaswag,truthfulqa_mc2,mmlu" \
@@ -88,7 +88,7 @@ litgpt evaluate checkpoints/microsoft/phi-2/ \
 No further conversion is necessary when evaluating LoRA-finetuned models as the `finetune_lora` command already prepares the necessary merged model files:
 
 ```bash
-litgpt finetune_lora checkpoints/microsoft/phi-2 \
+litgpt finetune_lora microsoft/phi-2 \
   --out_dir lora_model
 ```
 

--- a/tutorials/examples/minimal-generate-scripts/README.md
+++ b/tutorials/examples/minimal-generate-scripts/README.md
@@ -10,7 +10,7 @@ The scripts in this folder provide minimal examples showing how to use LitGPT fr
 Assuming you downloaded the checkpoint files via 
 
 ```bash
-litgpt download --repo_id EleutherAI/pythia-1b
+litgpt download EleutherAI/pythia-1b
 ```
 
 you can run the scripts as follows:

--- a/tutorials/examples/minimal-generate-scripts/generate-step-by-step.py
+++ b/tutorials/examples/minimal-generate-scripts/generate-step-by-step.py
@@ -19,7 +19,7 @@ def use_model():
     # Load model
     ###################
 
-    # run `litgpt download --repo_id EleutherAI/pythia-1b` to download the checkpoint first
+    # run `litgpt download EleutherAI/pythia-1b` to download the checkpoint first
     checkpoint_dir = Path("checkpoints") / "EleutherAI" / "pythia-1b"
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
 

--- a/tutorials/examples/minimal-generate-scripts/generate.py
+++ b/tutorials/examples/minimal-generate-scripts/generate.py
@@ -8,7 +8,7 @@ from litgpt.utils import get_default_supported_precision
 
 def use_model():
 
-    # run `litgpt download --repo_id EleutherAI/pythia-1b` to download the checkpoint first
+    # run `litgpt download EleutherAI/pythia-1b` to download the checkpoint first
     checkpoint_dir = Path("checkpoints") / "EleutherAI" / "pythia-1b"
 
     torch.manual_seed(123)

--- a/tutorials/finetune.md
+++ b/tutorials/finetune.md
@@ -1,6 +1,6 @@
 # Finetuning
 
-We provide a simple finetuning commands (`litgpt finetune *`) that instruction-finetune a pretrained model on datasets such as [Alpaca](https://github.com/tatsu-lab/stanford_alpaca), [Dolly](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm), and others. For more information on the supported instruction datasets and how to prepare your own custom datasets, please see the [tutorials/prepare_dataset](prepare_dataset.md) tutorials.
+We provide a simple finetuning commands (`litgpt finetune_*`) that instruction-finetune a pretrained model on datasets such as [Alpaca](https://github.com/tatsu-lab/stanford_alpaca), [Dolly](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm), and others. For more information on the supported instruction datasets and how to prepare your own custom datasets, please see the [tutorials/prepare_dataset](prepare_dataset.md) tutorials.
 
 LitGPT currently supports the following finetuning methods:
 
@@ -37,7 +37,7 @@ This method trains all model weight parameters and is the most memory-intensive 
 ### LoRA and QLoRA finetuning
 
 ```bash
-litgpt finetune_lora checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b
 ```
 
 LoRA and QLoRA are parameter-efficient finetuning technique that only require updating a small number of parameters, which makes this a more memory-efficienty alternative to full finetuning.
@@ -53,13 +53,13 @@ LoRA and QLoRA are parameter-efficient finetuning technique that only require up
 ### Adapter finetuning
 
 ```bash
-litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b
 ```
 
 or
 
 ```bash
-litgpt finetune_adapter_v2 checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b
 ```
 
 Similar to LoRA, adapter finetuning is a parameter-efficient finetuning technique that only requires training a small subset of weight parameters, making this finetuning method more memory-efficient than full-parameter finetuning. 

--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -22,14 +22,14 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
 ```
 
 or for Adapter V2
 
 ```bash
-litgpt finetune adapter_v2 checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune adapter_v2 stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
 ```
 
@@ -47,7 +47,7 @@ For example, the following settings will let you finetune the model in under 1 h
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter/my-model-finetuned
 ```
@@ -55,7 +55,7 @@ litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
 or for Adapter V2
 
 ```bash
-litgpt finetune_adapter_v2 checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter_v2/my-model-finetuned
 ```
@@ -64,7 +64,7 @@ If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` 
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter/my-model-finetuned \
   --precision 32-true
@@ -77,14 +77,14 @@ Note that `mps` as the accelerator will be picked up automatically by Fabric whe
 Optionally, finetuning using quantization can be enabled via the `--quantize` flag, for example using the 4-bit NormalFloat data type:
 
 ```bash
-litgpt finetune_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --quantize "bnb.nf4"
 ```
 
 or using `adapter_v2` with double-quantization:
 
 ```bash
-litgpt finetune_adapter_v2 checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b \
   --quantize "bnb.nf4-dq"
 ```
 
@@ -95,14 +95,14 @@ For additional benchmarks and resource requirements, please see the [Resource Ta
 You can test the finetuned model with your own instructions by running:
 
 ```bash
-litgpt generate_adapter checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt generate_adapter stabilityai/stablelm-base-alpha-3b \
     --prompt "Recommend a movie to watch on the weekend."
 ```
 
 or for Adapter V2
 
 ```bash
-litgpt generate_adapter_v2 checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt generate_adapter_v2 stabilityai/stablelm-base-alpha-3b \
     --prompt "Recommend a movie to watch on the weekend."
 
 ```
@@ -137,7 +137,7 @@ You can easily train on your own instruction dataset saved in JSON format.
 2. Run `litgpt adapter` or `litgpt adapter_v2` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune_adapter checkpoints/tiiuae/falcon-7b \
+    litgpt finetune_adapter tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
         --out_dir data/mydata-finetuned

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -16,7 +16,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-litgpt finetune_full checkpoints/tiiuae/falcon-7b \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
 ```
 
@@ -28,7 +28,7 @@ Depending on the available GPU memory, you can also tune the `micro_batch_size` 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-litgpt finetune_full checkpoints/tiiuae/falcon-7b \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
   --out_dir out/full/my-model-finetuned
 ```
@@ -37,7 +37,7 @@ If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` 
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-litgpt finetune_full checkpoints/tiiuae/falcon-7b \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
   --out_dir out/full/my-model-finetuned \
   --precision 32-true
@@ -50,7 +50,7 @@ Note that `mps` as the accelerator will be picked up automatically by Fabric whe
 You can test the finetuned model with your own instructions by running:
 
 ```bash
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
     --prompt "Recommend a movie to watch on the weekend." \
     --finetuned_path out/full/my-model-finetuned/lit_model_finetuned.pth
 ```
@@ -85,7 +85,7 @@ You can easily train on your own instruction dataset saved in JSON format.
 2. Run `litgpt finetune` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune checkpoints/tiiuae/falcon-7b \
+    litgpt finetune tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
         --out_dir data/mydata-finetuned

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -22,7 +22,7 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the Finetuning
 
 ```bash
-litgpt finetune_lora checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
   --data Alpaca
 ```
 
@@ -38,14 +38,14 @@ This script will save checkpoints periodically to the folder `out/`.
 Optionally, finetuning using 4-bit quantization (as in QLoRA) can be enabled via the `--quantize` flag, for example using the 4-bit NormalFloat data type:
 
 ```bash
-litgpt finetune_lora checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
   --quantize "bnb.nf4"
 ```
 
 and optionally with double-quantization:
 
 ```bash
-litgpt finetune_lora checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
   --quantize "bnb.nf4-dq"
 ```
 
@@ -77,7 +77,6 @@ You can test the finetuned model with your own instructions by running:
 
 ```bash
 litgpt generate "out/lora/final" \
-  --checkpoint_dir \
   --prompt "Recommend a movie to watch on the weekend."
 ```
 
@@ -113,10 +112,9 @@ You can easily train on your own instruction dataset saved in JSON format.
 2. Run `litgpt finetune_lora` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune lora \
+    litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
-        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
         --out_dir data/mydata-finetuned
     ```
 

--- a/tutorials/inference.md
+++ b/tutorials/inference.md
@@ -1,9 +1,9 @@
 # Inference
 
-We demonstrate how to run inference (next token prediction) with the GPT base model in the [`generate.py`](../litgpt/generate/base.py) script:
+We demonstrate how to run inference (next token prediction) with the GPT base model in the [`litgpt generate`](../litgpt/generate/base.py) command:
 
 ```bash
-litgpt generate checkpoints/stabilityai/stablelm-base-alpha-3b \
+litgpt generate stabilityai/stablelm-base-alpha-3b \
   --prompt "Hello, my name is"
 ```
 
@@ -22,7 +22,7 @@ This will run the 3B pre-trained model and require ~7 GB of GPU memory using the
 You can also chat with the model interactively:
 
 ```bash
-litgpt chat checkpoints/stabilityai/stablelm-tuned-alpha-3b
+litgpt chat stabilityai/stablelm-tuned-alpha-3b
 ```
 
 This script can work with any checkpoint. For the best chat-like experience, we recommend using it with a checkpoints
@@ -48,7 +48,7 @@ For instance, `meta-llama/Llama-2-70b-chat-hf` would require ~140 GB of GPU memo
 With 80 transformer layers, we could partition them across 8, 5, 4, or 2 devices.
 
 ```shell
-litgpt generate_sequentially checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_sequentially meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2
 ```
@@ -67,7 +67,7 @@ Note that the memory usage will also depend on the `max_new_tokens` value used.
 The script also supports quantization, using 4-bit precision, we can now use 2 GPUs
 
 ```shell
-litgpt generate_sequentially checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_sequentially meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2 \
   --quantize bnb.nf4-dq
@@ -92,7 +92,7 @@ With an intermediate size of 28672, we can use 2, 4, 7, or 8 devices. With a QKV
 Since the script is configured to shard both, the intersection is used: we can only use 2, 4, or 8 devices.
 
 ```shell
-litgpt generate_tp checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_tp meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2
 ```
@@ -110,7 +110,7 @@ Note that the memory usage will also depend on the `max_new_tokens` value used.
 The script also supports quantization, using 4-bit precision, we can now use 2 GPUs
 
 ```shell
-litgpt generate_tp checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_tp meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2 \
   --quantize bnb.nf4-dq

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -26,7 +26,7 @@ The steps here only need to be done once before preparing the finetuning dataset
 1. Follow the instructions in the [README](../README.md) to install the dependencies.
 2. Download and convert the weights following our [guide](download_model_weights.md).
 
-For the following examples, we will focus on finetuning with the `litgpt/finetune/lora.py` script and use a Falcon 7B model.
+For the following examples, we will focus on finetuning with the `litgpt finetune_lora` command and use a Falcon 7B model.
 However, the same steps apply to all other models and finetuning scripts.
 Please read the [tutorials/finetune_*.md](.) documents for more information about finetuning models.
 
@@ -47,7 +47,7 @@ In its development, the creators leveraged the data generation methodology from 
 The original [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html) dataset can be used as follows:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca
 ```
 
@@ -67,7 +67,7 @@ By default, the finetuning scripts will determine the size of the longest tokeni
 In this case, a cut-off of 256 may be a reasonable choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
   --train.max_seq_length 256
 ```
@@ -81,7 +81,7 @@ For comparison, the Falcon 7B model requires 23.52 GB of memory for the original
 [Alpaca-2k](https://huggingface.co/datasets/mhenrichsen/alpaca_2k_test) is a smaller, 2000-sample subset of Alpaca described above.
 
 ```bash
-litgpt finetune_lora "checkpoints/tiiuae/falcon-7b" \
+litgpt finetune_lora "tiiuae/falcon-7b" \
   --data Alpaca2k
 ```
 
@@ -105,7 +105,7 @@ dataset consists of 52,000 instructions and responses.
 The original [Alpaca-GPT4](https://github.com/Instruction-Tuning-with-GPT-4/GPT-4-LLM) dataset can be used as follows:
 
 ```bash
-litgpt finetune lora "checkpoints/tiiuae/falcon-7b" \
+litgpt finetune lora "tiiuae/falcon-7b" \
   --data AlpacaGPT4
 ```
 
@@ -129,7 +129,7 @@ The Alpaca-GPT4 dataset distribution is shown below.
 To use Alpaca Libre instead of the original Alpaca dataset, use the following command:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
   --data.file_name "alpaca_libre_data_cleaned_archive.json"
@@ -149,7 +149,7 @@ The Alpaca Libre dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 256 may be a good choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
   --data.file_name "alpaca_libre_data_cleaned_archive.json" \
@@ -164,7 +164,7 @@ The Deita dataset (short for Data-Efficient Instruction Tuning for Alignment) is
 Using Falcon 7b as an example, we can use the dataset as follows:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Deita
 ```
 
@@ -192,7 +192,7 @@ The Deita dataset distribution including multit-turn conversations is depicted i
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Deita \
   --train.max_seq_length 512
 ```
@@ -206,7 +206,7 @@ The Dolly dataset is a publicly available collection of 15k instruction-followin
 The usage is similar to the Alpaca dataset described above. Using Falcon 7b as an example, we can use the dataset as follows:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Dolly
 ```
 
@@ -224,7 +224,7 @@ The Dolly dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Dolly \
   --train.max_seq_length 256
 ```
@@ -264,7 +264,7 @@ The LongForm dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 1500 may be a good choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data LongForm \
   --train.max_seq_length 1500
 ```
@@ -289,7 +289,7 @@ export HF_TOKEN="insert_your_huggingface_token_here"
 
 litgpt finetune lora \
   --data LIMA \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "tiiuae/falcon-7b"
 ```
 
 &nbsp;
@@ -310,7 +310,7 @@ The LIMA dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data LIMA \
   --train.max_seq_length 512
 ```
@@ -325,14 +325,14 @@ FLAN is a collection of several datset subsets by Google. In particular, the pro
 By default, all subsets (1,386,050 samples) and validations sets (367,190 subsets) are combined into a single dataset:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data FLAN
 ```
 
 However, you can also select individual subsets via comma-separated strings as follows:
 
 ```bash
-litgpt finetune lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune lora tiiuae/falcon-7b \
   --data FLAN \
   --data.subsets "aeslc_10templates,ag_news_subset_10templates,anli_r1_10templates"
 ```
@@ -392,7 +392,7 @@ You can prepare custom dataset using a JSON file where each row is a dictionary 
 Then simply run any of the finetuning scripts with this input:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data JSON \
   --data.json_path path/to/your/data.json \
   --data.val_split_fraction 0.1
@@ -411,7 +411,7 @@ You can also customize how the dataset is read by using these additional paramet
 To use the settings described above, you can add the respective command line arguments when calling the finetuning scripts as shown in the example below:
 
 ```bash
-litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data JSON \
   --data.json_path path/to/your/data.json \
   --data.val_split_fraction 0.1 \

--- a/tutorials/pretrain.md
+++ b/tutorials/pretrain.md
@@ -6,10 +6,10 @@ This document explains how to pretrain LLMs using LitGPT.
 &nbsp;
 ## Using the `litgpt pretrain` command
 
-You can pretrain models in LitGPT using the `litgpt pretrain` API starting with any of the available architectures listed by calling `litgpt pretrain` without any additional arguments:
+You can pretrain models in LitGPT using the `litgpt pretrain` API starting with any of the available architectures listed by calling `litgpt pretrain list` without any additional arguments:
 
 ```bash
-litgpt pretrain
+litgpt pretrain list
 ```
 
 Shown below is an abbreviated list:
@@ -73,7 +73,7 @@ litgpt download EleutherAI/pythia-14m \
   --tokenizer_only true
 
 litgpt pretrain pythia-14m \
-   --tokenizer_dir checkpoints/EleutherAI/pythia-14m \
+   --tokenizer_dir EleutherAI/pythia-14m \
    --data TextFiles \
    --data.train_data_path custom_pretraining_data \
    --train.lr_warmup_steps=200
@@ -109,7 +109,8 @@ Next, assume we have a custom dataset stored in text files similar to the *Pretr
 
 ```bash
 litgpt pretrain pythia-14m \
-   --initial_checkpoint_dir checkpoints/EleutherAI/pythia-14m \
+   --initial_checkpoint_dir EleutherAI/pythia-14m \
+   --tokenizer_dir EleutherAI/pythia-14m \
    --out_dir new_phi-2_checkpoint \
    --data TextFiles \
    --data.train_data_path custom_pretraining_data \

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -145,7 +145,7 @@ The checkpoints saved during pretraining contain all the information to resume i
 Simply rerun the script with the `--resume` argument added:
 
 ```bash
-litgpt pretrain \
+litgpt pretrain tiny-llama\
   --config config_hub/pretrain/tinyllama.yaml \
   --resume out/pretrain/tiny-llama/step-00060500
 ```

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -12,7 +12,7 @@ This document provides different strategies for quantizing the various models av
 It's useful to start with a baseline to have a reference point for memory savings via the various quantization methods.
 
 ```bash
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --precision 32-true \
   --max_new_tokens 256
 ...
@@ -26,7 +26,7 @@ In short, when `--precision bf16-true` or `--precision 16-true` is used, the mod
 However, this might not be enough for large models or when using GPUs with limited memory.
 
 ```bash
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --precision bf16-true \
   --max_new_tokens 256
 ...
@@ -52,7 +52,7 @@ Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" base
 ```bash
 pip install bitsandbytes
 
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --quantize bnb.nf4 \
   --precision bf16-true \
   --max_new_tokens 256
@@ -71,7 +71,7 @@ In average, this amounts to about 0.37 bits per parameter (approximately 3 GB fo
 ```bash
 pip install bitsandbytes
 
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --quantize bnb.nf4-dq \
   --precision bf16-true \
   --max_new_tokens 256
@@ -90,7 +90,7 @@ Uses pure FP4 quantization.
 ```bash
 pip install bitsandbytes
 
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --quantize bnb.fp4 \
   --precision bf16-true \
   --max_new_tokens 256
@@ -109,7 +109,7 @@ In average, this amounts to about 0.37 bits per parameter (approximately 3 GB fo
 ```bash
 pip install bitsandbytes
 
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --quantize bnb.fp4-dq \
   --precision bf16-true \
   --max_new_tokens 256
@@ -125,7 +125,7 @@ Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check 
 ```bash
 pip install bitsandbytes
 
-litgpt generate checkpoints/tiiuae/falcon-7b \
+litgpt generate tiiuae/falcon-7b \
   --quantize bnb.int8 \
   --precision 16-true \
   --max_new_tokens 256

--- a/tutorials/resource-tables.md
+++ b/tutorials/resource-tables.md
@@ -34,7 +34,7 @@ Note that the number of tokens in the training set does not affect the supported
 
 ## Finetuning with LoRA on 1 GPU
 
-The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt/finetune/lora.py` script.
+The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt finetune_lora` command.
 
 | Size  | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |-------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -70,7 +70,7 @@ The following experiments were conducted on 1xA100 with a minibatch size of 128 
 
 ## Finetuning with Adapter on 1 GPU
 
-The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt/finetune/adapter.py` script.
+The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt finetune_adapter` command.
 
 | Size | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -82,7 +82,7 @@ The following experiments were conducted on 1xA100 with a minibatch size of 128 
 | 7 B  | Llama 2        | bnb.nf4      | 1               | 1,229,760            | 12.68 GB    | 2.93 min           |
 | 7 B  | Llama 2        | bnb.nf4-dq   | 1               | 1,229,760            | 12.38 GB    | 3.00 min           |
 
-The same config, but using the `litgpt/finetune/adapter_v2.py` script.
+The same config, but using the `litgpt finetune_adapter_v2` command.
 
 | Size | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -98,7 +98,7 @@ The same config, but using the `litgpt/finetune/adapter_v2.py` script.
 
 ## Finetuning with LoRA on Multiple GPUs
 
-The following experiments were conducted on multiple A100 GPUs with a minibatch size of 128 using the `litgpt/finetune/lora.py` script.
+The following experiments were conducted on multiple A100 GPUs with a minibatch size of 128 using the `litgpt finetune_lora` command.
 
 | Size  | Model          | Quantization | Microbatch size | Trainable parameters | GPU      | Max GPU RAM | Time 1k iterations |
 |-------|----------------|--------------|-----------------|----------------------|----------|-------------|--------------------|


### PR DESCRIPTION
This modification checks whether the provided `checkpoint_dir` is a valid dir, and if not, it will prepend `checkpoints`. This will allow us to support both

```
# ligpt [action] [model]
litgpt  download  meta-llama/Meta-Llama-3-8B-Instruct
litgpt  chat      checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
litgpt  finetune  checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
litgpt  pretrain  checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
litgpt  serve     checkpoints/meta-llama/Meta-Llama-3-8B-Instruct
```

and the nicer 

```
# ligpt [action] [model]
litgpt  download  meta-llama/Meta-Llama-3-8B-Instruct
litgpt  chat      meta-llama/Meta-Llama-3-8B-Instruct
litgpt  finetune  meta-llama/Meta-Llama-3-8B-Instruct
litgpt  pretrain  meta-llama/Meta-Llama-3-8B-Instruct
litgpt  serve     meta-llama/Meta-Llama-3-8B-Instruct
```

TODO:

- [ ] Update all docs