### PR TITLE
LitGPT Python API v1

### DIFF
--- a/extensions/xla/generate/adapter.py
+++ b/extensions/xla/generate/adapter.py
@@ -34,7 +34,7 @@ def setup(
     precision: str = "bf16-true",
 ) -> None:
     """Generates a response based on a given instruction and an optional input.
-    This script will only work with checkpoints from the instruction-tuned GPT-Adapter model.
+    This script will only work with checkpoints from the instruction-tuned Adapter model.
     See `xla/finetune/adapter.py`.
 
     Args:
@@ -42,7 +42,7 @@ def setup(
         input: Optional input (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             `xla/finetune/adapter.py`.
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
+        checkpoint_dir: The path to the checkpoint folder with pretrained model weights.
         max_new_tokens: The number of generation steps to take.
         top_k: The number of top most probable tokens to consider in the sampling process.
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random

--- a/litgpt/__init__.py
+++ b/litgpt/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import re
 
+from litgpt.api import LLM
 from litgpt.model import GPT  # needs to be imported before config
 from litgpt.config import Config
 from litgpt.prompts import PromptStyle
@@ -16,4 +17,4 @@ logging.getLogger("torch._dynamo.variables.torch").addFilter(lambda record: not 
 logging.getLogger("torch.distributed.fsdp._optim_utils").disabled = True
 logging.getLogger("torch.distributed.fsdp._debug_utils").disabled = True
 
-__all__ = ["GPT", "Config", "PromptStyle", "Tokenizer"]
+__all__ = ["LLM", "GPT", "Config", "PromptStyle", "Tokenizer"]

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -1,0 +1,81 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+#
+# This file implements the LitGPT Python API
+import torch
+import lightning as L
+
+from litgpt.model import GPT  # needs to be imported before config
+from litgpt.config import Config
+from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
+from litgpt.tokenizer import Tokenizer
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
+
+
+class LLM:
+    def __init__(self, model, tokenizer, device, prompt_style):
+        self.model = model
+        self.preprocessor = Preprocessor(tokenizer)
+
+    @classmethod
+    def load(cls, checkpoint_dir, device, quantize=None, precision=None):
+        model, tokenizer, device, prompt_style = self._setup_model_and_tokenizer(checkpoint_dir, precision, device)
+        return cls(model, tokenizer, device, prompt_style)
+
+    """
+    def save(self, checkpoint_dir):
+        self.model.save(checkpoint_dir, format=format)
+        self.preprocessor.tokenizer.save(checkpoint_dir)
+
+    def generate(self, prompt, **kwargs):
+        input_ids = self.preprocessor.tokenizer.encode(prompt)
+
+        output_ids = self.model.generate(input_ids, **kwargs)
+
+        return self.preprocessor.tokenizer.decode(output_ids)
+    """
+
+    def _setup_model_and_tokenizer(self, checkpoint_dir, precision, device):
+        config = Config.from_file(checkpoint_dir / "model_config.yaml")
+        device = torch.device(device)
+        torch.set_float32_matmul_precision("high")
+
+        self.precision = precision or get_default_supported_precision(training=False)
+
+        fabric = L.Fabric(
+            accelerator=device.type,
+            devices=1 if device.type == "cpu" else [device.index],
+            precision=precision,
+        )
+        checkpoint_path = checkpoint_dir / "lit_model.pth"
+        tokenizer = Tokenizer(checkpoint_dir)
+
+        prompt_style = (
+            load_prompt_style(checkpoint_dir)
+            if has_prompt_style(checkpoint_dir)
+            else PromptStyle.from_config(config)
+        )
+        with fabric.init_module(empty_init=True):
+            model = GPT(config)
+        with fabric.init_tensor():
+            # enable the kv cache
+            model.set_kv_cache(batch_size=1)
+        model.eval()
+
+        model = fabric.setup_module(model)
+        load_checkpoint(fabric, model, checkpoint_path)
+        return model, tokenizer, fabric.device, prompt_style
+
+
+class Preprocessor:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+    def encode(self, text):
+        return self.tokenizer.encode(text)
+
+    def decode(self, token_ids):
+        return self.tokenizer.decode(token_ids)

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -31,7 +31,7 @@ class LLM:
         fabric: L.Fabric = None
     ) -> None:
         self.model = model
-        self.preprocessor = Preprocessor(tokenizer)
+        self.preprocessor = Preprocessor(tokenizer, device=fabric.device)
         self.devices = devices
         self.prompt_style = prompt_style
         self.checkpoint_dir = checkpoint_dir
@@ -77,7 +77,7 @@ class LLM:
         if device_type == "auto":
             device_type = "cuda" if torch.cuda.is_available() else "cpu"
 
-        num_devices = calcuate_number_of_devices(devices)
+        num_devices = calculate_number_of_devices(devices)
 
         if num_devices > 1:
             raise NotImplementedError(
@@ -172,7 +172,7 @@ class LLM:
 
         self.model.eval()
 
-        if calcuate_number_of_devices(self.devices) > 1:
+        if calculate_number_of_devices(self.devices) > 1:
             raise NotImplementedError(
                 "Support for multiple devices is currently not implemented for `generate`"
             )
@@ -200,8 +200,9 @@ class Preprocessor:
     """
     Preprocesser class for tokenization and de-tokenization.
     """
-    def __init__(self, tokenizer: Tokenizer) -> None:
-        self.tokenizer: Tokenizer = tokenizer
+    def __init__(self, tokenizer: Tokenizer, device: str = "cpu") -> None:
+        self.tokenizer = tokenizer
+        self.device = device
 
     def encode(self, text: str) -> torch.Tensor:
         return self.tokenizer.encode(text, device=self.device)
@@ -210,7 +211,7 @@ class Preprocessor:
         return self.tokenizer.decode(token_ids)
 
 
-def calcuate_number_of_devices(devices):
+def calculate_number_of_devices(devices):
     """
     Utility function to calculate the number of devices.
     """

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -2,21 +2,22 @@
 #
 # This file implements the LitGPT Python API
 from pathlib import Path
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 import lightning as L
+from lightning.fabric.utilities.device_parser import _normalize_parse_gpu_input_to_list
 
 from litgpt.model import GPT  # needs to be imported before config
 from litgpt.config import Config
-from litgpt.generate.base import generate as generate_fn
-from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
 from litgpt.tokenizer import Tokenizer
+from litgpt.generate.base import generate as plain_generate
+from litgpt.chat.base import generate as stream_generate
+from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
 from litgpt.utils import (
     extend_checkpoint_dir,
     get_default_supported_precision,
     load_checkpoint,
-    parse_devices
 )
 
 
@@ -27,8 +28,10 @@ class LLM:
         tokenizer: Tokenizer,
         prompt_style: PromptStyle,
         device_type: str,
-        devices: Union[int, str] = 1,
-        checkpoint_dir: Path = None
+        devices: Union[int, List[int]] = 1,
+        precision: Optional[any] = None,
+        checkpoint_dir: Path = None,
+        fabric: L.Fabric = None
     ) -> None:
         self.model = model
         self.preprocessor = Preprocessor(tokenizer)
@@ -36,80 +39,33 @@ class LLM:
         self.devices = devices
         self.prompt_style = prompt_style
         self.checkpoint_dir = checkpoint_dir
+        self.fabric = fabric
+        self.precision = precision
 
     @classmethod
     def load(
-        cls, checkpoint_dir: Path, device_type: str = "cuda", devices: int = 1,
-        quantize: Optional[Any] = None, precision: Optional[Any] = None
-    ) -> "LLM":
-
-        if devices > 1:
-            raise NotImplementedError(
-                "Support for multiple devices is currently not implemented."
-            )
-
-        checkpoint_dir = extend_checkpoint_dir(Path(checkpoint_dir))
-        model, tokenizer, device, devices, prompt_style = cls._setup_model_and_tokenizer(
-            checkpoint_dir=checkpoint_dir,
-            precision=precision,
-            device_type=device_type,
-            devices=devices
-        )
-        return cls(
-            model=model, tokenizer=tokenizer, device_type=device_type, devices=devices,
-            prompt_style=prompt_style, checkpoint_dir=checkpoint_dir,
-        )
-
-    def generate(
-        self,
-        prompt: str,
-        max_new_tokens: int = 50,
-        temperature: float = 1.0,
-        top_k: Optional[int] = None,
-        top_p: float = 1.0,
-        eos_id: Optional[int] = None,
-        return_as_token_ids: bool = False
-    ) -> Tuple[str, torch.Tensor]:
-        prompt = self.prompt_style.apply(prompt)
-        input_ids = self.preprocessor.tokenizer.encode(prompt)
-        prompt_length = input_ids.size(0)
-        max_returned_tokens = prompt_length + max_new_tokens
-
-        output_ids = generate_fn(
-            model=self.model,
-            prompt=input_ids.to(self.model.device),
-            max_returned_tokens=max_returned_tokens,
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            eos_id=self.preprocessor.tokenizer.eos_id
-        )
-
-        if self.devices > 1:
-            raise NotImplementedError(
-                "Support for multiple devices is currently not implemented for `generate`."
-            )
-        for block in self.model.transformer.h:
-            block.attn.kv_cache.reset_parameters()
-
-        if return_as_token_ids:
-            return output_ids
-        else:
-            return self.preprocessor.tokenizer.decode(output_ids)
-
-    @classmethod
-    def _setup_model_and_tokenizer(
         cls,
         checkpoint_dir: Path,
-        precision: Optional[Any],
-        device_type: str,
-        devices: Union[int, str]
-    ) -> Tuple[GPT, Tokenizer, torch.device, PromptStyle]:
+        device_type: str = "cuda",
+        devices: Union[int, List[int]] = 1,
+        quantize: Optional[Any] = None,
+        precision: Optional[Any] = None,
+    ) -> "LLM":
 
+        num_devices = devices if isinstance(devices, int) else len(devices) if isinstance(devices, list) else 0
+
+        if num_devices > 1:
+            raise NotImplementedError(
+                "Support for multiple devices is currently not implemented for `load`"
+            )
+
+        # TODO: download model if not downloaded already
+
+        checkpoint_dir = extend_checkpoint_dir(Path(checkpoint_dir))
         config = Config.from_file(checkpoint_dir / "model_config.yaml")
         torch.set_float32_matmul_precision("high")
 
-        devices = parse_devices(devices)
+        devices = _normalize_parse_gpu_input_to_list(devices, include_cuda=True, include_mps=True)
         precision = precision or get_default_supported_precision(training=False)
 
         fabric = L.Fabric(
@@ -126,7 +82,7 @@ class LLM:
             else PromptStyle.from_config(config)
         )
 
-        with fabric.init_module(empty_init=(devices > 1)):
+        with fabric.init_module(empty_init=(num_devices > 1)):
             model = GPT(config)
         with fabric.init_tensor():
             # enable the kv cache
@@ -134,7 +90,93 @@ class LLM:
         model.eval()
         model = fabric.setup_module(model)
         load_checkpoint(fabric, model, checkpoint_path)
-        return model, tokenizer, fabric.device, devices, prompt_style
+        return cls(
+            model=model, tokenizer=tokenizer, device_type=device_type, devices=devices,
+            prompt_style=prompt_style, checkpoint_dir=checkpoint_dir, fabric=fabric,
+            precision=precision
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+        top_p: float = 1.0,
+        eos_id: Optional[int] = None,
+        return_as_token_ids: bool = False,
+        device_type: Optional[str] = None,
+        devices: Union[int, List[int]] = 1,
+        precision: Optional[Any] = None
+    ) -> Tuple[str, torch.Tensor]:
+        prompt = self.prompt_style.apply(prompt)
+        input_ids = self.preprocessor.tokenizer.encode(prompt)
+        prompt_length = input_ids.size(0)
+        max_returned_tokens = prompt_length + max_new_tokens
+
+        self.move_to_device(device_type=device_type, devices=devices, precision=precision)
+        self.model.eval()
+
+        if (isinstance(self.devices, int) and self.devices > 1) or (isinstance(self.devices, list) and len(self.devices) > 1):
+            raise NotImplementedError(
+                "Support for multiple devices is currently not implemented for `load`"
+            )
+
+        # TODO: Add streaming later
+        #if stream:
+        #    generate_fn = stream_generate
+        #else:
+        #    generate_fn = plain_generate
+        generate_fn = plain_generate
+
+        output_ids = generate_fn(
+            model=self.model,
+            prompt=input_ids.to(self.fabric.device),
+            max_returned_tokens=max_returned_tokens,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            eos_id=self.preprocessor.tokenizer.eos_id
+        )
+
+        for block in self.model.transformer.h:
+            block.attn.kv_cache.reset_parameters()
+
+        if return_as_token_ids:
+            return output_ids
+        else:
+            return self.preprocessor.tokenizer.decode(output_ids)
+
+    def move_to_device(self, device_type=None, devices=None, precision=None):
+        if device_type is not None:
+            self.device_type = device_type
+        if devices is not None:
+            self.devices = _normalize_parse_gpu_input_to_list(devices, include_cuda=True, include_mps=True)
+        if precision is not None:
+            self.precision = precision or get_default_supported_precision(training=False)
+
+        if self.devices is not None or self.device_type is not None:
+            self.fabric = L.Fabric(
+                accelerator=self.device_type,
+                devices=self.devices,
+                precision=self.precision,
+            )
+
+            self.model = self.model.to(self.fabric.device)
+            
+            # Code below may not be necessary;
+            # but moving the model still leaves some GPU memory on the original
+            # device unfreed for some reason
+            #
+            #for name, buffer in self.model.named_buffers():
+            #    setattr(self.model, name, buffer.to(self.fabric.device))
+
+            #for block in self.model.transformer.h:
+            #    if hasattr(block.attn, "kv_cache"):
+            #        block.attn.kv_cache = block.attn.kv_cache.to(self.fabric.device)
+
+            self.model.mask_cache = self.model.mask_cache.to(self.fabric.device)
+            torch.cuda.empty_cache()
 
 
 class Preprocessor:

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -142,6 +142,7 @@ class LLM:
         top_k: Optional[int] = None,
         top_p: float = 1.0,
         eos_id: Optional[int] = None,
+        include_prompt: bool = True,
         return_as_token_ids: bool = False,
     ) -> Tuple[str, torch.Tensor]:
         """
