### PR TITLE
LitGPT Python API draft

### DIFF
--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -1,0 +1,108 @@
+# LitGPT High-level Python API
+
+This is a work-in-progress draft for a high-level LitGPT Pyhon API.
+
+&nbsp;
+## Model loading & saving
+
+The `LLM.load` command loads an `llm` object, which contains both the model object (a PyTorch module) and a preprocessor.
+
+```python
+from litgpt import LLM
+
+llm = LLM.load(
+    source="url | local_path",
+    # high-level user only needs to care about those:
+    memory_reduction="none | medium | strong"
+    # advanced options for technical users:
+    hub="hf | local | other"
+    quantize="bnb.nf4",
+    precision="bf16-true",
+    device="cuda | cpu",
+)
+```
+
+Here,
+
+-  `llm.model` contains the PyTorch Module
+- and `llm.preprocessor.tokenizer`  contains the tokenizer
+
+The `llm.save` command saves the model weights, tokenizer, and configuration information.
+
+
+```python
+llm.save(checkpoint_dir, format="lightning | ollama | hf")
+```
+
+
+&nbsp;
+## Inference / Chat
+
+```
+response = llm.generate(
+    prompt="What do Llamas eat?",
+    temperature=0.1,
+    top_p=0.8,
+    ...
+)
+```
+
+
+&nbsp;
+## Dataset
+
+The `llm.prepare_dataset` command prepares a dataset for training.
+
+```
+llm.download_dataset(
+    URL,
+    ...
+)
+```
+
+```
+dataset = llm.prepare_dataset(
+    path,
+    task="pretrain | instruction_finetune",
+    test_portion=0.1,
+    ...
+)
+```
+
+&nbsp;
+## Training
+
+
+```python
+llm.instruction_finetune(
+    config_file=None,
+    dataset=dataset,
+    max_iter=10,
+    method="full | lora | adapter | adapter_v2"
+)
+```
+
+```python
+llm.pretrain(config_file=None, dataset=dataset, max_iter=10, ...)
+```
+
+&nbsp;
+## Serving
+
+
+```python
+llm.serve(port=8000)
+```
+
+Then in another Python session:
+
+```python
+import requests, json
+
+response = requests.post(
+    "http://127.0.0.1:8000/predict", 
+    json={"prompt": "Fix typos in the following sentence: Exampel input"}
+)
+
+print(response.json()["output"])
+```


### PR DESCRIPTION
This is a first draft for the Python API. 

In LitServe, the usage could then look like as follows:



## LitServe example

```python
#######################
# LitServe example
#######################

# litgpt_server.py
import litserve as ls
from litgpt import LLM

class LitGPTAPI(ls.LitAPI):
    def setup(self, device):
        llm = LLM.load(path="meta-llama/llama3", hub="local", device="cuda", ...)


    def decode_request(self, request):
        # llm.generate() already encodes the prompt before passing it to the LLM. So no action needed.
        return request["prompt"]
    
    def predict(self, prompt):
        text = self.llm.generate(prompt, max_tokens=100, temperature=1.0, top_k=25)
        return text
    
    def encode_response(self, output):
        # llm.generate() already decodes the generated token IDs. So no action needed.
        return {"response": output["text"]}
    

if __name__ == "__main__":
    api = LitGPTAPI()
    server = ls.LitServer(api, accelerator="gpu", timeout=1000, workers_per_device=2)
    server.run(port=8000)
```

CC @lantiga @aniketmaurya 