### PR TITLE
Allow batch size "auto" setting in evaluate

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -31,7 +31,7 @@ def convert_and_evaluate(
     out_dir: Optional[Path] = None,
     force_conversion: bool = False,
     num_fewshot: Optional[int] = None,
-    batch_size: int = 1,
+    batch_size: Union[int, str] = 1,
     device: Optional[str] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     limit: Optional[float] = None,
@@ -48,7 +48,7 @@ def convert_and_evaluate(
             an existing model.pth from a previous evaluation call.
         tasks: CSV of task names to evaluate. Example: "hellaswag,truthfulqa_mc2,mmlu"
         num_fewshot: Number of examples in few-shot context.
-        batch_size: Batch size configuration.
+        batch_size: Batch size configuration as positive integer value (default: 1) or "auto".
         device: Device to use for evaluation, for example, "cuda" or "cuda:0".
         limit: Limit on number of examples per task.
         seed: Random seed.
@@ -57,6 +57,9 @@ def convert_and_evaluate(
     """
     checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
+
+    if not (isinstance(batch_size, int) and batch_size > 0) and batch_size != "auto":
+        raise ValueError("batch_size must be a positive integer or 'auto'.")
 
     from lm_eval import evaluator
 


### PR DESCRIPTION
Fixes #1467 to allow setting the `batch_size` to "auto" in `litgpt evaluate`