@@ -168,6 +169,9 @@ class LLM:
                 For more details, see https://arxiv.org/abs/1904.09751
                 or https://huyenchip.com/2024/01/16/sampling.html#top_p
             eos_id: If specified, stop generating any more token once the <eos> token is triggered.
+            include_prompt: If true (default) prepends the prompt (after applying the prompt style) to the output.
+            return_as_token_ids: If true. returns the generated tokens as IDs rather then detokenized text.
+
         """
         prompt = self.prompt_style.apply(prompt)
         input_ids = self.preprocessor.tokenizer.encode(prompt)
@@ -188,7 +192,8 @@ class LLM:
             temperature=temperature,
             top_k=top_k,
             top_p=top_p,
-            eos_id=self.preprocessor.tokenizer.eos_id
+            eos_id=self.preprocessor.tokenizer.eos_id,
+            include_prompt=include_prompt,
         )
 
         for block in self.model.transformer.h:

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -1,53 +1,120 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 #
 # This file implements the LitGPT Python API
+from pathlib import Path
+from typing import Any, Optional, Tuple, Type, Union
+
 import torch
 import lightning as L
 
 from litgpt.model import GPT  # needs to be imported before config
 from litgpt.config import Config
+from litgpt.generate.base import generate as generate_fn
 from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
 from litgpt.tokenizer import Tokenizer
 from litgpt.utils import (
     extend_checkpoint_dir,
     get_default_supported_precision,
-    load_checkpoint
+    load_checkpoint,
+    parse_devices
 )
 
 
 class LLM:
-    def __init__(self, model, tokenizer, device, prompt_style):
+    def __init__(
+        self,
+        model: GPT,
+        tokenizer: Tokenizer,
+        prompt_style: PromptStyle,
+        device_type: str,
+        devices: Union[int, str] = 1,
+        checkpoint_dir: Path = None
+    ) -> None:
         self.model = model
         self.preprocessor = Preprocessor(tokenizer)
+        self.device_type = device_type
+        self.devices = devices
+        self.prompt_style = prompt_style
+        self.checkpoint_dir = checkpoint_dir
 
     @classmethod
-    def load(cls, checkpoint_dir, device, quantize=None, precision=None):
-        model, tokenizer, device, prompt_style = self._setup_model_and_tokenizer(checkpoint_dir, precision, device)
-        return cls(model, tokenizer, device, prompt_style)
+    def load(
+        cls, checkpoint_dir: Path, device_type: str = "cuda", devices: int = 1,
+        quantize: Optional[Any] = None, precision: Optional[Any] = None
+    ) -> "LLM":
 
-    """
-    def save(self, checkpoint_dir):
-        self.model.save(checkpoint_dir, format=format)
-        self.preprocessor.tokenizer.save(checkpoint_dir)
+        if devices > 1:
+            raise NotImplementedError(
+                "Support for multiple devices is currently not implemented."
+            )
 
