### PR TITLE
Fix sequence length bug

### DIFF
--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -12,7 +12,7 @@ import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
@@ -212,9 +212,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
-    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
-    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -212,7 +212,9 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
+    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -12,7 +12,7 @@ import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_adapter_v2_as_trainable
@@ -212,9 +212,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
-    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
-    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))h)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -212,7 +212,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))h)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -212,7 +212,9 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
+    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -189,7 +189,9 @@ def fit(
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
+    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import lightning as L
 import torch
 from lightning.fabric.strategies import FSDPStrategy
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.args import EvalArgs, TrainArgs
@@ -189,9 +189,7 @@ def fit(
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
-    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
-    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -243,7 +243,9 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
+    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -12,7 +12,7 @@ import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.args import EvalArgs, TrainArgs
@@ -243,9 +243,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_train_seq_length, longest_train_seq_ix = get_longest_seq_length(train_dataloader.dataset)
-    longest_val_seq_length, longest_val_seq_ix = get_longest_seq_length(val_dataloader.dataset)
-    longest_seq_length = max(longest_train_seq_length, longest_val_seq_length)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"


### PR DESCRIPTION
Fixes an issue that arises if the validation set contains examples longer than the ones in the training set as encountered in #1461