### PR TITLE
Fix issue where path in merge_lora is overwritten

### DIFF
--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -36,6 +36,8 @@ def merge_lora(
             automatically be inferred from the metadata in the given ``checkpoint_dir`` directory.
     """
     checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    if pretrained_checkpoint_dir is not None:
+        pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
     pprint(locals())
 
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth.lora")
@@ -45,8 +47,12 @@ def merge_lora(
         print("LoRA weights have already been merged in this checkpoint.")
         return
 
-    lora_params, pretrained_checkpoint_dir, lora_precision = load_lora_metadata(checkpoint_dir)
+    lora_params, meta_pretrained_checkpoint_dir, lora_precision = load_lora_metadata(checkpoint_dir)
     precision = precision if precision is not None else lora_precision
+
+    if pretrained_checkpoint_dir is not None:
+        pretrained_checkpoint_dir = meta_pretrained_checkpoint_dir
+        pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
 
     fabric = L.Fabric(devices=1, precision=precision, accelerator="cpu")
     config = Config.from_file(checkpoint_dir / "model_config.yaml", **lora_params)

--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -50,7 +50,7 @@ def merge_lora(
     lora_params, meta_pretrained_checkpoint_dir, lora_precision = load_lora_metadata(checkpoint_dir)
     precision = precision if precision is not None else lora_precision
 
-    if pretrained_checkpoint_dir is not None:
+    if pretrained_checkpoint_dir is None:
         pretrained_checkpoint_dir = meta_pretrained_checkpoint_dir
         pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
 


### PR DESCRIPTION
This fixes an issue where we always overwrite the provided initial checkpoint dir path with the one provided as metadata. 

CC @awaelchli 

This fixes a bug where the wrong path was used when merging the LoRA weights:

```
litgpt finetune microsoft/phi-2 \
  --data JSON \
  --data.json_path my_custom_dataset.json \
  --data.val_split_fraction 0.0001 \
  --out_dir out/phi-2-finetuned --train.max_steps 20

{'checkpoint_dir': PosixPath('checkpoints/microsoft/phi-2'),
 'data': JSON(json_path=PosixPath('my_custom_dataset.json'),
              mask_prompt=False,
              val_split_fraction=0.0001,
              prompt_style=<litgpt.prompts.Alpaca object at 0x7fd59d600e80>,
              ignore_index=-100,
              seed=42,
              num_workers=4),
 'devices': 1,
 'eval': EvalArgs(interval=100,
                  max_new_tokens=100,
                  max_iters=100,
                  initial_validation=False),
 'logger_name': 'csv',
 'lora_alpha': 16,
 'lora_dropout': 0.05,
 'lora_head': False,
 'lora_key': False,
 'lora_mlp': False,
 'lora_projection': False,
 'lora_query': True,
 'lora_r': 8,
 'lora_value': True,
 'optimizer': 'AdamW',
 'out_dir': PosixPath('out/phi-2-finetuned'),
 'precision': None,
 'quantize': None,
 'seed': 1337,
 'train': TrainArgs(save_interval=1000,
                    log_interval=1,
                    global_batch_size=16,
                    micro_batch_size=1,
                    lr_warmup_steps=100,
                    lr_warmup_fraction=None,
                    epochs=5,
                    max_tokens=None,
                    max_steps=10,
                    max_seq_length=None,
                    tie_embeddings=None,
                    max_norm=None,
                    min_lr=6e-05)}
Using bfloat16 Automatic Mixed Precision (AMP)
/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/data/dataset.py:449: UserWarning: Length of split at index 1 is 0. This might result in an empty dataset.
  warnings.warn(f"Length of split at index {i} is 0. "
Seed set to 1337
Number of trainable parameters: 2,621,440
Number of non-trainable parameters: 2,779,683,840
The longest sequence length in the train data is 1163, the model's maximum sequence length is 1163 and context length is 2048
Validating ...
Epoch 1 | iter 1 step 0 | loss train: 0.611, val: n/a | iter time: 853.10 ms
Epoch 1 | iter 2 step 0 | loss train: 0.597, val: n/a | iter time: 277.11 ms
Epoch 1 | iter 3 step 0 | loss train: 0.669, val: n/a | iter time: 282.15 ms
Epoch 1 | iter 4 step 0 | loss train: 0.692, val: n/a | iter time: 280.74 ms
...
Epoch 1 | iter 157 step 9 | loss train: 0.792, val: n/a | iter time: 341.78 ms
Epoch 1 | iter 158 step 9 | loss train: 0.787, val: n/a | iter time: 338.87 ms
Epoch 1 | iter 159 step 9 | loss train: 0.782, val: n/a | iter time: 346.30 ms
Epoch 1 | iter 160 step 10 | loss train: 0.771, val: n/a | iter time: 348.66 ms (step)
Training time: 59.51s
Memory used: 21.68 GB
Validating ...
Final evaluation | val loss: nan | val ppl: nan
Saving LoRA weights to '/teamspace/studios/this_studio/out/phi-2-finetuned/final/lit_model.pth.lora'
{'checkpoint_dir': PosixPath('/teamspace/studios/this_studio/out/phi-2-finetuned/final'),
 'precision': None,
 'pretrained_checkpoint_dir': None}
Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/bin/litgpt", line 8, in <module>
    sys.exit(main())
  File "/teamspace/studios/this_studio/litgpt/litgpt/__main__.py", line 57, in main
    CLI(parser_data)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/jsonargparse/_cli.py", line 119, in CLI
    return _run_component(component, init.get(subcommand))
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/jsonargparse/_cli.py", line 193, in _run_component
    return component(**cfg)
  File "/teamspace/studios/this_studio/litgpt/litgpt/finetune/lora.py", line 146, in setup
    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 866, in launch
    return self._wrap_and_launch(function, self, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 952, in _wrap_and_launch
    return to_run(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/lightning/fabric/fabric.py", line 957, in _wrap_with_setup
    return to_run(*args, **kwargs)
  File "/teamspace/studios/this_studio/litgpt/litgpt/finetune/lora.py", line 228, in main
    merge_lora(checkpoint_dir=save_path.parent)
  File "/teamspace/studios/this_studio/litgpt/litgpt/scripts/merge_lora.py", line 61, in merge_lora
    pretrained_checkpoint = torch.load(str(pretrained_checkpoint_dir / "lit_model.pth"), mmap=True)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/
```