-    def generate(self, prompt, **kwargs):
+        checkpoint_dir = extend_checkpoint_dir(Path(checkpoint_dir))
+        model, tokenizer, device, devices, prompt_style = cls._setup_model_and_tokenizer(
+            checkpoint_dir=checkpoint_dir,
+            precision=precision,
+            device_type=device_type,
+            devices=devices
+        )
+        return cls(
+            model=model, tokenizer=tokenizer, device_type=device_type, devices=devices,
+            prompt_style=prompt_style, checkpoint_dir=checkpoint_dir,
+        )
+
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: int = 50,
+        temperature: float = 1.0,
+        top_k: Optional[int] = None,
+        top_p: float = 1.0,
+        eos_id: Optional[int] = None,
+        return_as_token_ids: bool = False
+    ) -> Tuple[str, torch.Tensor]:
+        prompt = self.prompt_style.apply(prompt)
         input_ids = self.preprocessor.tokenizer.encode(prompt)
+        prompt_length = input_ids.size(0)
+        max_returned_tokens = prompt_length + max_new_tokens
 
-        output_ids = self.model.generate(input_ids, **kwargs)
+        output_ids = generate_fn(
+            model=self.model,
+            prompt=input_ids.to(self.model.device),
+            max_returned_tokens=max_returned_tokens,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            eos_id=self.preprocessor.tokenizer.eos_id
+        )
 
