### PR TITLE
Detect tensor cores

### DIFF
--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -53,8 +53,8 @@ def main() -> None:
     set_docstring_parse_options(attribute_docstrings=True)
     set_config_read_mode(urls_enabled=True)
 
-    CLI(parser_data)
     torch.set_float32_matmul_precision("high")
+    CLI(parser_data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I am preparing a demo, and the 

> You are using a CUDA device ('NVIDIA A10G') that has Tensor Cores. To properly utilize them, you should set `torch.set_float32_matmul_precision('medium' | 'high')` which will trade-off precision for performance. For more details, read https://pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html#torch.set_float32_matmul_precision

warning when using the `chat` and `generate` scripts is a bit ugly and annoying. So, I was removing it here by setting `torch.set_float32_matmul_precision("high")` if the device has tensor cores. 

Can you think of a downside/reason why we shouldn't do this @awaelchli ?