### PR TITLE
Allow batch argument with batch recomputation

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -48,7 +48,8 @@ def convert_and_evaluate(
             an existing model.pth from a previous evaluation call.
         tasks: CSV of task names to evaluate. Example: "hellaswag,truthfulqa_mc2,mmlu"
         num_fewshot: Number of examples in few-shot context.
-        batch_size: Batch size configuration as positive integer value (default: 1) or "auto".
+        batch_size: Batch size configuration as positive integer value (default: 1),
+            "auto", in the format 'auto:N', where 'auto:4' recomputes the batch size 4 times.
         device: Device to use for evaluation, for example, "cuda" or "cuda:0".
         limit: Limit on number of examples per task.
         seed: Random seed.
@@ -58,8 +59,8 @@ def convert_and_evaluate(
     checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
 
-    if not (isinstance(batch_size, int) and batch_size > 0) and batch_size != "auto":
-        raise ValueError("batch_size must be a positive integer or 'auto'.")
+    if not (isinstance(batch_size, int) and batch_size > 0) and not (isinstance(batch_size, str) and batch_size.startswith("auto")):
+            raise ValueError("batch_size must be a positive integer, 'auto', or in the format 'auto:N'.")
 
     from lm_eval import evaluator
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -36,7 +36,7 @@ def test_evaluate_script(tmp_path):
                 tasks="mathqa",
                 batch_size=0  # Test for non-positive integer
             )
-        assert "batch_size must be a positive integer or 'auto'" in str(excinfo.value)
+        assert "batch_size must be a positive integer, 'auto', or in the format 'auto:N'." in str(excinfo.value)
 
         with pytest.raises(ValueError) as excinfo:
             module.convert_and_evaluate(
@@ -48,7 +48,7 @@ def test_evaluate_script(tmp_path):
                 tasks="mathqa",
                 batch_size="invalid"  # Test for invalid string
             )
-        assert "batch_size must be a positive integer or 'auto'" in str(excinfo.value)
+        assert "batch_size must be a positive integer, 'auto', or in the format 'auto:N'." in str(excinfo.value)
 
     stdout = StringIO()
     with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):


### PR DESCRIPTION
This addresses a limitation where `'auto:N' could not be passed as `batch_size` argument in `litgpt evaluate` mentioned in #1467