-        return self.preprocessor.tokenizer.decode(output_ids)
-    """
+        if self.devices > 1:
+            raise NotImplementedError(
+                "Support for multiple devices is currently not implemented for `generate`."
+            )
+        for block in self.model.transformer.h:
+            block.attn.kv_cache.reset_parameters()
 
-    def _setup_model_and_tokenizer(self, checkpoint_dir, precision, device):
+        if return_as_token_ids:
+            return output_ids
+        else:
+            return self.preprocessor.tokenizer.decode(output_ids)
+
+    @classmethod
+    def _setup_model_and_tokenizer(
+        cls,
+        checkpoint_dir: Path,
+        precision: Optional[Any],
+        device_type: str,
+        devices: Union[int, str]
+    ) -> Tuple[GPT, Tokenizer, torch.device, PromptStyle]:
+
         config = Config.from_file(checkpoint_dir / "model_config.yaml")
-        device = torch.device(device)
         torch.set_float32_matmul_precision("high")
 
-        self.precision = precision or get_default_supported_precision(training=False)
+        devices = parse_devices(devices)
+        precision = precision or get_default_supported_precision(training=False)
 
         fabric = L.Fabric(
-            accelerator=device.type,
-            devices=1 if device.type == "cpu" else [device.index],
+            accelerator=device_type,
+            devices=devices,
             precision=precision,
         )
         checkpoint_path = checkpoint_dir / "lit_model.pth"
@@ -58,24 +125,24 @@ class LLM:
             if has_prompt_style(checkpoint_dir)
             else PromptStyle.from_config(config)
         )
-        with fabric.init_module(empty_init=True):
+
+        with fabric.init_module(empty_init=(devices > 1)):
             model = GPT(config)
         with fabric.init_tensor():
             # enable the kv cache
             model.set_kv_cache(batch_size=1)
         model.eval()
-
         model = fabric.setup_module(model)
         load_checkpoint(fabric, model, checkpoint_path)
-        return model, tokenizer, fabric.device, prompt_style
+        return model, tokenizer, fabric.device, devices, prompt_style
 
 
 class Preprocessor:
-    def __init__(self, tokenizer):
-        self.tokenizer = tokenizer
+    def __init__(self, tokenizer: Tokenizer) -> None:
+        self.tokenizer: Tokenizer = tokenizer
 
-    def encode(self, text):
-        return self.tokenizer.encode(text)
+    def encode(self, text: str) -> torch.Tensor:
+        return self.tokenizer.encode(text, device=self.device)
 
-    def decode(self, token_ids):
+    def decode(self, token_ids: torch.Tensor) -> str:
         return self.tokenizer.decode(token_ids)

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -10,7 +10,10 @@ import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 
-from litgpt import GPT, Config, PromptStyle, Tokenizer
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.prompts import PromptStyle
+from litgpt.tokenizer import Tokenizer
 from litgpt.generate.base import next_token
 from litgpt.prompts import has_prompt_style, load_prompt_style
 from litgpt.scripts.merge_lora import merge_lora

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -9,7 +9,7 @@ from lightning_utilities.core.imports import RequirementCache
 import torch
 
 
-from litgpt.model import GPT
+from litgpt.model import GPT  # needs to be imported before config
 from litgpt.config import Config
 from litgpt.tokenizer import Tokenizer
 from litgpt.generate.base import generate as plain_generate

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -42,7 +42,7 @@ def main(
     checkpoints from the instruction-tuned adapter model. See ``litgpt.finetune.adapter``.
 
     Args:
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
+        checkpoint_dir: The path to the checkpoint folder with pretrained model weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -42,7 +42,7 @@ def main(
     checkpoints from the instruction-tuned adapter v2 model. See ``litgpt.finetune.adapter_v2``.
 
     Args:
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
+        checkpoint_dir: The path to the checkpoint folder with pretrained model weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -12,8 +12,10 @@ import torch._dynamo.config
 import torch._inductor.config
 from lightning.fabric.plugins import BitsandbytesPrecision
 
-from litgpt import GPT, Config, PromptStyle, Tokenizer
-from litgpt.prompts import has_prompt_style, load_prompt_style
+from litgpt.model import GPT
+from litgpt.config import Config
+from litgpt.tokenizer import Tokenizer
+from litgpt.prompts import has_prompt_style, load_prompt_style, PromptStyle
 from litgpt.utils import (
     check_valid_checkpoint_dir,
     extend_checkpoint_dir,

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -38,10 +38,10 @@ def main(
     """For models finetuned with `litgpt finetune_full`.
 
     Generates a response based on a given instruction and an optional input. This script will only work with
-    checkpoints from the instruction-tuned GPT model. See ``litgpt.finetune.full``.
+    checkpoints from the instruction-tuned model. See ``litgpt.finetune.full``.
 
     Args:
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
+        checkpoint_dir: The path to the checkpoint folder with pretrained model weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         finetuned_path: Path to the checkpoint with trained weights, which are the output of

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,108 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
+import pytest
+from unittest.mock import Mock, patch
+import torch
+
+import lightning as L
+from litgpt.model import GPT
+from litgpt.tokenizer import Tokenizer
+from litgpt.prompts import PromptStyle
+from litgpt.api import LLM, Preprocessor, calculate_number_of_devices
+
+
+@pytest.fixture
+def gpt_model():
+    return Mock(spec=GPT)
+
+
+@pytest.fixture
+def tokenizer():
+    mock = Mock(spec=Tokenizer)
+    mock.encode.return_value = torch.tensor([1, 2, 3], dtype=torch.int32)
+    mock.decode.return_value = "decoded text"
+    return mock
+
+
+@pytest.fixture
+def prompt_style():
+    return Mock(spec=PromptStyle)
+
+
+@pytest.fixture
+def fabric():
+    fabric_mock = Mock(spec=L.Fabric)
+    fabric_mock.device = "cpu"
+    return fabric_mock
+
+
+@pytest.fixture
+def llm_instance(gpt_model, tokenizer, prompt_style, fabric):
+    return LLM(gpt_model, tokenizer, prompt_style, devices=1, fabric=fabric)
+
+
+def test_calculate_number_of_devices():
+    assert calculate_number_of_devices(5) == 5
+    assert calculate_number_of_devices([0, 1, 2]) == 3
+    assert calculate_number_of_devices([0]) == 1
+
+
+class TestPreprocessor:
+    def test_encode(self, tokenizer):
+        preprocessor = Preprocessor(tokenizer)
+        text = "Hello, world!"
+        result = preprocessor.encode(text)
+        tokenizer.encode.assert_called_once_with(text, device=preprocessor.device)
+        assert torch.equal(result, torch.tensor([1, 2, 3], dtype=torch.int32))
+
+    def test_decode(self, tokenizer):
+        preprocessor = Preprocessor(tokenizer)
+        tokens = torch.tensor([1, 2, 3], dtype=torch.int32)
+        result = preprocessor.decode(tokens)
+        tokenizer.decode.assert_called_once_with(tokens)
+        assert result == "decoded text"
+
+
+def mock_path_exists(path):
+    if str(path) in ["some/path", "checkpoints/some/path"]:
+        return True
+    return False
+
+
+def mock_path_is_file(path):
+    if str(path) in ["some/path/tokenizer.model", "some/path/tokenizer.json", "checkpoints/some/path/tokenizer_config.json"]:
+        return True
+    return False
+
+
+@patch("litgpt.config.Config.from_file")
+@patch("lightning.Fabric", autospec=True)
+@patch("litgpt.model.GPT", autospec=True)
+@patch("litgpt.tokenizer.Tokenizer", autospec=True)
+@patch("litgpt.utils.load_checkpoint")
+@patch("torch.cuda.is_available", return_value=True)
+@patch("pathlib.Path.exists", side_effect=mock_path_exists)
+@patch("pathlib.Path.is_file", side_effect=mock_path_is_file)
+def test_llm_load(is_file_mock, exists_mock, is_available_mock, load_checkpoint_mock, gpt_mock, tokenizer_mock, fabric_mock, config_mock, fabric, tokenizer, gpt_model):
+    model_path = "some/path"
+    device_type = "auto"
+    devices = 1
+    quantize = None
+    precision = None
+
+    config_mock.return_value = Mock()
+    fabric_mock.return_value = fabric
+    tokenizer_mock.return_value = tokenizer
+    gpt_mock.return_value = gpt_model
+
+    llm = LLM.load(model_path, device_type, devices, quantize, precision)
+
+    assert isinstance(llm, LLM)
+    assert llm.devices == 1
+    assert llm.fabric.device == "cpu"
+
+    with pytest.raises(ValueError):
+        LLM.load(model_path, "invalid_device", devices)
+
+    with pytest.raises(NotImplementedError):
+        LLM.load(model_path, device_type, [0, 1])

--- a/tutorials/developer-docs/python-api.md
+++ b/tutorials/developer-docs/python-api.md
@@ -11,11 +11,11 @@ The `LLM.load` command loads an `llm` object, which contains both the model obje
 from litgpt import LLM
 
 llm = LLM.load(
-    source="url | local_path",
+    model="url | local_path",
     # high-level user only needs to care about those:
     memory_reduction="none | medium | strong"
     # advanced options for technical users:
-    hub="hf | local | other"
+    source="hf | local | other"
     quantize="bnb.nf4",
     precision="bf16-true",
     device=""auto | cuda | cpu",

--- a/tutorials/developer-docs/python-api.md
+++ b/tutorials/developer-docs/python-api.md
@@ -1,6 +1,6 @@
 # LitGPT High-level Python API
 
-This is a work-in-progress draft for a high-level LitGPT Pyhon API.
+This is a work-in-progress draft for a high-level LitGPT Python API.
 
 &nbsp;
 ## Model loading & saving

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -15,7 +15,7 @@ Then, load the model in Python:
 
 ```python
 from litgpt.api import LLM
-llm = LLM.load("EleutherAI/pythia-160m", device_type="cuda", devices=1)
+llm = LLM.load("EleutherAI/pythia-160m", accelerator="cuda", devices=1)
 ```
 
 ## Generate/Chat

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -1,0 +1,34 @@
+# LitGPT Python API
+
+This is a work-in-progress draft describing the current LitGPT Python API (experimental and subject to change).
+
+
+## Model loading
+
+Download a model using the CLI:
+
+```bash
+litgpt download EleutherAI/pythia160-m
+```
+
+Then, load the model in Python:
+
+```python
+from litgpt.api import LLM
+llm = LLM.load("EleutherAI/pythia-160m", device_type="cuda", devices=1)
+```
+
+## Generate/Chat
+
+Generate output using the `.generate` method:
+
+```python
+text = llm.generate("What do Llamas eat?", top_k=1)
+print(text)
+```
+
+```
+What do Llamas eat?
+
+"A lot of people, the Llamas, I was, a Llamas, a lama, a lama, a lama, a lama, a lama, a lama, a lama, a
+```


### PR DESCRIPTION
This is a PR to implement a subset of the LitGPT Python API as discussed in #1459 (CC @aniketmaurya). This subset will focus only on the inference aspects (not the training and finetuning, yet).

### TODOs

- [x] add class structure
- [x] add model loading
- [x] add `generate` method
- [x] add type hints
- [x] change `checkpoint_dir` to `model`
- [x] add docstrings
- [x] add tests
- [x] add docs


To get the v1 out for inference soon, and to lower the reviewer burden for a single PR, these features will be added in separate PRs:

- Add streaming option
- Add functionality to download the model automatically
- Add multi-GPU loading
- Add finetuning functions
- Add pretraining function
- Extend to multi-device inference

