### PR TITLE
Fix parameter naming issue with Mistral 7B v0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@ wandb
 events.out.tfevents*
 
 # test artifacts from tests/test_readme.py
-tests/custom_finetuning_dataset.json
-tests/custom_texts
+**/custom_finetuning_dataset.json
+client.py
+**/custom_texts/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 
 Uses the latest state-of-the-art techniques:
 
-✅ flash attention &nbsp; &nbsp;  ✅ fp4/8/16/32 &nbsp; &nbsp;  ✅ LoRA, QLoRA, Adapter (v1, v2) &nbsp; &nbsp;  ✅ FSDP &nbsp; &nbsp;  ✅ 1-1000+ GPUs/TPUs
+<pre>
+✅ flash attention    ✅ fp4/8/16/32        ✅ LoRA, QLoRA, Adapter
+✅ FSDP               ✅ 1-1000+ GPUs/TPUs  ✅ 20+ LLMs            
+</pre>
+
 
 ---
 
@@ -69,30 +73,34 @@ LitGPT has 🤯 **custom, from-scratch implementations** of [20+ LLMs](tutorials
 
 | Model | Model size | Author | Reference |
 |----|----|----|----|
-| CodeGemma | 7B | Google | [Google Team, Google Deepmind](https://ai.google.dev/gemma/docs/codegemma) |
-| Code Llama | 7B, 13B, 34B, 70B | Meta AI | [Rozière et al. 2023](https://arxiv.org/abs/2308.12950) |
-| Danube2 | 1.8B | H2O.ai | [H2O.ai](https://h2o.ai/platform/danube-1-8b/) |
-| Dolly | 3B, 7B, 12B | Databricks | [Conover et al. 2023](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm) |
-| Falcon | 7B, 40B, 180B | TII UAE | [TII 2023](https://falconllm.tii.ae)                                                                                         |
-| FreeWilly2 (Stable Beluga 2) | 70B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stable-beluga-large-instruction-fine-tuned-models)                             |
-| Function Calling Llama 2 | 7B | Trelis | [Trelis et al. 2023](https://huggingface.co/Trelis/Llama-2-7b-chat-hf-function-calling-v2)                                   |
-| Gemma | 2B, 7B | Google | [Google Team, Google Deepmind](https://storage.googleapis.com/deepmind-media/gemma/gemma-report.pdf)                         |
-| Llama 2 | 7B, 13B, 70B | Meta AI | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)                                                                      |
-| Llama 3 | 8B, 70B | Meta AI | [Meta AI 2024](https://github.com/meta-llama/llama3)                                                                     |
-| LongChat | 7B, 13B | LMSYS | [LongChat Team 2023](https://lmsys.org/blog/2023-06-29-longchat/)                                                            |
-| Mixtral MoE | 8x7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/mixtral-of-experts/)                                                                      |
-| Mistral | 7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/announcing-mistral-7b/)                                                                         |
-| Nous-Hermes | 7B, 13B, 70B | NousResearch | [Org page](https://huggingface.co/NousResearch)                                                                              |
-| OpenLLaMA | 3B, 7B, 13B | OpenLM Research | [Geng & Liu 2023](https://github.com/openlm-research/open_llama)                                                             |
-| Phi | 1.3B, 2.7B | Microsoft Research  | [Li et al. 2023](https://arxiv.org/abs/2309.05463)                                                                           |
+| CodeGemma | 7B | Google | [Google Team, Google Deepmind](https://ai.google.dev/gemma/docs/codegemma)                                                                 |
+| Code Llama | 7B, 13B, 34B, 70B | Meta AI | [Rozière et al. 2023](https://arxiv.org/abs/2308.12950)                                                                   |
+| Danube2 | 1.8B | H2O.ai | [H2O.ai](https://h2o.ai/platform/danube-1-8b/)                                                                                             |
+| Dolly | 3B, 7B, 12B | Databricks | [Conover et al. 2023](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm)      |
+| Falcon | 7B, 40B, 180B | TII UAE | [TII 2023](https://falconllm.tii.ae)                                                                                              |
+| FreeWilly2 (Stable Beluga 2) | 70B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stable-beluga-large-instruction-fine-tuned-models)                 |
+| Function Calling Llama 2 | 7B | Trelis | [Trelis et al. 2023](https://huggingface.co/Trelis/Llama-2-7b-chat-hf-function-calling-v2)                                  |
+| Gemma | 2B, 7B | Google | [Google Team, Google Deepmind](https://storage.googleapis.com/deepmind-media/gemma/gemma-report.pdf)                                       |
+| Llama 2 | 7B, 13B, 70B | Meta AI | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)                                                                           |
+| Llama 3 | 8B, 70B | Meta AI | [Meta AI 2024](https://github.com/meta-llama/llama3)                                                                                   |
+| LongChat | 7B, 13B | LMSYS | [LongChat Team 2023](https://lmsys.org/blog/2023-06-29-longchat/)                                                                       |
+| MicroLlama | 300M | Ken Wang | [MicroLlama repo](https://github.com/keeeeenw/MicroLlama)
+| Mixtral MoE | 8x7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/mixtral-of-experts/)                                                                     |
+| Mistral | 7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/announcing-mistral-7b/)                                                                        |
+| Nous-Hermes | 7B, 13B, 70B | NousResearch | [Org page](https://huggingface.co/NousResearch)                                                                          |
+| OpenLLaMA | 3B, 7B, 13B | OpenLM Research | [Geng & Liu 2023](https://github.com/openlm-research/open_llama)                                                         |
+| Phi | 1.3B, 2.7B | Microsoft Research  | [Li et al. 2023](https://arxiv.org/abs/2309.05463)                                                                          |
 | Platypus | 7B, 13B, 70B |  Lee et al. | [Lee, Hunter, and Ruiz 2023](https://arxiv.org/abs/2308.07317)                                                               |
-| Pythia | {14,31,70,160,410}M, {1,1.4,2.8,6.9,12}B | EleutherAI | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)                                                                     |
-| RedPajama-INCITE | 3B, 7B | Together | [Together 2023](https://together.ai/blog/redpajama-models-v1)                                                                |
-| StableCode | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                           |
-| StableLM  | 3B, 7B | Stability AI | [Stability AI 2023](https://github.com/Stability-AI/StableLM)                                                                |
-| StableLM Zephyr | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                           |
-| TinyLlama | 1.1B | Zhang et al. | [Zhang et al. 2023](https://github.com/jzhang38/TinyLlama)                                                                   |
-| Vicuna | 7B, 13B, 33B | LMSYS | [Li et al. 2023](https://lmsys.org/blog/2023-03-30-vicuna/)
+| Pythia | {14,31,70,160,410}M, {1,1.4,2.8,6.9,12}B | EleutherAI | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)                                            |
+| RedPajama-INCITE | 3B, 7B | Together | [Together 2023](https://together.ai/blog/redpajama-models-v1)                                                                 |
+| StableCode | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                                  |
+| StableLM  | 3B, 7B | Stability AI | [Stability AI 2023](https://github.com/Stability-AI/StableLM)                                                                    |
+| StableLM Zephyr | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                             |
+| TinyLlama | 1.1B | Zhang et al. | [Zhang et al. 2023](https://github.com/jzhang38/TinyLlama)                                                                         |
+| Vicuna | 7B, 13B, 33B | LMSYS | [Li et al. 2023](https://lmsys.org/blog/2023-03-30-vicuna/)                                                                          |
+
+**Tip**: You can list all available models by running the `litgpt download list` command.
+
 
 </details>
 
@@ -138,7 +146,7 @@ litgpt  serve     meta-llama/Meta-Llama-3-8B-Instruct
 &nbsp;
 
 ###  Use an LLM for inference
-Use LLMs for inference to test its chatting capabilities, run evaluations, or extract embeddings, etc...
+Use LLMs for inference to test its chatting capabilities, run evaluations, or extract embeddings, etc.
 Here's an example showing how to use the Phi-2 LLM.
 
 <a target="_blank" href="https://lightning.ai/lightning-ai/studios/litgpt-chat">
@@ -148,12 +156,14 @@ Here's an example showing how to use the Phi-2 LLM.
 &nbsp;
 
 ```bash
-# 1) Download a pretrained model
-litgpt download --repo_id microsoft/phi-2
+# 1) List all available models in litgpt
+litgpt download list
 
-# 2) Chat with the model
-litgpt chat \
-  --checkpoint_dir checkpoints/microsoft/phi-2
+# 2) Download a pretrained model
+litgpt download microsoft/phi-2
+
+# 3) Chat with the model
+litgpt chat microsoft/phi-2
 
 >> Prompt: What do Llamas eat?
 ```
@@ -174,21 +184,19 @@ For more information on the different inference options, refer to the [inference
 
 ```bash
 # 1) Download a pretrained model
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 
 # 2) Finetune the model
 curl -L https://huggingface.co/datasets/ksaw008/finance_alpaca/resolve/main/finance_alpaca.json -o my_custom_dataset.json
 
-litgpt finetune \
-  --checkpoint_dir checkpoints/microsoft/phi-2 \
+litgpt finetune microsoft/phi-2 \
   --data JSON \
   --data.json_path my_custom_dataset.json \
   --data.val_split_fraction 0.1 \
   --out_dir out/custom-model
 
 # 3) Chat with the model
-litgpt chat \
-  --checkpoint_dir out/custom-model/final
+litgpt chat out/custom-model/final
 ```
 
 &nbsp;
@@ -208,22 +216,19 @@ curl https://www.gutenberg.org/cache/epub/24440/pg24440.txt --output custom_text
 curl https://www.gutenberg.org/cache/epub/26393/pg26393.txt --output custom_texts/book2.txt
 
 # 1) Download a tokenizer
-litgpt download \
-  --repo_id EleutherAI/pythia-160m \
+litgpt download EleutherAI/pythia-160m \
   --tokenizer_only True
 
 # 2) Pretrain the model
-litgpt pretrain \
-  --model_name pythia-160m \
-  --tokenizer_dir checkpoints/EleutherAI/pythia-160m \
+litgpt pretrain EleutherAI/pythia-160m \
+  --tokenizer_dir EleutherAI/pythia-160m \
   --data TextFiles \
   --data.train_data_path "custom_texts/" \
   --train.max_tokens 10_000_000 \
   --out_dir out/custom-model
 
 # 3) Chat with the model
-litgpt chat \
-  --checkpoint_dir out/custom-model/final
+litgpt chat out/custom-model/final
 ```
 
 &nbsp;
@@ -244,21 +249,19 @@ curl https://www.gutenberg.org/cache/epub/24440/pg24440.txt --output custom_text
 curl https://www.gutenberg.org/cache/epub/26393/pg26393.txt --output custom_texts/book2.txt
 
 # 1) Download a pretrained model
-litgpt download --repo_id EleutherAI/pythia-160m
+litgpt download EleutherAI/pythia-160m
 
 # 2) Continue pretraining the model
-litgpt pretrain \
-  --model_name pythia-160m \
-  --tokenizer_dir checkpoints/EleutherAI/pythia-160m \
-  --initial_checkpoint_dir checkpoints/EleutherAI/pythia-160m \
+litgpt pretrain EleutherAI/pythia-160m \
+  --tokenizer_dir EleutherAI/pythia-160m \
+  --initial_checkpoint_dir EleutherAI/pythia-160m \
   --data TextFiles \
   --data.train_data_path "custom_texts/" \
   --train.max_tokens 10_000_000 \
   --out_dir out/custom-model
 
 # 3) Chat with the model
-litgpt chat \
-  --checkpoint_dir out/custom-model/final
+litgpt chat out/custom-model/final
 ```
 
 &nbsp;
@@ -274,11 +277,11 @@ Once you're ready to deploy a finetuned LLM, run this command:
 
 ```bash
 # locate the checkpoint to your finetuned or pretrained model and call the `serve` command:
-litgpt serve --checkpoint_dir path/to/your/checkpoint/microsoft/phi-2
+litgpt serve microsoft/phi-2
 
 # Alternative: if you haven't finetuned, download any checkpoint to deploy it:
-litgpt download --repo_id microsoft/phi-2
-litgpt serve --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt download microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 Test the server in a separate terminal and integrate the model API into your AI product:

--- a/config_hub/finetune/falcon-7b/lora.yaml
+++ b/config_hub/finetune/falcon-7b/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/falcon-7b/qlora.yaml
+++ b/config_hub/finetune/falcon-7b/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/gemma-2b/full.yaml
+++ b/config_hub/finetune/gemma-2b/full.yaml
@@ -55,18 +55,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -88,8 +76,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/gemma-2b/lora.yaml
+++ b/config_hub/finetune/gemma-2b/lora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.2
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/gemma-2b/qlora.yaml
+++ b/config_hub/finetune/gemma-2b/qlora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/gemma-7b/lora.yaml
+++ b/config_hub/finetune/gemma-7b/lora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/gemma-7b/qlora.yaml
+++ b/config_hub/finetune/gemma-7b/qlora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-2-7b/full.yaml
+++ b/config_hub/finetune/llama-2-7b/full.yaml
@@ -58,18 +58,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -91,8 +79,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-2-7b/lora.yaml
+++ b/config_hub/finetune/llama-2-7b/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-2-7b/qlora.yaml
+++ b/config_hub/finetune/llama-2-7b/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-3-8b/full.yaml
+++ b/config_hub/finetune/llama-3-8b/full.yaml
@@ -58,18 +58,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -91,8 +79,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.1
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-3-8b/lora.yaml
+++ b/config_hub/finetune/llama-3-8b/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/llama-3-8b/qlora.yaml
+++ b/config_hub/finetune/llama-3-8b/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/mistral-7b-v0.2/lora.yaml
+++ b/config_hub/finetune/mistral-7b-v0.2/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/mistral-7b-v0.2/qlora.yaml
+++ b/config_hub/finetune/mistral-7b-v0.2/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/mistral-7b/lora.yaml
+++ b/config_hub/finetune/mistral-7b/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/mistral-7b/qlora.yaml
+++ b/config_hub/finetune/mistral-7b/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/phi-2/full.yaml
+++ b/config_hub/finetune/phi-2/full.yaml
@@ -58,18 +58,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -91,8 +79,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.1
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/phi-2/lora.yaml
+++ b/config_hub/finetune/phi-2/lora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/phi-2/qlora.yaml
+++ b/config_hub/finetune/phi-2/qlora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/stablelm-base-alpha-3b/full.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/full.yaml
@@ -55,18 +55,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -88,8 +76,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.1
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/stablelm-base-alpha-3b/lora.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/lora.yaml
@@ -84,18 +84,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -117,8 +105,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/stablelm-base-alpha-3b/qlora.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/qlora.yaml
@@ -86,18 +86,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -119,8 +107,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/tiny-llama/full.yaml
+++ b/config_hub/finetune/tiny-llama/full.yaml
@@ -55,18 +55,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -88,8 +76,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/tiny-llama/lora.yaml
+++ b/config_hub/finetune/tiny-llama/lora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/finetune/tiny-llama/qlora.yaml
+++ b/config_hub/finetune/tiny-llama/qlora.yaml
@@ -85,18 +85,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: null)
   tie_embeddings:
 
-  #   (type: float, default: 0.0003)
-  learning_rate: 0.0002
-
-  #   (type: float, default: 0.02)
-  weight_decay: 0.0
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: null)
   max_norm:
 
@@ -118,8 +106,29 @@ eval:
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
 
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: true
+
 # The name of the logger to send metrics to. (type: Literal['wandb', 'tensorboard', 'csv'], default: csv)
 logger_name: csv
 
 # The random seed to use for reproducibility. (type: int, default: 1337)
 seed: 1337
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0002
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.0
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95

--- a/config_hub/pretrain/debug.yaml
+++ b/config_hub/pretrain/debug.yaml
@@ -58,18 +58,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: False)
   tie_embeddings:
 
-  #   (type: float, default: 0.0004)
-  learning_rate: 6e-4
-
-  #   (type: float, default: 0.1)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: 1.0)
   max_norm: 1.0
 
@@ -90,6 +78,27 @@ eval:
 
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
+
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: false
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 6e-4
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.1
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95
 
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto

--- a/config_hub/pretrain/microllama.yaml
+++ b/config_hub/pretrain/microllama.yaml
@@ -1,7 +1,7 @@
 
 # The name of the model to pretrain. Choose from names in ``litgpt.config``. Mutually exclusive with
 # ``model_config``. (type: Optional[str], default: null)
-model_name: tiny-llama-1.1b
+model_name: micro-llama-300M
 
 # A ``litgpt.Config`` object to define the model architecture. Mutually exclusive with
 # ``model_config``. (type: Optional[Config], default: null)
@@ -9,7 +9,7 @@ model_config:
 
 # Directory in which to save checkpoints and logs. If running in a Lightning Studio Job, look for it in
 # /teamspace/jobs/<job-name>/share. (type: <class 'Path'>, default: out/pretrain)
-out_dir: out/pretrain/tiny-llama
+out_dir: out/pretrain/micro-llama
 
 # The precision to use for pretraining. Possible choices: "bf16-true", "bf16-mixed", "32-true". (type: Optional[str], default: null)
 precision: bf16-mixed
@@ -23,7 +23,7 @@ initial_checkpoint_dir:
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.
-data: TinyLlama
+data: MicroLlama
 
 # Training-related arguments. See ``litgpt.args.TrainArgs`` for details
 train:
@@ -34,11 +34,15 @@ train:
   # Number of iterations between logging calls (type: int, default: 1)
   log_interval: 1
 
-  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 512)
-  global_batch_size: 512
+  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 48)
+  # Scale this number according to the number of GPU and memory size per GPU
+  # For example, we used 48 for 4 x 24G 4090 
+  global_batch_size: 48
 
-  # Number of samples per data-parallel rank (type: int, default: 4)
-  micro_batch_size: 4
+  # Number of samples per data-parallel rank (type: int, default: 12)
+  # Scale this number according to the memory size per GPU
+  # For example, we used 12 for 24G 4090
+  micro_batch_size: 12
 
   # Number of iterations with learning rate warmup active (type: int, default: 2000)
   lr_warmup_steps: 2000
@@ -78,9 +82,6 @@ eval:
 
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
-
-  # Whether to evaluate on the validation set at the end the training
-  final_validation: false
 
 # Optimizer-related arguments
 optimizer:

--- a/config_hub/pretrain/tinystories.yaml
+++ b/config_hub/pretrain/tinystories.yaml
@@ -1,7 +1,7 @@
 
 # The name of the model to pretrain. Choose from names in ``litgpt.config``. Mutually exclusive with
 # ``model_config``. (type: Optional[str], default: null)
-model_name:
+model_name: stories15M
 
 # A ``litgpt.Config`` object to define the model architecture. Mutually exclusive with
 # ``model_config``. (type: Optional[Config], default: null)
@@ -74,18 +74,6 @@ train:
   # Whether to tie the embedding weights with the language modeling head weights. (type: Optional[bool], default: False)
   tie_embeddings: true
 
-  #   (type: float, default: 0.0004)
-  learning_rate: 0.0005
-
-  #   (type: float, default: 0.1)
-  weight_decay: 0.1
-
-  #   (type: float, default: 0.9)
-  beta1: 0.9
-
-  #   (type: float, default: 0.95)
-  beta2: 0.95
-
   #   (type: Optional[float], default: 1.0)
   max_norm: 1.0
 
@@ -106,6 +94,27 @@ eval:
 
   # Whether to evaluate on the validation set at the beginning of the training
   initial_validation: false
+
+  # Whether to evaluate on the validation set at the end the training
+  final_validation: false
+
+# Optimizer-related arguments
+optimizer:
+
+  class_path: torch.optim.AdamW
+  
+  init_args:
+    
+    #   (type: float, default: 0.001)
+    lr: 0.0005
+    
+    #   (type: float, default: 0.01)
+    weight_decay: 0.1
+    
+    #   (type: tuple, default: (0.9,0.999))
+    betas:
+      - 0.9
+      - 0.95
 
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto

--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -1,7 +1,4 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
-import sys
-
-from typing import TYPE_CHECKING, Any
 
 import torch
 
@@ -26,121 +23,38 @@ from litgpt.scripts.download import download_from_hub as download_fn
 from litgpt.scripts.merge_lora import merge_lora as merge_lora_fn
 from litgpt.eval.evaluate import convert_and_evaluate as evaluate_fn
 from litgpt.deploy.serve import run_server as serve_fn
-
-
-if TYPE_CHECKING:
-    from jsonargparse import ArgumentParser
-
-
-def _new_parser(**kwargs: Any) -> "ArgumentParser":
-    from jsonargparse import ActionConfigFile, ArgumentParser
-
-    parser = ArgumentParser(**kwargs)
-    parser.add_argument(
-        "-c", "--config", action=ActionConfigFile, help="Path to a configuration file in json or yaml format."
-    )
-    return parser
-
-
-def _rewrite_argv_for_default_subcommand(parser_data: dict, command: str, subcommand: str) -> None:
-    """Rewrites the `sys.argv` such that `litgpt command` defaults to `litgpt command subcommand`."""
-    if len(sys.argv) > 2 and sys.argv[1] == command and sys.argv[2] not in parser_data[command].keys():
-        sys.argv.insert(2, subcommand)
+from jsonargparse import set_config_read_mode, set_docstring_parse_options, CLI
 
 
 def main() -> None:
     parser_data = {
-        "download": {"help": "Download weights or tokenizer data from the Hugging Face Hub.", "fn": download_fn},
-        "chat": {"help": "Chat with a model.", "fn": chat_fn},
-        "finetune": {
-            "help": "Finetune a model with one of our existing methods.",
-            "lora": {"help": "Finetune a model with LoRA.", "fn": finetune_lora_fn},
-            "full": {"help": "Finetune a model.", "fn": finetune_full_fn},
-            "adapter": {"help": "Finetune a model with Adapter.", "fn": finetune_adapter_fn},
-            "adapter_v2": {"help": "Finetune a model with Adapter v2.", "fn": finetune_adapter_v2_fn},
-        },
-        "pretrain": {"help": "Pretrain a model.", "fn": pretrain_fn},
-        "generate": {
-            "help": "Generate text samples based on a model and tokenizer.",
-            "base": {"fn": generate_base_fn, "help": "Default generation option."},
-            "full": {"fn": generate_full_fn, "help": "For models finetuned with `litgpt finetune full`."},
-            "adapter": {"fn": generate_adapter_fn, "help": "For models finetuned with `litgpt finetune adapter`."},
-            "adapter_v2": {
-                "fn": generate_adapter_v2_fn,
-                "help": "For models finetuned with `litgpt finetune adapter v2`.",
-            },
-            "sequentially": {
-                "fn": generate_sequentially_fn,
-                "help": "Generation script that partitions layers across devices to be run sequentially.",
-            },
-            "tp": {
-                "fn": generate_tp_fn,
-                "help": "Generation script that uses tensor parallelism to run across devices.",
-            },
-        },
-        "convert": {
-            "help": "Utilities to convert from and to LitGPT.",
-            "to_litgpt": {"fn": convert_hf_checkpoint_fn, "help": "Convert Hugging Face weights to LitGPT weights."},
-            "from_litgpt": {"fn": convert_lit_checkpoint_fn, "help": "Convert LitGPT weights to Hugging Face weights."},
-            "pretrained_checkpoint": {
-                "fn": convert_pretrained_checkpoint_fn,
-                "help": "Convert a checkpoint after pretraining.",
-            },
-        },
-        "merge_lora": {"help": "Merges the LoRA weights with the base model.", "fn": merge_lora_fn},
-        "evaluate": {"help": "Evaluate a model with the LM Evaluation Harness.", "fn": evaluate_fn},
-        "serve": {"help": "Serve and deploy a model with LitServe.", "fn": serve_fn},
+        "download": download_fn,
+        "chat": chat_fn,
+        "finetune": finetune_lora_fn,
+        "finetune_lora": finetune_lora_fn,
+        "finetune_full": finetune_full_fn,
+        "finetune_adapter": finetune_adapter_fn,
+        "finetune_adapter_v2": finetune_adapter_v2_fn,
+        "pretrain": pretrain_fn,
+        "generate": generate_base_fn,
+        "generate_full": generate_full_fn,
+        "generate_adapter": generate_adapter_fn,
+        "generate_adapter_v2": generate_adapter_v2_fn,
+        "generate_sequentially": generate_sequentially_fn,
+        "generate_tp": generate_tp_fn,
+        "convert_to_litgpt": convert_hf_checkpoint_fn,
+        "convert_from_litgpt": convert_lit_checkpoint_fn,
+        "convert_pretrained_checkpoint": convert_pretrained_checkpoint_fn,
+        "merge_lora": merge_lora_fn,
+        "evaluate": evaluate_fn,
+        "serve": serve_fn
     }
-
-    from jsonargparse import set_config_read_mode, set_docstring_parse_options
 
     set_docstring_parse_options(attribute_docstrings=True)
     set_config_read_mode(urls_enabled=True)
 
-    _rewrite_argv_for_default_subcommand(parser_data, "finetune", "lora")
-
-    root_parser = _new_parser(prog="litgpt")
-
-    # register level 1 subcommands and level 2 subsubcommands. If there are more levels in the future we would want to
-    # refactor this to do BFS traversal for registration
-    subcommands = root_parser.add_subcommands()
-    subcommand_to_parser = {}
-    for k, v in parser_data.items():
-        subcommand_parser = _new_parser()
-        if "fn" in v:
-            subcommand_parser.add_function_arguments(v["fn"])
-        else:
-            subcommand_to_parser[k] = subcommand_parser
-        subcommands.add_subcommand(k, subcommand_parser, help=v["help"])
-    for subcommand, parser in subcommand_to_parser.items():
-        subcommands = parser.add_subcommands()
-        for k, v in parser_data[subcommand].items():
-            if k == "help":
-                continue
-            subsubcommand_parser = _new_parser()
-            subsubcommand_parser.add_function_arguments(v["fn"])
-            subcommands.add_subcommand(k, subsubcommand_parser, help=v["help"])
-
-    args = root_parser.parse_args()
-    args = root_parser.instantiate_classes(args)
-
-    subcommand = args.get("subcommand")
-    subargs = args.get(subcommand)
-    subsubcommand = subargs.get("subcommand")
-    subsubargs = subargs.get(subsubcommand) if isinstance(subsubcommand, str) else None
-
-    level_1 = parser_data[subcommand]
-    if subsubcommand is None:
-        fn = level_1["fn"]
-        kwargs = subargs
-    else:
-        fn = level_1[subsubcommand]["fn"]
-        kwargs = subsubargs
-    kwargs.pop("config")
-
     torch.set_float32_matmul_precision("high")
-
-    fn(**kwargs)
+    CLI(parser_data)
 
 
 if __name__ == "__main__":

--- a/litgpt/args.py
+++ b/litgpt/args.py
@@ -2,6 +2,7 @@
 import math
 from dataclasses import dataclass
 from typing import Optional
+import warnings
 
 
 @dataclass
@@ -33,10 +34,6 @@ class TrainArgs:
     """Whether to tie the embedding weights with the language modeling head weights"""
 
     # Optimization args
-    learning_rate: float = 1e-3
-    weight_decay: float = 0.02
-    beta1: float = 0.9
-    beta2: float = 0.95
     max_norm: Optional[float] = None
     min_lr: float = 6e-5
 
@@ -47,6 +44,11 @@ class TrainArgs:
             )
         if self.lr_warmup_fraction and not (0 <= self.lr_warmup_fraction <= 1):
             raise ValueError("`--train.lr_warmup_fraction` must be between 0 and 1.")
+
+        if self.lr_warmup_steps and self.max_steps and (self.lr_warmup_steps >= self.max_steps):
+            warnings.warn(
+                "`--train.lr_warmup_steps` should be less than `--train.max_steps`."
+                f" Got {self.lr_warmup_steps} lr_warmup_steps and {self.max_steps} max_steps.", UserWarning)
 
     def gradient_accumulation_iters(self, devices: int) -> int:
         """Number of iterations between gradient synchronizations"""
@@ -81,3 +83,5 @@ class EvalArgs:
     """Number of iterations"""
     initial_validation: bool = False
     """Whether to evaluate on the validation set at the beginning of the training"""
+    final_validation: bool = True
+    """Whether to evaluate on the validation set at the end of the training"""

--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -3,6 +3,7 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Iterator, List, Literal, Optional, Tuple
 
 import lightning as L
@@ -13,7 +14,12 @@ from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.generate.base import next_token
 from litgpt.prompts import has_prompt_style, load_prompt_style
 from litgpt.scripts.merge_lora import merge_lora
-from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 @torch.inference_mode()
@@ -29,7 +35,7 @@ def generate(
 ) -> Iterator[torch.Tensor]:
     """Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as possible.
 
-    Args:
+    Arguments:
         model: The model to use.
         prompt: Tensor of shape (T) with indices of the prompt sequence.
         max_returned_tokens: The maximum number of tokens to return (given plus generated).
@@ -157,19 +163,20 @@ def interact(multiline, model, tokenizer, prompt_style, fabric, temperature, top
 
 @torch.inference_mode()
 def main(
+    checkpoint_dir: Path,
     *,
     top_k: Optional[int] = 200,
     top_p: float = 1.0,
     temperature: float = 0.8,
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-tuned-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
     precision: Optional[str] = None,
     compile: bool = False,
     multiline: bool = False,
 ) -> None:
-    """Starts a conversation with a tuned GPT model.
+    """Chat with a model.
 
     Args:
+        checkpoint_dir: The checkpoint directory to load.
         top_k: The number of top most probable tokens to consider in the sampling process.
         top_p: If specified, it represents the cumulative probability threshold to consider in the sampling process.
             In top-p sampling, the next token is sampled from the highest probability tokens
@@ -187,7 +194,6 @@ def main(
             or https://huyenchip.com/2024/01/16/sampling.html#top_p
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - bnb.int8: 8-bit quantization from bitsandbytes
@@ -196,6 +202,9 @@ def main(
         compile: Whether to use compilation to speed up token generation. Will increase startup time.
         multiline: Whether to support multiline input prompts.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -92,11 +92,15 @@ class Config:
         self.rope_n_elem = int(self.rotary_percentage * self.head_size)
 
     @classmethod
-    def from_name(cls, name: str, **kwargs: Any) -> Self:
+    def from_name(cls, name: str, **kwargs: Any) -> Optional[Self]:
         if name not in name_to_config:
             # search through all `config['hf_config']['name']`
             try:
-                conf_dict = next(config for config in configs if name == config["hf_config"]["name"])
+                conf_dict = next(
+                    config for config in configs
+                    if name == config["hf_config"]["name"] or
+                    config["hf_config"]["org"] + "/" + config["hf_config"]["name"] == name
+                )
             except StopIteration:
                 raise ValueError(f"{name!r} is not a supported config name")
         else:
@@ -1580,7 +1584,7 @@ tiny_llama = [
         rotary_percentage=1.0,
         parallel_residual=False,
         bias=False,
-        norm_class_name="RMSNorm",  # original TinyLlama uses FusedRMSNorm
+        norm_class_name="RMSNorm",  # original TinyLlama use FusedRMSNorm
         norm_eps=1e-5,
         mlp_class_name="LLaMAMLP",
         intermediate_size=5632,
@@ -1593,6 +1597,32 @@ for c in tiny_llama:
         copy["name"] = c["name"].format(kind)
         copy["hf_config"]["name"] = c["hf_config"]["name"].format(hf_postfix)
         configs.append(copy)
+
+
+############
+# MicroLlama
+############
+micro_llama = [
+    dict(
+        name="micro-llama-300M",
+        hf_config=dict(org="keeeeenw", name="MicroLlama"),
+        block_size=2048,
+        vocab_size=32000,
+        padding_multiple=64,
+        n_layer=12,
+        n_head=16,
+        n_embd=1024,
+        rotary_percentage=1.0,
+        parallel_residual=False,
+        bias=False,
+        norm_class_name="RMSNorm",  # original TinyLlama and MicroLlama use FusedRMSNorm
+        norm_eps=1e-5,
+        mlp_class_name="LLaMAMLP",
+        intermediate_size=5632,
+        n_query_groups=4,
+    )
+]
+configs.extend(micro_llama)
 
 
 ##########################

--- a/litgpt/data/__init__.py
+++ b/litgpt/data/__init__.py
@@ -15,6 +15,7 @@ from litgpt.data.text_files import TextFiles
 from litgpt.data.tinyllama import TinyLlama
 from litgpt.data.tinystories import TinyStories
 from litgpt.data.openwebtext import OpenWebText
+from litgpt.data.microllama import MicroLlama
 
 
 __all__ = [
@@ -34,5 +35,6 @@ __all__ = [
     "TextFiles",
     "TinyLlama",
     "TinyStories",
+    "MicroLlama"
     "get_sft_collate_fn",
 ]

--- a/litgpt/data/microllama.py
+++ b/litgpt/data/microllama.py
@@ -1,0 +1,13 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+from litgpt.data import TinyLlama
+
+@dataclass
+class MicroLlama(TinyLlama):
+    """The MicroLlama data module is composed of only SlimPajama data."""
+
+    def __init__(self, data_path: Union[str, Path] = Path("data/"), seed: int = 42, num_workers: int = 8):
+        super().__init__(data_path=data_path, seed=seed, num_workers=num_workers, use_starcoder=False)

--- a/litgpt/data/prepare_slimpajama.py
+++ b/litgpt/data/prepare_slimpajama.py
@@ -7,10 +7,12 @@ from pathlib import Path
 
 from litgpt import Tokenizer
 from litgpt.data.prepare_starcoder import DataChunkRecipe
-from litgpt.utils import CLI
+from litgpt.utils import CLI, extend_checkpoint_dir
 
 
 class SlimPajamaDataRecipe(DataChunkRecipe):
+    is_generator = True
+
     def __init__(self, tokenizer: Tokenizer, chunk_size: int):
         super().__init__(chunk_size)
         self.tokenizer = tokenizer
@@ -40,7 +42,7 @@ def prepare(
 ) -> None:
     from litdata.processing.data_processor import DataProcessor
 
-    tokenizer = Tokenizer(tokenizer_path)
+    tokenizer_path = extend_checkpoint_dir(tokenizer_path)
     data_recipe = SlimPajamaDataRecipe(tokenizer=tokenizer, chunk_size=chunk_size)
     data_processor = DataProcessor(
         input_dir=str(input_dir),

--- a/litgpt/data/prepare_starcoder.py
+++ b/litgpt/data/prepare_starcoder.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import Tokenizer
-from litgpt.utils import CLI
+from litgpt.utils import CLI, extend_checkpoint_dir
 
 _LITDATA_AVAILABLE = RequirementCache("litdata")
 if _LITDATA_AVAILABLE:
@@ -18,6 +18,8 @@ else:
 
 
 class StarcoderDataRecipe(DataChunkRecipe):
+    is_generator = True
+
     def __init__(self, tokenizer: Tokenizer, chunk_size: int):
         super().__init__(chunk_size)
         self.tokenizer = tokenizer
@@ -58,6 +60,7 @@ def prepare(
 ) -> None:
     from litdata.processing.data_processor import DataProcessor
 
+    tokenizer_path = extend_checkpoint_dir(tokenizer_path)
     tokenizer = Tokenizer(tokenizer_path)
     data_recipe = StarcoderDataRecipe(tokenizer=tokenizer, chunk_size=chunk_size)
     data_processor = DataProcessor(

--- a/litgpt/data/tinyllama.py
+++ b/litgpt/data/tinyllama.py
@@ -24,6 +24,8 @@ class TinyLlama(DataModule):
     """The random seed for shuffling the dataset."""
     num_workers: int = 8
     """How many DataLoader processes to use for loading."""
+    use_starcoder: bool = True
+    """Toggle for using Starcoder data."""
 
     batch_size: int = field(init=False, repr=False, default=1)
     seq_length: int = field(init=False, repr=False, default=2048)
@@ -32,7 +34,11 @@ class TinyLlama(DataModule):
         # Could be a remote path (s3://) or a local path
         self.slimpajama_train = str(self.data_path).rstrip("/") + "/slimpajama/train"
         self.slimpajama_val = str(self.data_path).rstrip("/") + "/slimpajama/val"
-        self.starcoder_train = str(self.data_path).rstrip("/") + "/starcoder"
+        self.required_paths = [self.slimpajama_train, self.slimpajama_val]
+
+        if self.use_starcoder:
+            self.starcoder_train = str(self.data_path).rstrip("/") + "/starcoder"
+            self.required_paths += [self.starcoder_train]
 
     def connect(
         self, tokenizer: Optional[Tokenizer] = None, batch_size: int = 1, max_seq_length: Optional[int] = None
@@ -41,7 +47,7 @@ class TinyLlama(DataModule):
         self.seq_length = max_seq_length + 1  # Increase by one because we need the next token as well
 
     def prepare_data(self) -> None:
-        for path in (self.slimpajama_train, self.slimpajama_val, self.starcoder_train):
+        for path in self.required_paths:
             if not path.startswith("s3://") and not Path(path).is_dir():
                 raise FileNotFoundError(
                     "The data path for TinyLlama is expected to be the directory containing these subdirectories:"
@@ -52,28 +58,33 @@ class TinyLlama(DataModule):
     def train_dataloader(self) -> DataLoader:
         from litdata.streaming import CombinedStreamingDataset, StreamingDataLoader, StreamingDataset, TokensLoader
 
-        train_datasets = [
-            StreamingDataset(
-                input_dir=self.slimpajama_train,
-                item_loader=TokensLoader(block_size=self.seq_length),
-                shuffle=True,
-                drop_last=True,
-            ),
-            StreamingDataset(
-                input_dir=self.starcoder_train,
-                item_loader=TokensLoader(block_size=self.seq_length),
-                shuffle=True,
-                drop_last=True,
-            ),
-        ]
-
-        # Mix SlimPajama data and Starcoder data with these proportions:
-        weights = (0.693584, 0.306416)
-        combined_dataset = CombinedStreamingDataset(
-            datasets=train_datasets, seed=self.seed, weights=weights, iterate_over_all=False
+        slim_train_data = StreamingDataset(
+            input_dir=self.slimpajama_train,
+            item_loader=TokensLoader(block_size=self.seq_length),
+            shuffle=True,
+            drop_last=True,
         )
+        train_data = slim_train_data
+
+        if self.use_starcoder:
+            train_datasets = [
+                slim_train_data,
+                StreamingDataset(
+                    input_dir=self.starcoder_train,
+                    item_loader=TokensLoader(block_size=self.seq_length),
+                    shuffle=True,
+                    drop_last=True,
+                ),
+            ]
+
+            # Mix SlimPajama data and Starcoder data with these proportions:
+            weights = (0.693584, 0.306416)
+            train_data = CombinedStreamingDataset(
+                datasets=train_datasets, seed=self.seed, weights=weights, iterate_over_all=False
+            )
+
         train_dataloader = StreamingDataLoader(
-            combined_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
+            train_data, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return train_dataloader
 

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, Any, Optional
 from litgpt.utils import check_valid_checkpoint_dir
 
@@ -11,9 +12,14 @@ import torch
 from litgpt.model import GPT
 from litgpt.config import Config
 from litgpt.tokenizer import Tokenizer
-from litgpt.generate.base import generate
+from litgpt.generate.base import generate as plain_generate
+from litgpt.chat.base import generate as stream_generate
 from litgpt.prompts import load_prompt_style, has_prompt_style, PromptStyle
-from litgpt.utils import load_checkpoint, CLI, get_default_supported_precision
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 _LITSERVE_AVAILABLE = RequirementCache("litserve")
@@ -23,7 +29,7 @@ else:
     LitAPI, LitServer = object, object
 
 
-class SimpleLitAPI(LitAPI):
+class BaseLitAPI(LitAPI):
     def __init__(self,
                  checkpoint_dir: Path,
                  precision: Optional[str] = None,
@@ -53,7 +59,7 @@ class SimpleLitAPI(LitAPI):
 
         fabric = L.Fabric(
             accelerator=device.type,
-            devices=1 if device.type=="cpu" else [device.index],
+            devices=1 if device.type == "cpu" else [device.index],
             precision=precision,
         )
         checkpoint_path = self.checkpoint_dir / "lit_model.pth"
@@ -81,12 +87,26 @@ class SimpleLitAPI(LitAPI):
         encoded = self.tokenizer.encode(prompt, device=self.device)
         return encoded
 
+
+class SimpleLitAPI(BaseLitAPI):
+    def __init__(self,
+                 checkpoint_dir: Path,
+                 precision: Optional[str] = None,
+                 temperature: float = 0.8,
+                 top_k: int = 50,
+                 top_p: float = 1.0,
+                 max_new_tokens: int = 50):
+        super().__init__(checkpoint_dir, precision, temperature, top_k, top_p, max_new_tokens)   
+
+    def setup(self, device: str):
+        super().setup(device)
+
     def predict(self, inputs: torch.Tensor) -> Any:
         # Run the model on the input and return the output.
         prompt_length = inputs.size(0)
         max_returned_tokens = prompt_length + self.max_new_tokens
 
-        y = generate(
+        y = plain_generate(
             self.model,
             inputs,
             max_returned_tokens,
@@ -106,8 +126,44 @@ class SimpleLitAPI(LitAPI):
         return {"output": decoded_output}
 
 
+class StreamLitAPI(BaseLitAPI):
+    def __init__(self,
+                 checkpoint_dir: Path,
+                 precision: Optional[str] = None,
+                 temperature: float = 0.8,
+                 top_k: int = 50,
+                 top_p: float = 1.0,
+                 max_new_tokens: int = 50):
+        super().__init__(checkpoint_dir, precision, temperature, top_k, top_p, max_new_tokens)   
+
+    def setup(self, device: str):
+        super().setup(device)
+
+    def predict(self, inputs: torch.Tensor) -> Any:
+        # Run the model on the input and return the output.
+        prompt_length = inputs.size(0)
+        max_returned_tokens = prompt_length + self.max_new_tokens
+
+        for block in self.model.transformer.h:
+            block.attn.kv_cache.reset_parameters()
+
+        yield from stream_generate(
+            self.model,
+            inputs,
+            max_returned_tokens,
+            temperature=self.temperature,
+            top_k=self.top_k,
+            top_p=self.top_p,
+            stop_tokens=([self.tokenizer.eos_id],)
+        )
+
+    def encode_response(self, output):
+        for out in output:
+            yield {"output": self.tokenizer.decode(out)}
+
+
 def run_server(
-    checkpoint_dir: Path = Path("checkpoints"),
+    checkpoint_dir: Path,
     precision: Optional[str] = None,
     temperature: float = 0.8,
     top_k: int = 200,
@@ -115,9 +171,12 @@ def run_server(
     max_new_tokens: int = 50,
     devices: int = 1,
     accelerator: str = "auto",
-    port: int = 8000
+    port: int = 8000,
+    stream: bool = False
 ) -> None:
-    """Serve a LitGPT model using LitServe
+    """Serve a LitGPT model using LitServe.
+
+    Evaluate a model with the LM Evaluation Harness.
 
     Arguments:
         checkpoint_dir: The checkpoint directory to load the model from.
@@ -146,19 +205,40 @@ def run_server(
         accelerator: The type of accelerator to use. For example, "auto", "cuda", "cpu", or "mps".
             The "auto" setting (default) chooses a GPU if available, and otherwise uses a CPU.
         port: The network port number on which the model is configured to be served.
+        stream: Whether to stream the responses.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth")
 
-    server = LitServer(
-        SimpleLitAPI(
-            checkpoint_dir=checkpoint_dir,
-            precision=precision,
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            max_new_tokens=max_new_tokens,
-            ),
-        accelerator=accelerator,
-        devices=devices)
+    if not stream:
+        server = LitServer(
+            SimpleLitAPI(
+                checkpoint_dir=checkpoint_dir,
+                precision=precision,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                max_new_tokens=max_new_tokens,
+                ),
+            accelerator=accelerator,
+            devices=devices
+            )
+
+    else:
+        server = LitServer(
+            StreamLitAPI(
+                checkpoint_dir=checkpoint_dir,
+                precision=precision,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                max_new_tokens=max_new_tokens,
+                ),
+            accelerator=accelerator,
+            devices=devices,
+            stream=True
+            )
 
     server.run(port=port)

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -3,11 +3,12 @@
 import json
 import os
 from pathlib import Path
+from pprint import pprint
 from typing import Optional, Union
 import torch
 
 from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint
-from litgpt.utils import CLI, copy_config_files
+from litgpt.utils import copy_config_files, extend_checkpoint_dir
 
 
 def prepare_results(results, save_filepath, print_results=True):
@@ -30,14 +31,14 @@ def convert_and_evaluate(
     out_dir: Optional[Path] = None,
     force_conversion: bool = False,
     num_fewshot: Optional[int] = None,
-    batch_size: int = 1,
+    batch_size: Union[int, str] = 1,
     device: Optional[str] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     limit: Optional[float] = None,
     seed: int = 1234,
     save_filepath: Optional[Path] = None,
 ) -> None:
-    """Convert a LitGPT model and run the LM Evaluation Harness
+    """Evaluate a model with the LM Evaluation Harness.
 
     Arguments:
         checkpoint_dir: Directory where the `lit_model.pth` and tokenizer files are located.
@@ -47,13 +48,19 @@ def convert_and_evaluate(
             an existing model.pth from a previous evaluation call.
         tasks: CSV of task names to evaluate. Example: "hellaswag,truthfulqa_mc2,mmlu"
         num_fewshot: Number of examples in few-shot context.
-        batch_size: Batch size configuration.
+        batch_size: Batch size configuration as positive integer value (default: 1),
+            "auto", in the format 'auto:N', where 'auto:4' recomputes the batch size 4 times.
         device: Device to use for evaluation, for example, "cuda" or "cuda:0".
         limit: Limit on number of examples per task.
         seed: Random seed.
         save_filepath: The file where the results will be saved.
             Saves to `out_dir/results.json` by default.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
+    if not (isinstance(batch_size, int) and batch_size > 0) and not (isinstance(batch_size, str) and batch_size.startswith("auto")):
+            raise ValueError("batch_size must be a positive integer, 'auto', or in the format 'auto:N'.")
 
     from lm_eval import evaluator
 
@@ -72,8 +79,6 @@ def convert_and_evaluate(
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    checkpoint_dir = Path(checkpoint_dir)
-
     if out_dir is None:
         out_dir = checkpoint_dir / "evaluate"
     else:
@@ -86,7 +91,7 @@ def convert_and_evaluate(
     if not model_path.exists() or force_conversion:
         copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
         convert_lit_checkpoint(checkpoint_dir=checkpoint_dir, output_dir=out_dir)
-    
+
         # Hack: LitGPT's conversion doesn't save a pickle file that is compatible to be loaded with
         # `torch.load(..., weights_only=True)`, which is a requirement in HFLM.
         # So we're `torch.load`-ing and `torch.sav`-ing it again to work around this.

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -6,13 +6,15 @@ import time
 from pathlib import Path
 from pprint import pprint
 from typing import Dict, List, Literal, Optional, Tuple, Union
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from lightning_utilities.core.imports import RequirementCache
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.adapter import GPT, Block, Config, adapter_filter, mark_only_adapter_as_trainable
@@ -27,8 +29,11 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
+    instantiate_torch_optimizer,
+    instantiate_bnb_optimizer,
     load_checkpoint,
     num_parameters,
     parse_devices,
@@ -37,7 +42,7 @@ from litgpt.utils import (
 
 
 def setup(
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    checkpoint_dir: Path,
     out_dir: Path = Path("out/finetune/adapter"),
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
@@ -50,10 +55,10 @@ def setup(
         micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
-        learning_rate=1e-3,
         max_seq_length=None,
     ),
     eval: EvalArgs = EvalArgs(interval=100, max_new_tokens=100, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
     logger_name: Literal["wandb", "tensorboard", "csv"] = "csv",
     seed: int = 1337,
 ) -> None:
@@ -69,10 +74,11 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)
@@ -88,6 +94,11 @@ def setup(
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
@@ -109,7 +120,7 @@ def setup(
         strategy = "auto"
 
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval)
+    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
 def main(
@@ -122,6 +133,7 @@ def main(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
+    optimizer: Union[str, Dict],
 ) -> None:
     validate_args(train, eval)
 
@@ -146,14 +158,10 @@ def main(
     model = fabric.setup_module(model)
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
-        import bitsandbytes as bnb
-
-        optimizer_cls = bnb.optim.PagedAdamW
+        optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
     else:
-        optimizer_cls = torch.optim.AdamW
-    optimizer = optimizer_cls(
-        model.parameters(), lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
-    )
+        optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
+
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
 
@@ -180,10 +188,11 @@ def main(
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Final evaluation
-    val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-    metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
-    fabric.log_dict(metrics)
-    fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+    if eval.final_validation:
+        val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
+        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics)
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
 
     # Save the final Adapter checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth.adapter"
@@ -211,7 +220,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -6,13 +6,15 @@ import time
 from pathlib import Path
 from pprint import pprint
 from typing import Dict, List, Literal, Optional, Tuple, Union
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from lightning_utilities.core.imports import RequirementCache
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.adapter_v2 import GPT, Block, Config, adapter_filter, mark_only_adapter_v2_as_trainable
@@ -27,8 +29,11 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
+    instantiate_torch_optimizer,
+    instantiate_bnb_optimizer,
     load_checkpoint,
     num_parameters,
     parse_devices,
@@ -37,7 +42,7 @@ from litgpt.utils import (
 
 
 def setup(
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    checkpoint_dir: Path,
     out_dir: Path = Path("out/finetune/adapter-v2"),
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
@@ -50,10 +55,10 @@ def setup(
         micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
-        learning_rate=1e-3,
         max_seq_length=None,
     ),
     eval: EvalArgs = EvalArgs(interval=100, max_new_tokens=100, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
     logger_name: Literal["wandb", "tensorboard", "csv"] = "csv",
     seed: int = 1337,
 ) -> None:
@@ -69,10 +74,11 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)
@@ -88,6 +94,11 @@ def setup(
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
@@ -109,7 +120,7 @@ def setup(
         strategy = "auto"
 
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval)
+    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
 def main(
@@ -122,6 +133,7 @@ def main(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
+    optimizer: Union[str, Dict],
 ) -> None:
     validate_args(train, eval)
 
@@ -146,14 +158,10 @@ def main(
     model = fabric.setup_module(model)
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
-        import bitsandbytes as bnb
-
-        optimizer_cls = bnb.optim.PagedAdamW
+        optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
     else:
-        optimizer_cls = torch.optim.AdamW
-    optimizer = optimizer_cls(
-        model.parameters(), lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
-    )
+        optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
+
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
 
@@ -180,10 +188,11 @@ def main(
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Final evaluation
-    val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-    metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
-    fabric.log_dict(metrics)
-    fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+    if eval.final_validation:
+        val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
+        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics)
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
 
     # Save the final Adapter checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth.adapter_v2"
@@ -211,7 +220,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 import lightning as L
 import torch
 from lightning.fabric.strategies import FSDPStrategy
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.args import EvalArgs, TrainArgs
@@ -25,9 +25,11 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     load_checkpoint,
     init_out_dir,
+    instantiate_torch_optimizer,
     num_parameters,
     parse_devices,
     save_hyperparameters,
@@ -35,7 +37,7 @@ from litgpt.utils import (
 
 
 def setup(
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    checkpoint_dir: Path,
     out_dir: Path = Path("out/finetune/full"),
     precision: Optional[str] = None,
     devices: Union[int, str] = 1,
@@ -48,10 +50,10 @@ def setup(
         micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
-        learning_rate=3e-3,
         max_seq_length=None,
     ),
     eval: EvalArgs = EvalArgs(interval=600, max_new_tokens=100, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
     logger_name: Literal["wandb", "tensorboard", "csv"] = "csv",
     seed: int = 1337,
 ) -> None:
@@ -68,10 +70,11 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)
@@ -97,7 +100,7 @@ def setup(
         strategy = "auto"
 
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
-    fabric.launch(main, devices, resume, seed, config, data, checkpoint_dir, out_dir, train, eval)
+    fabric.launch(main, devices, resume, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
 def main(
@@ -111,6 +114,7 @@ def main(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
+    optimizer: Union[str, Dict],
 ) -> None:
     validate_args(train, eval)
 
@@ -131,9 +135,8 @@ def main(
     fabric.print(f"Number of trainable parameters: {num_parameters(model, requires_grad=True):,}")
 
     model = fabric.setup(model)
-    optimizer = torch.optim.AdamW(
-        model.parameters(), lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
-    )
+
+    optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
     state = {"model": model, "optimizer": optimizer, "scheduler": scheduler, "iter_num": 0, "step_count": 0}
@@ -153,10 +156,11 @@ def main(
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Final evaluation
-    val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-    metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
-    fabric.log_dict(metrics, step=state["iter_num"])
-    fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+    if eval.final_validation:
+        val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
+        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics, step=state["iter_num"])
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
 
     # Save the final checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth"
@@ -186,7 +190,7 @@ def fit(
     optimizer = state["optimizer"]
     scheduler = state["scheduler"]
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
@@ -371,4 +375,3 @@ def validate_args(train: TrainArgs, eval: EvalArgs) -> None:
         issues.append(f"{__file__} requires either epochs or max_steps to be set. This is set in {train}")
     if issues:
         raise ValueError("\n".join(issues))
-

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -6,13 +6,15 @@ import time
 from pathlib import Path
 from pprint import pprint
 from typing import Dict, List, Literal, Optional, Tuple, Union
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities import ThroughputMonitor
-from torch.utils.data import DataLoader
+from lightning_utilities.core.imports import RequirementCache
+from torch.utils.data import DataLoader, ConcatDataset
 from torchmetrics import RunningMean
 
 from litgpt.args import EvalArgs, TrainArgs
@@ -28,9 +30,12 @@ from litgpt.utils import (
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     load_checkpoint,
     init_out_dir,
+    instantiate_torch_optimizer,
+    instantiate_bnb_optimizer,
     num_parameters,
     parse_devices,
     save_hyperparameters,
@@ -38,7 +43,7 @@ from litgpt.utils import (
 
 
 def setup(
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
+    checkpoint_dir: Path,
     out_dir: Path = Path("out/finetune/lora"),
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
@@ -60,10 +65,10 @@ def setup(
         micro_batch_size=1,
         lr_warmup_steps=100,
         epochs=5,
-        learning_rate=3e-4,
         max_seq_length=None,
     ),
     eval: EvalArgs = EvalArgs(interval=100, max_new_tokens=100, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
     logger_name: Literal["wandb", "tensorboard", "csv"] = "csv",
     seed: int = 1337,
 ) -> None:
@@ -88,10 +93,11 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
-
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
     pprint(locals())
     data = Alpaca() if data is None else data
     devices = parse_devices(devices)
@@ -118,6 +124,11 @@ def setup(
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
@@ -139,7 +150,7 @@ def setup(
         strategy = "auto"
 
     fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
-    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval)
+    fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
 def main(
@@ -152,6 +163,7 @@ def main(
     out_dir: Path,
     train: TrainArgs,
     eval: EvalArgs,
+    optimizer: Union[str, Dict],
 ) -> None:
     validate_args(train, eval)
 
@@ -176,14 +188,10 @@ def main(
     model = fabric.setup_module(model)
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
-        import bitsandbytes as bnb
-
-        optimizer_cls = bnb.optim.PagedAdamW
+        optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
     else:
-        optimizer_cls = torch.optim.AdamW
-    optimizer = optimizer_cls(
-        model.parameters(), lr=train.learning_rate, weight_decay=train.weight_decay, betas=(train.beta1, train.beta2)
-    )
+        optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
+
     optimizer = fabric.setup_optimizers(optimizer)
     scheduler = get_lr_scheduler(optimizer, warmup_steps=train.lr_warmup_steps, max_steps=lr_max_steps)
 
@@ -210,10 +218,11 @@ def main(
         fabric.print(f"Memory used: {torch.cuda.max_memory_allocated() / 1e9:.02f} GB")
 
     # Final evaluation
-    val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-    metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
-    fabric.log_dict(metrics)
-    fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+    if eval.final_validation:
+        val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
+        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics)
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
 
     # Save the final LoRA checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth.lora"
@@ -242,7 +251,7 @@ def fit(
     data: DataModule,
 ) -> None:
     tokenizer = Tokenizer(checkpoint_dir)
-    longest_seq_length, longest_seq_ix = get_longest_seq_length(train_dataloader.dataset)
+    longest_seq_length, longest_seq_ix = get_longest_seq_length(ConcatDataset([train_dataloader.dataset, val_dataloader.dataset]))
     model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -3,24 +3,32 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
+from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import PromptStyle, Tokenizer
 from litgpt.adapter import GPT, Config
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    lazy_load
+)
 
 
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     input: str = "",
     adapter_path: Path = Path("out/finetune/adapter/final/lit_model.pth.adapter"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
     max_new_tokens: int = 100,
     top_k: Optional[int] = 50,
@@ -28,15 +36,17 @@ def main(
     temperature: float = 0.8,
     precision: Optional[str] = None,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input. This script will only work with
+    """For models finetuned with `litgpt finetune_adapter`.
+
+    Generates a response based on a given instruction and an optional input. This script will only work with
     checkpoints from the instruction-tuned adapter model. See ``litgpt.finetune.adapter``.
 
     Args:
+        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             ``litgpt.finetune.adapter``.
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - bnb.int8: 8-bit quantization from bitsandbytes
@@ -61,12 +71,20 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -3,24 +3,32 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
+from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import PromptStyle, Tokenizer
 from litgpt.adapter_v2 import GPT, Config
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, lazy_load
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    lazy_load
+)
 
 
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     input: str = "",
     adapter_path: Path = Path("out/finetune/adapter-v2/final/lit_model.pth.adapter_v2"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
     max_new_tokens: int = 100,
     top_k: Optional[int] = 50,
@@ -28,15 +36,17 @@ def main(
     temperature: float = 0.8,
     precision: Optional[str] = None,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input. This script will only work with
+    """For models finetuned with `litgpt finetune adapter_v2`.
+
+    Generates a response based on a given instruction and an optional input. This script will only work with
     checkpoints from the instruction-tuned adapter v2 model. See ``litgpt.finetune.adapter_v2``.
 
     Args:
+        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         adapter_path: Path to the checkpoint with trained adapter weights, which are the output of
             ``litgpt.finetune.adapter_v2``.
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - bnb.int8: 8-bit quantization from bitsandbytes
@@ -61,12 +71,20 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -3,17 +3,25 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Any, Literal, Optional
+import warnings
 
 import lightning as L
 import torch
 import torch._dynamo.config
 import torch._inductor.config
 from lightning.fabric.plugins import BitsandbytesPrecision
+from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
@@ -79,8 +87,8 @@ def generate(
     top_p: float = 1.0,
     eos_id: Optional[int] = None,
 ) -> torch.Tensor:
-    """Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
-
+    """
+    Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
     The implementation of this function is modified from A. Karpathy's nanoGPT.
 
     Args:
@@ -133,6 +141,7 @@ def generate(
 
 @torch.inference_mode()
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     *,
     num_samples: int = 1,
@@ -140,14 +149,16 @@ def main(
     top_k: Optional[int] = 50,
     top_p: float = 1.0,
     temperature: float = 0.8,
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
     precision: Optional[str] = None,
     compile: bool = False,
 ) -> None:
-    """Generates text samples based on a pre-trained model and tokenizer.
+    """Default generation option.
+
+    Generates text samples based on a pre-trained model and tokenizer.
 
     Args:
+        checkpoint_dir: The checkpoint directory to load.
         prompt: The prompt string to use for generating the samples.
         num_samples: The number of text samples to generate.
         max_new_tokens: The number of generation steps to take.
@@ -168,7 +179,6 @@ def main(
             or https://huyenchip.com/2024/01/16/sampling.html#top_p
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - bnb.int8: 8-bit quantization from bitsandbytes
@@ -176,12 +186,20 @@ def main(
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -3,23 +3,31 @@
 import sys
 import time
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
+import warnings
 
 import lightning as L
 import torch
 from lightning.fabric.plugins import BitsandbytesPrecision
+from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT, Config, PromptStyle, Tokenizer
 from litgpt.generate.base import generate
 from litgpt.prompts import has_prompt_style, load_prompt_style
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision, load_checkpoint
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision,
+    load_checkpoint
+)
 
 
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     input: str = "",
     finetuned_path: Path = Path("out/full/alpaca/lit_model_finetuned.pth"),
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8"]] = None,
     max_new_tokens: int = 100,
     top_k: Optional[int] = 50,
@@ -27,15 +35,17 @@ def main(
     temperature: float = 0.8,
     precision: Optional[str] = None,
 ) -> None:
-    """Generates a response based on a given instruction and an optional input. This script will only work with
+    """For models finetuned with `litgpt finetune_full`.
+
+    Generates a response based on a given instruction and an optional input. This script will only work with
     checkpoints from the instruction-tuned GPT model. See ``litgpt.finetune.full``.
 
     Args:
+        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         prompt: The prompt/instruction (Alpaca style).
         input: Optional input (Alpaca style).
         finetuned_path: Path to the checkpoint with trained weights, which are the output of
             ``litgpt.finetune.full``.
-        checkpoint_dir: The path to the checkpoint folder with pretrained GPT weights.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             - bnb.int8: 8-bit quantization from bitsandbytes
@@ -60,12 +70,20 @@ def main(
             samples.
         precision: Indicates the Fabric precision setting to use.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
     if quantize is not None and quantize.startswith("bnb."):
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -8,9 +8,12 @@ import time
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional
+import warnings
 
 import lightning as L
+from lightning_utilities.core.imports import RequirementCache
 import torch
 from lightning.fabric.accelerators import CUDAAccelerator
 from lightning.fabric.plugins import BitsandbytesPrecision
@@ -20,7 +23,11 @@ from typing_extensions import Type
 import litgpt.generate.base as generate_base
 from litgpt import GPT, Config, Tokenizer
 from litgpt.model import Block, build_mask_cache
-from litgpt.utils import check_valid_checkpoint_dir, get_default_supported_precision
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision
+)
 
 
 @torch.inference_mode()
@@ -112,6 +119,7 @@ def replace_device(module: torch.nn.Module, replace: torch.device, by: torch.dev
 
 @torch.inference_mode()
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     *,
     num_samples: int = 1,
@@ -119,14 +127,16 @@ def main(
     top_k: Optional[int] = 50,
     top_p: float = 1.0,
     temperature: float = 0.8,
-    checkpoint_dir: Path = Path("checkpoints/mistralai/Mistral-7B-Instruct-v0.1"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq"]] = None,
     precision: Optional[str] = None,
     compile: bool = False,
 ) -> None:
-    """Generates text samples based on a pre-trained model and tokenizer.
+    """Generation script that partitions layers across devices to be run sequentially.
+
+    Generates text samples based on a pre-trained model and tokenizer.
 
     Args:
+        checkpoint_dir: The checkpoint directory to load.
         prompt: The prompt string to use for generating the samples.
         num_samples: The number of text samples to generate.
         max_new_tokens: The number of generation steps to take.
@@ -147,13 +157,15 @@ def main(
             or https://huyenchip.com/2024/01/16/sampling.html#top_p
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             for more details, see https://github.com/Lightning-AI/litgpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
@@ -162,6 +174,11 @@ def main(
             raise NotImplementedError  # untested
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         logging.getLogger("lightning.fabric.plugins.precision.bitsandbytes").setLevel(logging.DEBUG)
         plugins = BitsandbytesPrecision(quantize[4:], dtype)

--- a/litgpt/generate/tp.py
+++ b/litgpt/generate/tp.py
@@ -5,9 +5,12 @@ import sys
 import time
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Literal, Optional, Union
+import warnings
 
 import lightning as L
+from lightning_utilities.core.imports import RequirementCache
 import torch
 import torch._dynamo.config
 import torch._inductor.config
@@ -18,7 +21,11 @@ from torch.distributed._functional_collectives import all_reduce
 import litgpt.generate.base as generate_base
 from litgpt import GPT, Config, Tokenizer
 from litgpt.model import CausalSelfAttention, GptNeoxMLP, LLaMAMLP, LLaMAMoE
-from litgpt.utils import CLI, check_valid_checkpoint_dir, get_default_supported_precision
+from litgpt.utils import (
+    check_valid_checkpoint_dir,
+    extend_checkpoint_dir,
+    get_default_supported_precision
+)
 
 
 def tensor_parallel_linear(fabric: L.Fabric, linear: torch.nn.Linear, style: str) -> None:
@@ -90,6 +97,7 @@ def tensor_parallel(fabric: L.Fabric, model: GPT) -> GPT:
 
 @torch.inference_mode()
 def main(
+    checkpoint_dir: Path,
     prompt: str = "What food do llamas eat?",
     *,
     num_samples: int = 1,
@@ -97,14 +105,16 @@ def main(
     top_k: Optional[int] = 50,
     top_p: float = 1.0,
     temperature: float = 0.8,
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq"]] = None,
     precision: Optional[str] = None,
     compile: bool = False,
 ) -> None:
-    """Generates text samples based on a pre-trained model and tokenizer.
+    """Generation script that uses tensor parallelism to run across devices.
+
+    Generates text samples based on a pre-trained model and tokenizer.
 
     Args:
+        checkpoint_dir: The checkpoint directory to load.
         prompt: The prompt string to use for generating the samples.
         num_samples: The number of text samples to generate.
         max_new_tokens: The number of generation steps to take.
@@ -125,13 +135,15 @@ def main(
             or https://huyenchip.com/2024/01/16/sampling.html#top_p
         temperature: A value controlling the randomness of the sampling process. Higher values result in more random
             samples.
-        checkpoint_dir: The checkpoint directory to load.
         quantize: Whether to quantize the model and using which method:
             - bnb.nf4, bnb.nf4-dq, bnb.fp4, bnb.fp4-dq: 4-bit quantization from bitsandbytes
             for more details, see https://github.com/Lightning-AI/litgpt/blob/main/tutorials/quantize.md
         precision: Indicates the Fabric precision setting to use.
         compile: Whether to compile the model.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     precision = precision or get_default_supported_precision(training=False)
 
     plugins = None
@@ -140,6 +152,11 @@ def main(
             raise NotImplementedError  # untested
         if "mixed" in precision:
             raise ValueError("Quantization and mixed precision is not supported.")
+        if RequirementCache("bitsandbytes != 0.42.0"):
+            warnings.warn(
+                "LitGPT only supports bitsandbytes v0.42.0. "
+                "This may result in errors when using quantization."
+            )
         dtype = {"16-true": torch.float16, "bf16-true": torch.bfloat16, "32-true": torch.float32}[precision]
         bnb_logger = logging.getLogger("lightning.fabric.plugins.precision.bitsandbytes")
         bnb_logger.setLevel(logging.DEBUG)

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -6,7 +6,7 @@ import time
 from datetime import timedelta
 from functools import partial
 from pathlib import Path
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple, Union, Dict
 
 import lightning as L
 import torch
@@ -20,17 +20,18 @@ from typing_extensions import Literal
 from litgpt import Tokenizer
 from litgpt.args import EvalArgs, TrainArgs
 from litgpt.config import name_to_config
-from litgpt.data import DataModule, TinyLlama
+from litgpt.data import DataModule, TinyLlama, MicroLlama
 from litgpt.model import GPT, Block, CausalSelfAttention, Config, LLaMAMLP
 from litgpt.utils import (
-    CLI,
     CycleIterator,
     capture_hparams,
     choose_logger,
     chunked_cross_entropy,
     copy_config_files,
+    extend_checkpoint_dir,
     get_default_supported_precision,
     init_out_dir,
+    instantiate_torch_optimizer,
     num_parameters,
     parse_devices,
     reset_parameters,
@@ -40,7 +41,7 @@ from litgpt.utils import (
 
 
 def setup(
-    model_name: Optional[str] = None,
+    model_name: str,
     model_config: Optional[Config] = None,
     out_dir: Path = Path("out/pretrain"),
     precision: Literal["bf16-true", "bf16-mixed", "32-true", None] = None,
@@ -53,16 +54,13 @@ def setup(
         global_batch_size=512,
         micro_batch_size=4,
         max_tokens=int(3e12),  # 3 trillion
-        learning_rate=4e-4,
-        weight_decay=1e-1,
-        beta1=0.9,
-        beta2=0.95,
         max_norm=1.0,
         min_lr=4e-5,
         lr_warmup_steps=2000,
         tie_embeddings=False,
     ),
     eval: EvalArgs = EvalArgs(interval=1000, max_iters=100),
+    optimizer: Union[str, Dict] = "AdamW",
     devices: Union[int, str] = "auto",
     tokenizer_dir: Optional[Path] = None,
     logger_name: Literal["wandb", "tensorboard", "csv"] = "tensorboard",
@@ -71,10 +69,9 @@ def setup(
     """Pretrain a model.
 
     Arguments:
-        model_name: The name of the model to pretrain. Choose from names in ``litgpt.config``. Mutually exclusive with
-            ``model_config``.
+        model_name: The name of the model to pretrain. Choose from names in ``litgpt.config``. Use "list" to list the supported models.
         model_config: A ``litgpt.Config`` object to define the model architecture. Mutually exclusive with
-            ``model_config``.
+            ``model_config``. Overrides the `model_name` if specified.
         out_dir: Directory in which to save checkpoints and logs. If running in a Lightning Studio Job, look for it in
             /teamspace/jobs/<job-name>/share.
         precision: The precision to use for finetuning. Determines a compatible precision setting by default.
@@ -85,19 +82,38 @@ def setup(
         data: Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
+        optimizer: An optimizer name (such as "AdamW") or config.
+
         devices: How many devices/GPUs to use. Uses all GPUs by default.
         tokenizer_dir: Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
             module require this.
         logger_name: The name of the logger to send metrics to.
         seed: The random seed to use for reproducibility.
     """
+    if model_name == "list":
+        available_models = "\n".join(sorted(name_to_config))
+        print(f"Available values:\n{available_models}")
+        quit()
+
+    if initial_checkpoint_dir is not None:
+        initial_checkpoint_dir = extend_checkpoint_dir(initial_checkpoint_dir)
+
+    if tokenizer_dir is not None:
+        tokenizer_dir = extend_checkpoint_dir(tokenizer_dir)
+
+    if model_config is None:
+        # Support both model_name options: meta-llama/Meta-Llama-3-8B & Meta-Llama-3-8B
+        try:
+            model_config = Config.from_name(model_name)
+        except ValueError:
+            print(f"Model name {model_name} is not supported.\n")
+            available_models = "\n".join(sorted(name_to_config))
+            print(f"Available values:\n{available_models}")
+            quit()
+
     hparams = capture_hparams()
     data = TinyLlama() if data is None else data
-    if model_config is not None and model_name is not None:
-        raise ValueError("Only one of `model_name` or `model_config` can be set.")
-    elif model_config is None and model_name is None:
-        available_models = "\n".join(sorted(name_to_config))
-        raise ValueError(f"Please specify --model_name <model_name>. Available values:\n{available_models}")
+
     config = Config.from_name(model_name) if model_config is None else model_config
     precision = precision or get_default_supported_precision(training=True)
     devices = parse_devices(devices)
@@ -133,6 +149,7 @@ def setup(
         tokenizer,
         train,
         eval,
+        optimizer,
     )
 
 
@@ -149,6 +166,7 @@ def main(
     tokenizer: Optional[Tokenizer],
     train: TrainArgs,
     eval: EvalArgs,
+    optimizer: Union[str, Dict],
 ) -> None:
     validate_args(train, eval, initial_checkpoint_dir, resume)
 
@@ -174,13 +192,8 @@ def main(
     model = torch.compile(model)
     model = fabric.setup(model)
 
-    optimizer = torch.optim.AdamW(
-        model.parameters(),
-        lr=train.learning_rate,
-        weight_decay=train.weight_decay,
-        betas=(train.beta1, train.beta2),
-        fused=fabric.device.type == "cuda",
-    )
+    extra_kwargs = {"fused": fabric.device.type == "cuda"}
+    optimizer = instantiate_torch_optimizer(optimizer, model.parameters(), **extra_kwargs)
     optimizer = fabric.setup_optimizers(optimizer)
 
     train_dataloader, val_dataloader = get_dataloaders(fabric, data, tokenizer, train, model.max_seq_length)
@@ -266,7 +279,7 @@ def fit(
             break
 
         # determine and set the learning rate for this iteration
-        lr = get_lr(train.learning_rate, state["iter_num"], warmup_iters, max_iters, train.min_lr)
+        lr = get_lr(optimizer.defaults["lr"], state["iter_num"], warmup_iters, max_iters, train.min_lr)
         for param_group in optimizer.param_groups:
             param_group["lr"] = lr
 
@@ -341,6 +354,13 @@ def fit(
 
         if train.save_interval is not None and not is_accumulating and state["step_count"] % train.save_interval == 0:
             save_checkpoint(fabric, state, tokenizer_dir, out_dir / f"step-{state['step_count']:08d}" / "lit_model.pth")
+
+    # Final validation
+    if eval.final_validation:
+        val_loss = validate(fabric, model, val_dataloader, max_iters=eval.max_iters)
+        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        fabric.log_dict(metrics, step=state["iter_num"])
+        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
 
 
 @torch.no_grad()
@@ -442,4 +462,3 @@ def validate_args(train: TrainArgs, eval: EvalArgs, initial_checkpoint_dir, resu
         issues.append("Can't provide both `--resume` and `--initial_checkpoint_dir`. Choose one.")
     if issues:
         raise ValueError("\n".join(issues))
-

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -2,6 +2,7 @@
 
 import gc
 import json
+import os
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
@@ -337,10 +338,19 @@ def convert_hf_checkpoint(
 
     # Load the json file containing weight mapping
     pytorch_bin_map_json_path = checkpoint_dir / "pytorch_model.bin.index.json"
+    model_safetensor_map_json_path = checkpoint_dir / "model.safetensors.index.json"
     if pytorch_bin_map_json_path.is_file():  # not all checkpoints have this file
         with open(pytorch_bin_map_json_path, encoding="utf-8") as json_map:
             bin_index = json.load(json_map)
         bin_files = {checkpoint_dir / bin for bin in bin_index["weight_map"].values()}
+    elif model_safetensor_map_json_path.is_file():
+        print(f"Found {model_safetensor_map_json_path} file containing weight mapping!")
+        with open(model_safetensor_map_json_path, encoding="utf-8") as json_map:
+            bin_index = json.load(json_map)
+        bin_files = {
+            checkpoint_dir / os.path.splitext(bin)[0] + ".bin"
+            for bin in bin_index["weight_map"].values()
+        }
     else:
         bin_files = set(checkpoint_dir.glob("*.bin"))
         # some checkpoints serialize the training arguments

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -348,7 +348,7 @@ def convert_hf_checkpoint(
         with open(model_safetensor_map_json_path, encoding="utf-8") as json_map:
             bin_index = json.load(json_map)
         bin_files = {
-            checkpoint_dir / os.path.splitext(bin)[0] + ".bin"
+            checkpoint_dir / (os.path.splitext(bin)[0] + ".bin")
             for bin in bin_index["weight_map"].values()
         }
     else:

--- a/litgpt/scripts/convert_hf_checkpoint.py
+++ b/litgpt/scripts/convert_hf_checkpoint.py
@@ -5,13 +5,19 @@ import json
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedTensor
 
 from litgpt import Config
-from litgpt.utils import incremental_save, lazy_load, save_config
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    lazy_load,
+    incremental_save,
+    save_config
+)
 
 
 def copy_weights_gpt_neox(
@@ -287,8 +293,8 @@ def load_param(param: Union[torch.Tensor, NotYetLoadedTensor], name: str, dtype:
 
 @torch.inference_mode()
 def convert_hf_checkpoint(
+    checkpoint_dir: Path,
     *,
-    checkpoint_dir: Path = Path("checkpoints/stabilityai/stablelm-base-alpha-3b"),
     model_name: Optional[str] = None,
     dtype: Optional[str] = None,
 ) -> None:
@@ -302,6 +308,9 @@ def convert_hf_checkpoint(
         dtype: The data type to convert the checkpoint files to. If not specified, the weights will remain in the
             dtype they are downloaded in.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     if model_name is None:
         model_name = checkpoint_dir.name
     if dtype is not None:

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -3,6 +3,7 @@
 import gc
 from functools import partial
 from pathlib import Path
+from pprint import pprint
 from typing import Dict, Optional, Tuple, Union
 
 import torch
@@ -10,7 +11,11 @@ from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedT
 
 from litgpt import Config
 from litgpt.scripts.convert_hf_checkpoint import layer_template, load_param
-from litgpt.utils import incremental_save, lazy_load
+from litgpt.utils import (
+    extend_checkpoint_dir,
+    incremental_save,
+    lazy_load
+)
 
 
 def copy_weights_falcon(
@@ -241,6 +246,9 @@ def check_conversion_supported(lit_weights: Dict[str, torch.Tensor]) -> None:
 @torch.inference_mode()
 def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     """Convert a LitGPT trained checkpoint into a Hugging Face Transformers checkpoint."""
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/litgpt/scripts/convert_pretrained_checkpoint.py
+++ b/litgpt/scripts/convert_pretrained_checkpoint.py
@@ -1,10 +1,14 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 from pathlib import Path
-
+from pprint import pprint
 import torch
 
-from litgpt.utils import CLI, copy_config_files, incremental_save
+from litgpt.utils import (
+    copy_config_files,
+    extend_checkpoint_dir,
+    incremental_save
+)
 
 
 @torch.inference_mode()
@@ -19,6 +23,8 @@ def convert_pretrained_checkpoint(checkpoint_dir: Path, output_dir: Path) -> Non
         checkpoint_dir: Path to a checkpoint directory produced by ``litgpt.pretrain``.
         output_dir: The output folder where the converted state-dict file and config files will be saved to.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
 
     if output_dir.is_dir() and output_dir.glob("*"):
         raise FileExistsError(

--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -9,14 +9,13 @@ import torch
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint
-from litgpt.utils import CLI
 
 _SAFETENSORS_AVAILABLE = RequirementCache("safetensors")
 _HF_TRANSFER_AVAILABLE = RequirementCache("hf_transfer")
 
 
 def download_from_hub(
-    repo_id: Optional[str] = None,
+    repo_id: str,
     access_token: Optional[str] = os.getenv("HF_TOKEN"),
     tokenizer_only: bool = False,
     convert_checkpoint: bool = True,
@@ -28,6 +27,7 @@ def download_from_hub(
 
     Arguments:
         repo_id: The repository ID in the format ``org/name`` or ``user/name`` as shown in Hugging Face.
+            If "list" is provided as input, a list of the currently supported models in LitGPT and quits.
         access_token: Optional API token to access models with restrictions.
         tokenizer_only: Whether to download only the tokenizer files.
         convert_checkpoint: Whether to convert the checkpoint files to the LitGPT format after downloading.
@@ -37,8 +37,9 @@ def download_from_hub(
         model_name: The existing config name to use for this repo_id. This is useful to download alternative weights of
             existing architectures.
     """
+    print("repo_id:", repo_id)
 
-    if repo_id is None:
+    if repo_id == "list":
         from litgpt.config import configs
 
         options = [f"{config['hf_config']['org']}/{config['hf_config']['name']}" for config in configs]

--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -59,7 +59,7 @@ def download_from_hub(
         elif safetensors:
             if not _SAFETENSORS_AVAILABLE:
                 raise ModuleNotFoundError(str(_SAFETENSORS_AVAILABLE))
-            download_files.append("*.safetensors")
+            download_files.append("*.safetensors*")
             from_safetensors = True
         else:
             raise ValueError(f"Couldn't find weight files for {repo_id}")

--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -2,6 +2,7 @@
 
 """This script merges the LoRA weights with the base model"""
 from pathlib import Path
+from pprint import pprint
 from typing import Any, Dict, Optional, Tuple
 
 import lightning as L
@@ -9,18 +10,22 @@ import torch
 import yaml
 
 from litgpt.lora import GPT, Config, lora_filter, merge_lora_weights
-from litgpt.utils import CLI, check_valid_checkpoint_dir
+from litgpt.utils import check_valid_checkpoint_dir, extend_checkpoint_dir
 
 
 def merge_lora(
-    checkpoint_dir: Path, pretrained_checkpoint_dir: Optional[Path] = None, precision: Optional[str] = None
+    checkpoint_dir: Path,
+    pretrained_checkpoint_dir: Optional[Path] = None,
+    precision: Optional[str] = None
 ) -> None:
-    """Merges the LoRA weights with the base model. See ``litgpt finetune lora``.
+    """Merges the LoRA weights with the base model.
+
+    See ``litgpt finetune lora``.
 
     Creates a new ``lit_model.pth`` file by merging the LoRA weights (``lit_model.pth.lora``)
     with the original checkpoint weights.
 
-    Args:
+    Arguments:
         checkpoint_dir: Path to the checkpoint directory with trained LoRA weights, which is the output of
             ``litgpt finetune lora``.
         pretrained_checkpoint_dir: Optional path to the checkpoint directory with the weights of the base model
@@ -30,6 +35,11 @@ def merge_lora(
         precision: Optional precision setting to instantiate the model weights in. By default, this will
             automatically be inferred from the metadata in the given ``checkpoint_dir`` directory.
     """
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    if pretrained_checkpoint_dir is not None:
+        pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
+    pprint(locals())
+
     check_valid_checkpoint_dir(checkpoint_dir, model_filename="lit_model.pth.lora")
     if pretrained_checkpoint_dir is not None:
         check_valid_checkpoint_dir(pretrained_checkpoint_dir)
@@ -37,8 +47,12 @@ def merge_lora(
         print("LoRA weights have already been merged in this checkpoint.")
         return
 
-    lora_params, pretrained_checkpoint_dir, lora_precision = load_lora_metadata(checkpoint_dir)
+    lora_params, meta_pretrained_checkpoint_dir, lora_precision = load_lora_metadata(checkpoint_dir)
     precision = precision if precision is not None else lora_precision
+
+    if pretrained_checkpoint_dir is None:
+        pretrained_checkpoint_dir = meta_pretrained_checkpoint_dir
+        pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
 
     fabric = L.Fabric(devices=1, precision=precision, accelerator="cpu")
     config = Config.from_file(checkpoint_dir / "model_config.yaml", **lora_params)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.0.dev0"
+version = "0.4.1.dev0"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },
@@ -37,8 +37,8 @@ all = [
     "sentencepiece>=0.2.0",      # llama-based models
     "tokenizers>=0.15.2",        # pythia, falcon, redpajama
     "requests>=2.31.0",          # litgpt.data
-    "litdata>=0.2.6",            # litgpt.data
-    "litserve>=0.1.0",           # litgpt.deploy
+    "litdata==0.2.6",            # litgpt.data
+    "litserve==0.1.1dev0",       # litgpt.deploy
     "zstandard>=0.22.0",         # litgpt.data.prepare_slimpajama.py
     "pandas>=1.9.0",             # litgpt.data.prepare_starcoder.py
     "pyarrow>=15.0.2",           # litgpt.data.prepare_starcoder.py

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -69,12 +69,12 @@ def test_adapter_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path)
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=out_dir,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
@@ -157,14 +157,14 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
             precision="16-true",
             quantize="bnb.nf4-dq",
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=tmp_path,
         )
 

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -86,12 +86,12 @@ def test_adapter_v2_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_pa
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=out_dir,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
@@ -272,14 +272,14 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alp
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["adapter_v2.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
             precision="16-true",
             quantize="bnb.nf4-dq",
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=tmp_path,
         )
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -119,14 +119,14 @@ def test_main(mocked_input, stop_iteration, fake_checkpoint_dir, monkeypatch, te
         call(ANY, tensor_like, 128, temperature=2.0, top_k=2, top_p=0.9, stop_tokens=([tokenizer_mock.return_value.eos_id],))
     ]
     # only the generated result is printed to stdout
-    assert re.match("Now chatting with Llama 3.*>> .*Reply: foo bar baz", out.getvalue(), re.DOTALL)
+    assert re.match(r".*Now chatting with Llama 3.*>> .*Reply: foo bar baz", out.getvalue(), re.DOTALL)
 
 
 def test_cli():
     args = ["litgpt", "chat", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "Starts a conversation" in output
+    assert "Chat with a model" in output
 
 
 @patch("litgpt.chat.base.input")
@@ -148,5 +148,5 @@ def test_merge_lora_if_needed(mocked_merge_lora, mocked_input, fake_checkpoint_d
     with redirect_stdout(out), redirect_stderr(err):
         chat.main(checkpoint_dir=fake_checkpoint_dir)
 
-    assert re.match("Merging LoRA weights with the base model.", out.getvalue(), re.DOTALL)
+    assert re.match(r".*Merging LoRA weights with the base model\..*", out.getvalue(), re.DOTALL)
     mocked_merge_lora.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,10 @@ def test_cli():
         main()
     out = out.getvalue()
     assert "usage: litgpt" in out
-    assert "{download,chat,finetune,pretrain,generate,convert,merge_lora,evaluate,serve}" in out
+    assert ("{download,chat,finetune,finetune_lora,finetune_full,finetune_adapter,finetune_adapter_v2,"
+            "pretrain,generate,generate_full,generate_adapter,generate_adapter_v2,generate_sequentially,"
+            "generate_tp,convert_to_litgpt,convert_from_litgpt,convert_pretrained_checkpoint,"
+            "merge_lora,evaluate,serve}" in out)
     assert (
         """Available subcommands:
     download            Download weights or tokenizer data from the Hugging
@@ -24,9 +27,9 @@ def test_cli():
         in out
     )
     assert """evaluate            Evaluate a model with the LM Evaluation Harness.""" in out
-    assert """serve               Serve and deploy a model with LitServe.""" in out
+    assert """serve               Serve a LitGPT model using LitServe.""" in out
     out = StringIO()
-    with pytest.raises(SystemExit), redirect_stdout(out), mock.patch("sys.argv", ["litgpt", "finetune", "lora", "-h"]):
+    with pytest.raises(SystemExit), redirect_stdout(out), mock.patch("sys.argv", ["litgpt", "finetune_lora", "-h"]):
         main()
     out = out.getvalue()
     assert (
@@ -57,6 +60,6 @@ def test_rewrite_finetune_command():
     with pytest.raises(SystemExit), redirect_stdout(out1), mock.patch("sys.argv", ["litgpt", "fineune", "-h"]):
         main()
     out2 = StringIO()
-    with pytest.raises(SystemExit), redirect_stdout(out2), mock.patch("sys.argv", ["litgpt", "fineune", "lora", "-h"]):
+    with pytest.raises(SystemExit), redirect_stdout(out2), mock.patch("sys.argv", ["litgpt", "fineune_lora", "-h"]):
         main()
     assert out1.getvalue() == out2.getvalue()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,7 +30,14 @@ def test_from_hf_name():
     config0 = Config.from_name("tiny-llama-1.1b")
     # or by huggingface hub repo name
     config1 = Config.from_name("TinyLlama-1.1B-intermediate-step-1431k-3T")
+    assert config0 is not None
+    assert config1 is not None
     assert config0 == config1
+
+
+def test_nonexisting_name():
+    with pytest.raises(ValueError, match="'invalid-model-name' is not a supported config name"):
+        Config.from_name("invalid-model-name")
 
 
 @pytest.mark.parametrize("config", config_module.configs, ids=[c["name"] for c in config_module.configs])
@@ -42,9 +49,21 @@ def test_short_and_hf_names_are_equal_unless_on_purpose(config):
     assert config0.name == config1.name
 
 
-def test_nonexisting_name():
-    with pytest.raises(ValueError, match="not a supported"):
-        Config.from_name("foobar")
+def test_from_hf_name_with_org_string():
+    # Test case 1: valid input
+    config0 = Config.from_name("tiny-llama-1.1b")
+    config1 = Config.from_name("TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T")
+    assert config0 is not None
+    assert config1 is not None
+    assert config0 == config1
+
+    # Test case 2: invalid input - org not found
+    with pytest.raises(ValueError, match="'UnknownOrg/TinyLlama-1.1B-intermediate-step-1431k-3T' is not a supported config name"):
+        Config.from_name("UnknownOrg/TinyLlama-1.1B-intermediate-step-1431k-3T")
+
+    # Test case 3: invalid input - name not found
+    with pytest.raises(ValueError, match="'TinyLlama/TinyLlama-XYZ' is not a supported config name"):
+        Config.from_name("TinyLlama/TinyLlama-XYZ")
 
 
 def test_from_checkpoint(tmp_path):
@@ -82,3 +101,5 @@ def test_head_size(head_size):
     config = Config(head_size)
 
     assert config.head_size == head_size or config.n_embd // config.n_head
+
+

--- a/tests/test_config_hub.py
+++ b/tests/test_config_hub.py
@@ -16,7 +16,7 @@ fixed_pairs = [
     ("litgpt/pretrain.py", "pretrain/tinystories.yaml"),
     (
         "litgpt/pretrain.py",
-        "https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/pretrain/tinystories.yaml",
+        "https://raw.githubusercontent.com/Lightning-AI/litgpt/4d55ab6d0aa404f0da0d03a80a8801ed60e07e83/config_hub/pretrain/tinystories.yaml",  # TODO: Update with path from main after merge
     ),
 ]
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import pytest
 import subprocess
 from contextlib import redirect_stdout
 from dataclasses import asdict
@@ -20,18 +21,45 @@ def test_evaluate_script(tmp_path):
     checkpoint_dir = tmp_path / "EleutherAI" / "pythia-14m"
     ours_model = GPT(ours_config)
     torch.save(ours_model.state_dict(), checkpoint_dir / "lit_model.pth")
-    with open( checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
+    with open(checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
         yaml.dump(asdict(ours_config), fp)
 
     stdout = StringIO()
     with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
+        with pytest.raises(ValueError) as excinfo:
+            module.convert_and_evaluate(
+                checkpoint_dir,
+                out_dir=tmp_path / "out_dir",
+                device=None,
+                dtype=torch.float32,
+                limit=5,
+                tasks="mathqa",
+                batch_size=0  # Test for non-positive integer
+            )
+        assert "batch_size must be a positive integer, 'auto', or in the format 'auto:N'." in str(excinfo.value)
+
+        with pytest.raises(ValueError) as excinfo:
+            module.convert_and_evaluate(
+                checkpoint_dir,
+                out_dir=tmp_path / "out_dir",
+                device=None,
+                dtype=torch.float32,
+                limit=5,
+                tasks="mathqa",
+                batch_size="invalid"  # Test for invalid string
+            )
+        assert "batch_size must be a positive integer, 'auto', or in the format 'auto:N'." in str(excinfo.value)
+
+    stdout = StringIO()
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["eval/evaluate.py"]):
         module.convert_and_evaluate(
-            checkpoint_dir=checkpoint_dir,
+            checkpoint_dir,
             out_dir=tmp_path / "out_dir",
             device=None,
             dtype=torch.float32,
             limit=5,
-            tasks="mathqa"
+            tasks="mathqa",
+            batch_size=1  # Valid case
         )
     stdout = stdout.getvalue()
     assert (tmp_path / "out_dir" / "results.json").is_file()
@@ -44,4 +72,4 @@ def test_cli():
     args = ["litgpt", "evaluate", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "run the LM Evaluation Harness" in output
+    assert "Evaluate a model with the LM Evaluation Harness" in output

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import re
 import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -77,17 +78,19 @@ def test_main(fake_checkpoint_dir, monkeypatch, tensor_like):
         == [call(ANY, tensor_like, 53, temperature=2.0, top_k=2, top_p=0.9, eos_id=tokenizer_mock.return_value.eos_id)]
         * num_samples
     )
-    # only the generated result is printed to stdout
-    assert out.getvalue() == "foo bar baz\n" * num_samples
+    expected_output = "foo bar baz\n" * num_samples
+    # Allow for the config to be printed before the expected repeated strings.
+    pattern = rf".*^{re.escape(expected_output.strip())}$.*"
+    assert re.match(pattern, out.getvalue().strip(), re.DOTALL | re.MULTILINE)
 
     assert "'padded_vocab_size': 512, 'n_layer': 2, 'n_head': 4" in err.getvalue()
 
 
 def test_cli():
-    args = ["litgpt", "generate", "base", "-h"]
+    args = ["litgpt", "generate", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "Generates text samples" in output
+    assert "Default generation option" in output
 
 
 @pytest.mark.parametrize("temperature", (0.0, 1.0, 0.5))

--- a/tests/test_generate_adapter.py
+++ b/tests/test_generate_adapter.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import re
 import subprocess
 import sys
 from contextlib import redirect_stderr, redirect_stdout
@@ -41,15 +42,18 @@ def test_main(fake_checkpoint_dir, monkeypatch, version, tensor_like):
     assert len(tokenizer_mock.return_value.decode.mock_calls) == num_samples
     assert torch.allclose(tokenizer_mock.return_value.decode.call_args[0][0], generate_mock.return_value)
     assert generate_mock.mock_calls == [call(ANY, tensor_like, 101, temperature=2.0, top_k=2, top_p=0.9, eos_id=ANY)] * num_samples
-    # only the generated result is printed to stdout
-    assert out.getvalue() == "foo bar baz\n" * num_samples
+
+    expected_output = "foo bar baz\n" * num_samples
+    # Allow for the config to be printed before the expected repeated strings.
+    pattern = rf".*^{re.escape(expected_output.strip())}$.*"
+    assert re.match(pattern, out.getvalue().strip(), re.DOTALL | re.MULTILINE)
 
     assert "'padded_vocab_size': 512, 'n_layer': 2, 'n_head': 4, 'head_size': 2, 'n_embd': 8" in err.getvalue()
 
 
 @pytest.mark.parametrize("version", ("", "_v2"))
 def test_cli(version):
-    args = ["litgpt", "generate", f"adapter{version}", "-h"]
+    args = ["litgpt", f"generate_adapter{version}", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "Generates a response" in output
+    assert "For models finetuned with" in output

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -278,24 +278,22 @@ def test_base_with_sequentially(tmp_path):
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 
     args = [
+        str(checkpoint_dir),
         "--num_samples=1",
         "--max_new_tokens=10",
         "--precision=16-true",
         "--temperature=0.0",
-        f"--checkpoint_dir={str(checkpoint_dir)}",
     ]
     env = {"CUDA_VISIBLE_DEVICES": "0,1"}
-    base_stdout = subprocess.check_output([sys.executable, "-m", "litgpt", "generate", "base", *args], env=env, cwd=root).decode()
     sequential_stdout = subprocess.check_output(
-        [sys.executable, "-m", "litgpt", "generate", "sequentially", *args], env=env, cwd=root,
+        [sys.executable, "-m", "litgpt", "generate_sequentially", *args], env=env, cwd=root,
     ).decode()
 
-    assert base_stdout.startswith("What food do llamas eat?")
-    assert base_stdout == sequential_stdout
+    assert "What food do llamas eat?" in sequential_stdout
 
 
 def test_cli():
-    args = ["litgpt", "generate", "sequentially", "-h"]
+    args = ["litgpt", "generate_sequentially", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "Generates text samples" in output
+    assert "Generation script that partitions layers across" in output

--- a/tests/test_generate_tp.py
+++ b/tests/test_generate_tp.py
@@ -117,21 +117,21 @@ def test_tp(tmp_path):
     torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
 
     args = [
+        str(checkpoint_dir),
         "--num_samples=1",
         "--max_new_tokens=10",
         "--precision=16-true",
         "--temperature=0.0",
-        f"--checkpoint_dir={str(checkpoint_dir)}",
     ]
     env = {"CUDA_VISIBLE_DEVICES": "0,1"}
-    tp_stdout = subprocess.check_output([sys.executable, "-m", "litgpt", "generate", "tp", *args], env=env, cwd=root).decode()
+    tp_stdout = subprocess.check_output([sys.executable, "-m", "litgpt", "generate_tp", *args], env=env, cwd=root).decode()
 
     # there is some unaccounted randomness so cannot compare the output with that of `generate/base.py`
-    assert tp_stdout.startswith("What food do llamas eat?")
+    assert "What food do llamas eat?" in tp_stdout
 
 
 def test_cli():
-    args = ["litgpt", "generate", "tp", "-h"]
+    args = ["litgpt", "generate_tp", "-h"]
     output = subprocess.check_output(args)
     output = str(output.decode())
-    assert "Generates text samples" in output
+    assert "Generation script that uses tensor parallelism" in output

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -192,12 +192,12 @@ def test_lora_script(tmp_path, fake_checkpoint_dir, monkeypatch, alpaca_path):
 
     out_dir = tmp_path / "out"
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["lora.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["lora.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=out_dir,
             precision="32-true",
             train=TrainArgs(global_batch_size=1, save_interval=2, epochs=1, max_steps=6, micro_batch_size=1),
@@ -655,12 +655,12 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
     monkeypatch.setattr(module, "fit", train_mock)
 
     stdout = StringIO()
-    with redirect_stdout(stdout), mock.patch("sys.argv", ["full.py"]):
+    with redirect_stdout(stdout), mock.patch("sys.argv", ["full.py", str(fake_checkpoint_dir)]):
         module.setup(
+            fake_checkpoint_dir,
             data=Alpaca(
                 download_dir=alpaca_path.parent, file_name=alpaca_path.name, val_split_fraction=0.5, num_workers=0
             ),
-            checkpoint_dir=fake_checkpoint_dir,
             out_dir=tmp_path,
             precision="16-true",
             quantize="bnb.nf4-dq",

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 import os
+from unittest import mock
+
 import pytest
 import requests
 import subprocess
@@ -38,7 +40,7 @@ def run_command(command):
 @pytest.mark.dependency()
 def test_download_model():
     repo_id = str(REPO_ID).replace("\\", "/")  # fix for Windows CI
-    command = ["litgpt", "download", "--repo_id", str(repo_id)]
+    command = ["litgpt", "download", str(repo_id)]
     output = run_command(command)
 
     s = Path("checkpoints") / repo_id
@@ -60,14 +62,16 @@ def test_download_books():
         assert (CUSTOM_TEXTS_DIR / filename).exists(), f"{filename} not downloaded"
 
 
+@mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model"])
 def test_chat_with_model():
-    command = ["litgpt", "generate", "base", "--checkpoint_dir", f"checkpoints"/REPO_ID]
+    command = ["litgpt", "generate", f"checkpoints" / REPO_ID]
     prompt = "What do Llamas eat?"
     result = subprocess.run(command, input=prompt, text=True, capture_output=True, check=True)
     assert "What food do llamas eat?" in result.stdout
 
 
+@mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model"])
 @pytest.mark.timeout(300)
 def test_finetune_model():
@@ -82,8 +86,8 @@ def test_finetune_model():
     assert DATASET_PATH.exists(), "Dataset file not downloaded"
 
     finetune_command = [
-        "litgpt", "finetune", "lora",
-        "--checkpoint_dir", str(CHECKPOINT_DIR),
+        "litgpt", "finetune_lora",
+        str(CHECKPOINT_DIR),
         "--lora_r", "1",
         "--data", "JSON",
         "--data.json_path", str(DATASET_PATH),
@@ -97,12 +101,13 @@ def test_finetune_model():
     assert (OUT_DIR/"final"/"lit_model.pth").exists(), "Model file was not created"
 
 
+@mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])
 def test_pretrain_model():
     OUT_DIR = Path("out") / "custom_pretrained"
     pretrain_command = [
         "litgpt", "pretrain",
-        "--model_name", "pythia-14m",
+        "pythia-14m",
         "--tokenizer_dir", str("checkpoints" / REPO_ID),
         "--data", "TextFiles",
         "--data.train_data_path", str(CUSTOM_TEXTS_DIR),
@@ -116,12 +121,13 @@ def test_pretrain_model():
     assert (OUT_DIR / "final" / "lit_model.pth").exists(), "Model file was not created"
 
 
+@mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])
 def test_continue_pretrain_model():
     OUT_DIR = Path("out") / "custom_continue_pretrained"
     pretrain_command = [
         "litgpt", "pretrain",
-        "--model_name", "pythia-14m",
+        "pythia-14m",
         "--initial_checkpoint", str("checkpoints" / REPO_ID),
         "--tokenizer_dir", str("checkpoints" / REPO_ID),
         "--data", "TextFiles",
@@ -140,8 +146,7 @@ def test_continue_pretrain_model():
 def test_serve():
     CHECKPOINT_DIR = str("checkpoints" / REPO_ID)
     run_command = [
-        "litgpt", "serve",
-        "--checkpoint_dir", str(CHECKPOINT_DIR)
+        "litgpt", "serve", str(CHECKPOINT_DIR)
     ]
 
     process = None

--- a/tests/test_thunder_pretrain.py
+++ b/tests/test_thunder_pretrain.py
@@ -37,6 +37,7 @@ def test_pretrain(tmp_path, monkeypatch):
             out_dir=out_dir,
             train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1, max_norm=1.0),
             eval=EvalArgs(interval=1, max_iters=1),
+            optimizer="AdamW",
         )
 
     out_dir_contents = set(os.listdir(out_dir))

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -50,7 +50,7 @@ However, if you feel adventurous and want to pretrain your own LLM, here's how.
 First, we have to decide which type of model architecture we want to use. We list the available architectures by using the `pretrain` command without any additional arguments:
 
 ```bash
-litgpt pretrain
+litgpt pretrain list
 ```
 
 This prints a list of all available model architectures in alphabetical order:
@@ -60,7 +60,8 @@ Camel-Platypus2-13B
 Camel-Platypus2-70B
 CodeLlama-13b-Python-hf
 ...
-tiny-llama-1.1b
+EleutherAI/pythia-410m
+...
 vicuna-13b-v1.3
 vicuna-13b-v1.5
 vicuna-13b-v1.5-16k
@@ -72,12 +73,12 @@ vicuna-7b-v1.5-16k
 
 Suppose we want to pretraining the 1.1B parameter small `tiny-llama-1.1b` model. Before starting finetuning, we must also choose and download a tokenizer. 
 
-We can download a tokenizer via the `download` command. Note that running `litgpt download` without any additional arguments will also print a list of all available models and tokenizers to download. 
+We can download a tokenizer via the `download` command. Note that running `litgpt download list` will also print a list of all available models and tokenizers to download. 
 
 To filter for specific models, e.g., TinyLlama, we can use the `grep` command in our terminal:
 
 ```bash
-litgpt download | grep  TinyLlama
+litgpt download list | grep  TinyLlama
 ```
 
 This prints
@@ -87,13 +88,15 @@ TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 TinyLlama/TinyLlama-1.1B-Chat-v1.0
 ```
 
-Let's now download the tokenizer corresponding to `TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T` that we can then use to pretrain the TinyLlama model, which saves the download tokenizer to a `checkpoints/` folder by default:
+Let's now download the tokenizer corresponding to `TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T` that we can then use to pretrain the TinyLlama model:
 
 ```
 litgpt download \
-   --repo_id TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
+   TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
    --tokenizer_only true
 ```
+
+(when specif)
 
 &nbsp;
 
@@ -104,10 +107,9 @@ litgpt download \
 Next, we can pretrain the model on the OpenWebText dataset with the default setting as follows:
 
 ```bash
-litgpt pretrain \
-  --model_name tiny-llama-1.1b \
+litgpt pretrain tiny-llama-1.1b \
   --data OpenWebText \
-  --tokenizer_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
+  --tokenizer_dir TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
 ```
 
 If you are interested in additional settings, you can use the help command as follows:
@@ -137,10 +139,10 @@ litgpt pretrain --help
 &nbsp;
 ## Download pretrained model weights
 
-Most practical use cases, like LLM inference (/chat) or finetuning, involve using pretrained model weights. LitGPT supports a large number of model weights, which can be listed by executing the `download` command without any additional arguments:
+Most practical use cases, like LLM inference (/chat) or finetuning, involve using pretrained model weights. LitGPT supports a large number of model weights, which can be listed by executing the `download` with `list` as an argument:
 
 ```bash
-litgpt download
+litgpt download list
 ```
 
 This will print a (long) list of all supported pretrained models (abbreviated for readability below):
@@ -157,10 +159,10 @@ mistralai/Mixtral-8x7B-Instruct-v0.1
 ...
 ```
 
-To download the model weights, provide one of the model strings above as a `--repo_id` argument:
+To download the model weights, provide one of the model strings above as input argument:
 
 ```bash
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 ```
 
 ```
@@ -204,7 +206,7 @@ total 11G
 The model is now ready for inference and chat, for example, using the `chat` command on the checkpoint directory:
 
 ```bash
-litgpt chat --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt chat microsoft/phi-2
 ```
 
 ```
@@ -262,7 +264,7 @@ In the following example, we will use LoRA for finetuning, which is one of the m
 Before we start, we have to download a model as explained in the previous "Download pretrained model" section above:
 
 ```bash
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 ```
 
 The LitGPT interface can be used via command line arguments and configuration files. We recommend starting with the configuration files from the [config_hub](../config_hub) and either modifying them directly or overriding specific settings via the command line. For example, we can use the following setting to train the downloaded 2.7B parameter `microsoft/phi-2` model, where we set `--max_steps 5` for a quick test run.
@@ -270,7 +272,7 @@ The LitGPT interface can be used via command line arguments and configuration fi
 If you have downloaded or cloned the LitGPT repository, you can provide the `config` file via a relative path:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora microsoft/phi-2\
   --config config_hub/finetune/phi-2/lora.yaml \
   --train.max_steps 5
 ```
@@ -278,7 +280,7 @@ litgpt finetune lora \
 Alternatively, you can provide a URL:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora microsoft/phi-2\
   --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/finetune/phi-2/lora.yaml \
   --train.max_steps 5
 ```
@@ -289,14 +291,14 @@ litgpt finetune lora \
 
 > [!TIP]
 > Note that the config file above will finetune the model on the `Alpaca2k` dataset on 1 GPU and save the resulting files in an `out/finetune/lora-phi-2` directory. All of these settings can be changed via a respective command line argument or by changing the config file. 
-> To see more options, execute `litgpt finetune lora --help`.
+> To see more options, execute `litgpt finetune_lora --help`.
 
 &nbsp;
 
 Running the previous finetuning command will initiate the finetuning process, which should only take about a minute on a GPU due to the `--train.max_steps 5` setting.
 
 ```
-{'checkpoint_dir': PosixPath('checkpoints/microsoft/phi-2'),
+{'checkpoint_dir': PosixPath('checkpoints/microsoft/phi-2'),  # TODO
  'data': Alpaca2k(mask_prompt=False,
                   val_split_fraction=0.03847,
                   prompt_style=<litgpt.prompts.Alpaca object at 0x7f5fa2867e80>,
@@ -372,7 +374,7 @@ Saved merged weights to 'out/finetune/lora-phi-2/final/lit_model.pth'
 Notice that the LoRA script saves both the LoRA weights (`'out/finetune/lora-phi-2/final/lit_model.pth.lora'`) and the LoRA weight merged back into the original model (`'out/finetune/lora-phi-2/final/lit_model.pth'`) for convenience. This allows us to use the finetuned model via the `chat` function directly:
 
 ```bash
-litgpt chat --checkpoint_dir out/finetune/lora-phi-2/final/
+litgpt chat out/finetune/lora-phi-2/final/
 ```
 
 ```
@@ -408,7 +410,7 @@ Time for inference: 2.15 sec total, 39.57 tokens/sec, 85 tokens
 To use a downloaded or finetuned model for chat, you only need to provide the corresponding checkpoint directory containing the model and tokenizer files. For example, to chat with the phi-2 model from Microsoft, download it as follows, as described in the "Download pretrained model" section:
 
 ```bash
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 ```
 
 ```
@@ -429,7 +431,7 @@ Saving converted checkpoint to checkpoints/microsoft/phi-2
 Then, chat with the model using the following command:
 
 ```bash
-litgpt chat --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt chat microsoft/phi-2
 ```
 
 ```
@@ -459,9 +461,10 @@ Time for inference: 1.14 sec total, 26.26 tokens/sec, 30 tokens
 
 LitGPT comes with a handy `litgpt evaluate` command to evaluate models with [Eleuther AI's Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness). For example, to evaluate the previously downloaded `microsoft/phi-2` model on several tasks available from the Evaluation Harness, you can use the following command:
 
+- TODO: Explain root dir
+
 ```bash
-litgpt evaluate \
-  --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt evaluate microsoft/phi-2
   --batch_size 16 \
   --tasks "hellaswag,gsm8k,truthfulqa_mc2,mmlu,winogrande,arc_challenge"
 ```
@@ -477,10 +480,10 @@ You can deploy LitGPT LLMs using your tool of choice. Below is an example using 
 
 ```bash
 # 1) Download a pretrained model (alternatively, use your own finetuned model)
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 
 # 2) Start the server
-litgpt serve --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 ```python
@@ -510,14 +513,10 @@ Output: Example input.
 &nbsp;
 ## Converting LitGPT model weights to `safetensors` format
 
-Sometimes, it can be useful to convert LitGPT model weights for third-party and external tools. For example, we can convert a LitGPT model to the Hugging Face format and save it via `.safetensors` files.
-
-The `--checkpoint_dir` argument provided below points to a directory corresponding to a downloaded or finetuned model (see the *Download pretrained model* or *Finetune LLMs* sections above for more information):
-
+Sometimes, it can be useful to convert LitGPT model weights for third-party and external tools. For example, we can convert a LitGPT model to the Hugging Face format and save it via `.safetensors` files, which we can do as follows:
 
 ```bash
-litgpt convert from_litgpt \
-    --checkpoint_dir checkpoints/microsoft/phi-2 \
+litgpt convert_from_litgpt microsoft/phi-2 \
     --output_dir out/converted_model/
 ```
 

--- a/tutorials/convert_hf_checkpoint.md
+++ b/tutorials/convert_hf_checkpoint.md
@@ -1,9 +1,9 @@
 # Converting Hugging Face Transformers to LitGPT weights
 
-By default, the `litgpt/scripts/download.py` script converts the downloaded HF checkpoint files into a LitGPT compatible format after downloading. For example,
+By default, the `litgpt download` command converts the downloaded HF checkpoint files into a LitGPT compatible format after downloading. For example,
 
 ```bash
-litgpt download --repo_id EleutherAI/pythia-14m
+litgpt download EleutherAI/pythia-14m
 ```
 
 creates the following files:
@@ -23,13 +23,12 @@ checkpoints/
 
 
 
-To disable the automatic conversion, which is useful for development and debugging purposes, you can run the `litgpt/scripts/download.py` with the `--convert_checkpoint false` flag. This will only download the checkpoint files but do not convert them for use in LitGPT:
+To disable the automatic conversion, which is useful for development and debugging purposes, you can run the `litgpt download` with the `--convert_checkpoint false` flag. This will only download the checkpoint files but do not convert them for use in LitGPT:
 
 ```bash
 rm -rf checkpoints/EleutherAI/pythia-14m
 
-litgpt download \
-  --repo_id EleutherAI/pythia-14m \
+litgpt download EleutherAI/pythia-14m \
   --convert_checkpoint false
 
 ls checkpoints/EleutherAI/pythia-14m
@@ -49,6 +48,5 @@ ls checkpoints/EleutherAI/pythia-14m
 The required files `model_config.yaml` and `lit_model.pth` files can then be manually generated via the `litgpt/scripts/convert_hf_checkpoint.py` script:
 
 ```bash
-litgpt convert to_litgpt \
-  --checkpoint_dir checkpoints/EleutherAI/pythia-14m
+litgpt convert_to_litgpt checkpoints/EleutherAI/pythia-14m
 ```

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -2,15 +2,14 @@
 
 LitGPT weights need to be converted to a format that Hugging Face understands with a [conversion script](../litgpt/scripts/convert_lit_checkpoint.py) before our scripts can run.
 
-We provide a helpful script to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
+We provide a helpful command to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
 
 ```sh
-litgpt convert from_litgpt \
-    --checkpoint_dir checkpoint_dir \
+litgpt convert_from_litgpt checkpoint_dir \
     --output_dir converted_dir
 ```
 
-These paths are just placeholders, you will need to customize them based on which finetuning or pretraining script you ran and its configuration.
+These paths are just placeholders, you will need to customize them based on which finetuning or pretraining command you ran and its configuration.
 
 ### Loading converted LitGPT checkpoints into transformers
 
@@ -44,11 +43,10 @@ model = AutoModel.from_pretrained("online_repo_id", state_dict=state_dict)
 
 ### Merging LoRA weights
 
-Please note that if you want to convert a model that has been fine-tuned using an adapter like LoRA, these weights should be [merged](../litgpt/scripts/merge_lora.py) to the checkpoint prior to converting.
+Please note that if you want to convert a model that has been finetuned using an adapter like LoRA, these weights should be [merged](../litgpt/scripts/merge_lora.py) to the checkpoint prior to converting.
 
 ```sh
-litgpt merge_lora \
-    --checkpoint_dir path/to/lora/checkpoint_dir
+litgpt merge_lora path/to/lora/checkpoint_dir
 ```
 
 <br>
@@ -73,7 +71,7 @@ by running `litgpt/scripts/download.py` without any additional arguments.
 Then, we download the model we specified via `$repo_id` above:
 
 ```bash
-litgpt download --repo_id $repo_id
+litgpt download $repo_id
 ```
 
 2. Finetune the model:
@@ -82,8 +80,7 @@ litgpt download --repo_id $repo_id
 ```bash
 export finetuned_dir=out/lit-finetuned-model
 
-litgpt finetune lora \
-   --checkpoint_dir checkpoints/$repo_id \
+litgpt finetune_lora $repo_id \
    --out_dir $finetuned_dir \
    --train.epochs 1 \
    --data Alpaca
@@ -94,16 +91,14 @@ litgpt finetune lora \
 Note that this step only applies if the model was finetuned with `lora.py` above and not when `full.py` was used for finetuning.
 
 ```bash
-litgpt merge_lora \
-    --checkpoint_dir $finetuned_dir/final
+litgpt merge_lora $finetuned_dir/final
 ```
 
 
 4. Convert the finetuning model back into a HF format:
 
 ```bash
-litgpt convert from_litgpt \
-   --checkpoint_dir $finetuned_dir/final/ \
+litgpt convert from_litgpt $finetuned_dir/final/ \
    --output_dir out/hf-tinyllama/converted \
 ```
 

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -14,10 +14,10 @@ This section illustrates how we can set up an inference server for a phi-2 LLM u
 
 ```bash
 # 1) Download a pretrained model (alternatively, use your own finetuned model)
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 
 # 2) Start the server
-litgpt serve --checkpoint_dir checkpoints/microsoft/phi-2
+litgpt serve microsoft/phi-2
 ```
 
 > [!TIP]

--- a/tutorials/developer-docs/README.md
+++ b/tutorials/developer-docs/README.md
@@ -1,0 +1,1 @@
+LitGPT developer documentation files.

--- a/tutorials/developer-docs/python-api.md
+++ b/tutorials/developer-docs/python-api.md
@@ -1,0 +1,108 @@
+# LitGPT High-level Python API
+
+This is a work-in-progress draft for a high-level LitGPT Pyhon API.
+
+&nbsp;
+## Model loading & saving
+
+The `LLM.load` command loads an `llm` object, which contains both the model object (a PyTorch module) and a preprocessor.
+
+```python
+from litgpt import LLM
+
+llm = LLM.load(
+    source="url | local_path",
+    # high-level user only needs to care about those:
+    memory_reduction="none | medium | strong"
+    # advanced options for technical users:
+    hub="hf | local | other"
+    quantize="bnb.nf4",
+    precision="bf16-true",
+    device=""auto | cuda | cpu",
+)
+```
+
+Here,
+
+-  `llm.model` contains the PyTorch Module
+- and `llm.preprocessor.tokenizer`  contains the tokenizer
+
+The `llm.save` command saves the model weights, tokenizer, and configuration information.
+
+
+```python
+llm.save(checkpoint_dir, format="lightning | ollama | hf")
+```
+
+
+&nbsp;
+## Inference / Chat
+
+```
+response = llm.generate(
+    prompt="What do Llamas eat?",
+    temperature=0.1,
+    top_p=0.8,
+    ...
+)
+```
+
+
+&nbsp;
+## Dataset
+
+The `llm.prepare_dataset` command prepares a dataset for training.
+
+```
+llm.download_dataset(
+    URL,
+    ...
+)
+```
+
+```
+dataset = llm.prepare_dataset(
+    path,
+    task="pretrain | instruction_finetune",
+    test_portion=0.1,
+    ...
+)
+```
+
+&nbsp;
+## Training
+
+
+```python
+llm.instruction_finetune(
+    config=None,
+    dataset=dataset,
+    max_iter=10,
+    method="full | lora | adapter | adapter_v2"
+)
+```
+
+```python
+llm.pretrain(config=None, dataset=dataset, max_iter=10, ...)
+```
+
+&nbsp;
+## Serving
+
+
+```python
+llm.serve(port=8000)
+```
+
+Then in another Python session:
+
+```python
+import requests, json
+
+response = requests.post(
+    "http://127.0.0.1:8000/predict", 
+    json={"prompt": "Fix typos in the following sentence: Exampel input"}
+)
+
+print(response.json()["output"])
+```

--- a/tutorials/download_model_weights.md
+++ b/tutorials/download_model_weights.md
@@ -1,32 +1,37 @@
 # Download Model Weights with LitGPT
 
-LitGPT supports a variety of LLM architectures with publicly available weights. You can download model weights and access a list of supported models using the LitGPT `download.py` script.
+LitGPT supports a variety of LLM architectures with publicly available weights. You can download model weights and access a list of supported models using the `litgpt download list` command.
 
-| Model                                        | Model size                              | Reference                                                                                                                |
-|----------------------------------------------|-----------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| CodeGemma by Google                          | 7B                                      | [Google Team, Google Deepmind](https://ai.google.dev/gemma/docs/codegemma)                                                             |
-| Code Llama by Meta AI                        | 7B, 13B, 34B, 70B                       | [Rozière et al. 2023](https://arxiv.org/abs/2308.12950)                                                                  |
-| Danube2 by H2O.ai                            | 1.8B                                    | [H2O.ai](https://h2o.ai/platform/danube-1-8b/)
-| Dolly by Databricks                          | 3B, 7B, 12B                             | [Conover et al. 2023](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm) |
-| Falcon by TII UAE                            | 7B, 40B, 180B                           | [TII 2023](https://falconllm.tii.ae)                                                                                     |
-| FreeWilly2 (Stable Beluga 2) by Stability AI | 70B                                     | [Stability AI 2023](https://stability.ai/blog/stable-beluga-large-instruction-fine-tuned-models)                         |
-| Function Calling Llama 2 by Trelis           | 7B                                      | [Trelis et al. 2023](https://huggingface.co/Trelis/Llama-2-7b-chat-hf-function-calling-v2)                               |
-| Gemma by Google                              | 2B, 7B                                  | [Google Team, Google Deepmind](https://storage.googleapis.com/deepmind-media/gemma/gemma-report.pdf)                     |
-| Llama 2 by Meta AI                           | 7B, 13B, 70B                            | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)                                                                  |
-| Llama 3 by Meta AI                           | 8B, 70B                                 | [Meta AI 2024](https://github.com/meta-llama/llama3)                                                                     |
-| LongChat by LMSYS                            | 7B, 13B                                 | [LongChat Team 2023](https://lmsys.org/blog/2023-06-29-longchat/)                                                        |
-| Mistral and Mixtral by Mistral AI            | 7B                                      | [Mistral website](https://mistral.ai/)                                                                                   |
-| Nous-Hermes by NousResearch                  | 7B, 13B, 70B                            | [Org page](https://huggingface.co/NousResearch)                                                                          |
-| OpenLLaMA by OpenLM Research                 | 3B, 7B, 13B                             | [Geng & Liu 2023](https://github.com/openlm-research/open_llama)                                                         |
-| Phi by Microsoft Research                    | 1.3B, 2.7B                              | [Li et al. 2023](https://arxiv.org/abs/2309.05463)                                                                       |
-| Platypus by Lee at el.                       | 7B, 13B, 70B                            | [Lee, Hunter, and Ruiz 2023](https://arxiv.org/abs/2308.07317)                                                           |
-| Pythia by EleutherAI                         | {14,31,70,160,410}M, {1,1.4,2.8,6.9,12}B | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)                                                                 |
-| RedPajama-INCITE by Together                 | 3B, 7B                                  | [Together 2023](https://together.ai/blog/redpajama-models-v1)                                                            |
-| StableCode by Stability AI                   | 3B                                      | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                       |
-| StableLM by Stability AI                     | 3B, 7B                                  | [Stability AI 2023](https://github.com/Stability-AI/StableLM)                                                            |
-| StableLM Zephyr by Stability AI              | 3B                                      | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                       |
-| TinyLlama by Zhang et al.                    | 1.1B                                    | [Zhang et al. 2023](https://github.com/jzhang38/TinyLlama)                                                               |
-| Vicuna by LMSYS                              | 7B, 13B, 33B                            | [Li et al. 2023](https://lmsys.org/blog/2023-03-30-vicuna/)                                                              |
+&nbsp;
+
+
+| Model | Model size | Author | Reference |
+|----|----|----|----|
+| CodeGemma | 7B | Google | [Google Team, Google Deepmind](https://ai.google.dev/gemma/docs/codegemma)                                                                 |
+| Code Llama | 7B, 13B, 34B, 70B | Meta AI | [Rozière et al. 2023](https://arxiv.org/abs/2308.12950)                                                                   |
+| Danube2 | 1.8B | H2O.ai | [H2O.ai](https://h2o.ai/platform/danube-1-8b/)                                                                                             |
+| Dolly | 3B, 7B, 12B | Databricks | [Conover et al. 2023](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm)      |
+| Falcon | 7B, 40B, 180B | TII UAE | [TII 2023](https://falconllm.tii.ae)                                                                                              |
+| FreeWilly2 (Stable Beluga 2) | 70B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stable-beluga-large-instruction-fine-tuned-models)                 |
+| Function Calling Llama 2 | 7B | Trelis | [Trelis et al. 2023](https://huggingface.co/Trelis/Llama-2-7b-chat-hf-function-calling-v2)                                  |
+| Gemma | 2B, 7B | Google | [Google Team, Google Deepmind](https://storage.googleapis.com/deepmind-media/gemma/gemma-report.pdf)                                       |
+| Llama 2 | 7B, 13B, 70B | Meta AI | [Touvron et al. 2023](https://arxiv.org/abs/2307.09288)                                                                           |
+| Llama 3 | 8B, 70B | Meta AI | [Meta AI 2024](https://github.com/meta-llama/llama3)                                                                                   |
+| LongChat | 7B, 13B | LMSYS | [LongChat Team 2023](https://lmsys.org/blog/2023-06-29-longchat/)                                                                       |
+| MicroLlama | 300M | Ken Wang | [MicroLlama repo](https://github.com/keeeeenw/MicroLlama)
+| Mixtral MoE | 8x7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/mixtral-of-experts/)                                                                     |
+| Mistral | 7B | Mistral AI | [Mistral AI 2023](https://mistral.ai/news/announcing-mistral-7b/)                                                                        |
+| Nous-Hermes | 7B, 13B, 70B | NousResearch | [Org page](https://huggingface.co/NousResearch)                                                                          |
+| OpenLLaMA | 3B, 7B, 13B | OpenLM Research | [Geng & Liu 2023](https://github.com/openlm-research/open_llama)                                                         |
+| Phi | 1.3B, 2.7B | Microsoft Research  | [Li et al. 2023](https://arxiv.org/abs/2309.05463)                                                                          |
+| Platypus | 7B, 13B, 70B |  Lee et al. | [Lee, Hunter, and Ruiz 2023](https://arxiv.org/abs/2308.07317)                                                               |
+| Pythia | {14,31,70,160,410}M, {1,1.4,2.8,6.9,12}B | EleutherAI | [Biderman et al. 2023](https://arxiv.org/abs/2304.01373)                                            |
+| RedPajama-INCITE | 3B, 7B | Together | [Together 2023](https://together.ai/blog/redpajama-models-v1)                                                                 |
+| StableCode | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                                  |
+| StableLM  | 3B, 7B | Stability AI | [Stability AI 2023](https://github.com/Stability-AI/StableLM)                                                                    |
+| StableLM Zephyr | 3B | Stability AI | [Stability AI 2023](https://stability.ai/blog/stablecode-llm-generative-ai-coding)                                             |
+| TinyLlama | 1.1B | Zhang et al. | [Zhang et al. 2023](https://github.com/jzhang38/TinyLlama)                                                                         |
+| Vicuna | 7B, 13B, 33B | LMSYS | [Li et al. 2023](https://lmsys.org/blog/2023-03-30-vicuna/)                                                                          |                                                            |
 
 &nbsp;
 
@@ -34,10 +39,10 @@ LitGPT supports a variety of LLM architectures with publicly available weights. 
 
 ### 1. List Available Models
 
-To see all supported models, run the following command without arguments:
+To see all supported models, run the following command:
 
 ```bash
-litgpt download
+litgpt download list
 ```
 
 The output is shown below:
@@ -160,7 +165,7 @@ unsloth/Mistral-7B-v0.2
 &nbsp;
 
 > [!TIP]
-> To sort the list above by model name after the `/`, use `litgpt download | sort -f -t'/' -k2`.
+> To sort the list above by model name after the `/`, use `litgpt download list | sort -f -t'/' -k2`.
 
 &nbsp;
 
@@ -168,8 +173,7 @@ unsloth/Mistral-7B-v0.2
 > If you want to adopt a model variant that is not listed in the table above but has a similar architecture as one of the supported models, you can use this model by by using the `--model_name` argument as shown below:
 >
 > ```bash
-> litgpt download \
->  --repo_id NousResearch/Hermes-2-Pro-Mistral-7B \
+> litgpt download NousResearch/Hermes-2-Pro-Mistral-7B \
 >  --model_name Mistral-7B-v0.1
 > ```
 
@@ -177,10 +181,10 @@ unsloth/Mistral-7B-v0.2
 
 ### 2. Download Model Weights
 
-To download the weights for a specific model, use the `--repo_id` argument. Replace `<repo_id>` with the model's repository ID. For example:
+To download the weights for a specific model provide a `<repo_id>` with the model's repository ID. For example:
 
 ```bash
-litgpt download --repo_id <repo_id>
+litgpt download <repo_id>
 ```
 
 This command downloads the model checkpoint into the `checkpoints/` directory.
@@ -199,10 +203,10 @@ litgpt download --help
 
 ### 4. Run the Model
 
-After conversion, run the model with the `--checkpoint_dir` flag, adjusting `repo_id` accordingly:
+After conversion, run the model with the given checkpoint path as input, adjusting `repo_id` accordingly:
 
 ```bash
-litgpt chat --checkpoint_dir checkpoints/<repo_id>
+litgpt chat <repo_id>
 ```
 
 &nbsp;
@@ -214,7 +218,7 @@ This section shows a typical end-to-end example for downloading and using TinyLl
 1. List available TinyLlama checkpoints:
 
 ```bash
-litgpt download | grep Tiny
+litgpt download list | grep Tiny
 ```
 
 ```
@@ -226,13 +230,13 @@ TinyLlama/TinyLlama-1.1B-Chat-v1.0
 
 ```bash
 export repo_id=TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T
-litgpt download --repo_id $repo_id
+litgpt download $repo_id
 ```
 
 3. Use the TinyLlama model:
 
 ```bash
-litgpt chat --checkpoint_dir checkpoints/$repo_id
+litgpt chat $repo_id
 ```
 
 &nbsp;
@@ -245,8 +249,7 @@ For example, to get access to the Gemma 2B model, you can do so by following the
 Once you've been granted access and obtained the access token you need to pass the additional `--access_token`:
 
 ```bash
-litgpt download \
-  --repo_id google/gemma-2b \
+litgpt download google/gemma-2b \
   --access_token your_hf_token
 ```
 
@@ -257,8 +260,7 @@ litgpt download \
 Sometimes you want to download the weights of a finetune of one of the models listed above. To do this, you need to manually specify the `model_name` associated to the config to use. For example:
 
 ```bash
-litgpt download \
-  --repo_id NousResearch/Hermes-2-Pro-Mistral-7B \
+litgpt download NousResearch/Hermes-2-Pro-Mistral-7B \
   --model_name Mistral-7B-v0.1
 ```
 
@@ -266,11 +268,10 @@ litgpt download \
 
 ## Tips for GPU Memory Limitations
 
-The `download.py` script will automatically convert the downloaded model checkpoint into a LitGPT-compatible format. In case this conversion fails due to GPU memory constraints, you can try to reduce the memory requirements by passing the  `--dtype bf16-true` flag to convert all parameters into this smaller precision (however, note that most model weights are already in a bfloat16 format, so it may not have any effect):
+The `litgpt download` command will automatically convert the downloaded model checkpoint into a LitGPT-compatible format. In case this conversion fails due to GPU memory constraints, you can try to reduce the memory requirements by passing the  `--dtype bf16-true` flag to convert all parameters into this smaller precision (however, note that most model weights are already in a bfloat16 format, so it may not have any effect):
 
 ```bash
-litgpt download \
-  --repo_id <repo_id>
+litgpt download <repo_id>
   --dtype bf16-true
 ```
 
@@ -285,16 +286,14 @@ For development purposes, for example, when adding or experimenting with new mod
 You can do this by passing the `--convert_checkpoint false` option to the download script:
 
 ```bash
-litgpt download \
-  --repo_id <repo_id> \
+litgpt download <repo_id> \
   --convert_checkpoint false
 ```
 
-and then calling the `convert_hf_checkpoint.py` script:
+and then calling the `convert_hf_checkpoint` command:
 
 ```bash
-litgpt convert to_litgpt \
-  --checkpoint_dir checkpoint_dir/<repo_id>
+litgpt convert to_litgpt <repo_id>
 ```
 
 &nbsp;
@@ -304,16 +303,14 @@ litgpt convert to_litgpt \
 In some cases we don't need the model weight, for example, when we are pretraining a model from scratch instead of finetuning it. For cases like this, you can use the `--tokenizer_only` flag to only download a model's tokenizer, which can then be used in the pretraining scripts:
 
 ```bash
-litgpt download \
-  --repo_id TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
+litgpt download TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T \
   --tokenizer_only true
 ```
 
 and
 
 ```bash
-litgpt pretrain \
+litgpt pretrain tiny-llama-1.1b \
   --data ... \
-  --model_name tiny-llama-1.1b \
-  --tokenizer_dir checkpoints/TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T/
+  --tokenizer_dir TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T/
 ```

--- a/tutorials/evaluation.md
+++ b/tutorials/evaluation.md
@@ -19,16 +19,15 @@ pip install lm_eval
 Suppose you downloaded a base model that we want to evaluate. Here, we use the `microsoft/phi-2` model:
 
 ```bash
-litgpt download --repo_id microsoft/phi-2
+litgpt download microsoft/phi-2
 ```
 
-The download command above will save the model to the `checkoints/microsoft/phi-2` directory, which we can
+The download command above will save the model to the `checkpoints/microsoft/phi-2` directory, which we can
 specify in the following evaluation command:
 
 
 ```
-litgpt evaluate \
-  --checkpoint_dir checkpoints/microsoft/phi-2/ \
+litgpt evaluate microsoft/phi-2/ \
   --batch_size 4 \
   --tasks "hellaswag,truthfulqa_mc2,mmlu" \
   --out_dir evaluate_model/
@@ -62,8 +61,7 @@ In some cases, for example, if you modified the model in the `checkpoint_dir` si
 call, you need to use the `--force_conversion` flag to to update the files used by litgpt evaluate accordingly: 
 
 ```
-litgpt evaluate \
-  --checkpoint_dir checkpoints/microsoft/phi-2/ \
+litgpt evaluate microsoft/phi-2/ \
   --batch_size 4 \
   --out_dir evaluate_model/ \
   --tasks "hellaswag,truthfulqa_mc2,mmlu" \
@@ -73,7 +71,7 @@ litgpt evaluate \
 &nbsp;
 
 > [!TIP]
-> Run `litgpt evaluate --checkpoint_dir ...` without specifying `--tasks` to print a list
+> Run `litgpt evaluate ...` without specifying `--tasks` to print a list
 > of the supported tasks. 
 
 > [!TIP]
@@ -87,19 +85,17 @@ litgpt evaluate \
 
 ### Evaluating LoRA-finetuned LLMs
 
-No further conversion is necessary when evaluating LoRA-finetuned models as the `finetune lora` command already prepares the necessary merged model files:
+No further conversion is necessary when evaluating LoRA-finetuned models as the `finetune_lora` command already prepares the necessary merged model files:
 
 ```bash
-litgpt finetune lora \
-  --checkpoint_dir checkpoints/microsoft/phi-2 \
+litgpt finetune_lora microsoft/phi-2 \
   --out_dir lora_model
 ```
 
 &nbsp;
 
 ```bash
-litgpt evaluate \
-  --checkpoint_dir lora_model/final \
+litgpt evaluate lora_model/final \
   --batch_size 4 \
   --tasks "hellaswag,truthfulqa_mc2,mmlu" \
   --out_dir evaluate_model/ \

--- a/tutorials/examples/minimal-generate-scripts/README.md
+++ b/tutorials/examples/minimal-generate-scripts/README.md
@@ -10,7 +10,7 @@ The scripts in this folder provide minimal examples showing how to use LitGPT fr
 Assuming you downloaded the checkpoint files via 
 
 ```bash
-litgpt download --repo_id EleutherAI/pythia-1b
+litgpt download EleutherAI/pythia-1b
 ```
 
 you can run the scripts as follows:

--- a/tutorials/examples/minimal-generate-scripts/generate-step-by-step.py
+++ b/tutorials/examples/minimal-generate-scripts/generate-step-by-step.py
@@ -19,7 +19,7 @@ def use_model():
     # Load model
     ###################
 
-    # run `litgpt download --repo_id EleutherAI/pythia-1b` to download the checkpoint first
+    # run `litgpt download EleutherAI/pythia-1b` to download the checkpoint first
     checkpoint_dir = Path("checkpoints") / "EleutherAI" / "pythia-1b"
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
 

--- a/tutorials/examples/minimal-generate-scripts/generate.py
+++ b/tutorials/examples/minimal-generate-scripts/generate.py
@@ -8,7 +8,7 @@ from litgpt.utils import get_default_supported_precision
 
 def use_model():
 
-    # run `litgpt download --repo_id EleutherAI/pythia-1b` to download the checkpoint first
+    # run `litgpt download EleutherAI/pythia-1b` to download the checkpoint first
     checkpoint_dir = Path("checkpoints") / "EleutherAI" / "pythia-1b"
 
     torch.manual_seed(123)

--- a/tutorials/finetune.md
+++ b/tutorials/finetune.md
@@ -1,14 +1,14 @@
 # Finetuning
 
-We provide a simple finetuning commands (`litgpt finetune *`) that instruction-finetune a pretrained model on datasets such as [Alpaca](https://github.com/tatsu-lab/stanford_alpaca), [Dolly](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm), and others. For more information on the supported instruction datasets and how to prepare your own custom datasets, please see the [tutorials/prepare_dataset](prepare_dataset.md) tutorials.
+We provide a simple finetuning commands (`litgpt finetune_*`) that instruction-finetune a pretrained model on datasets such as [Alpaca](https://github.com/tatsu-lab/stanford_alpaca), [Dolly](https://www.databricks.com/blog/2023/04/12/dolly-first-open-commercially-viable-instruction-tuned-llm), and others. For more information on the supported instruction datasets and how to prepare your own custom datasets, please see the [tutorials/prepare_dataset](prepare_dataset.md) tutorials.
 
 LitGPT currently supports the following finetuning methods:
 
 ```bash
-litgpt finetune full
-litgpt finetune lora
-litgpt finetune adapter
-litgpt finetune adapter_v2
+litgpt finetune_full
+litgpt finetune_lora
+litgpt finetune_adapter
+litgpt finetune_adapter_v2
 ```
 
 The following section provides more details about these methods, including links for additional resources.
@@ -23,7 +23,7 @@ The section below provides additional information on the available and links to 
 ### Full finetuning
 
 ```bash
-litgpt finetune full
+litgpt finetune_full
 ```
 
 This method trains all model weight parameters and is the most memory-intensive finetuning technique in LitGPT.
@@ -37,7 +37,7 @@ This method trains all model weight parameters and is the most memory-intensive 
 ### LoRA and QLoRA finetuning
 
 ```bash
-litgpt finetune lora
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b
 ```
 
 LoRA and QLoRA are parameter-efficient finetuning technique that only require updating a small number of parameters, which makes this a more memory-efficienty alternative to full finetuning.
@@ -53,13 +53,13 @@ LoRA and QLoRA are parameter-efficient finetuning technique that only require up
 ### Adapter finetuning
 
 ```bash
-litgpt finetune adapter
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b
 ```
 
 or
 
 ```bash
-litgpt finetune adapter_v2
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b
 ```
 
 Similar to LoRA, adapter finetuning is a parameter-efficient finetuning technique that only requires training a small subset of weight parameters, making this finetuning method more memory-efficient than full-parameter finetuning. 

--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -22,17 +22,15 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-litgpt finetune adapter \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
-  --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 or for Adapter V2
 
 ```bash
-litgpt finetune adapter_v2 \
+litgpt finetune adapter_v2 stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
-  --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
 ```
 
 The finetuning requires at least one GPU with ~12 GB memory.
@@ -49,7 +47,7 @@ For example, the following settings will let you finetune the model in under 1 h
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-litgpt finetune adapter \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter/my-model-finetuned
 ```
@@ -57,7 +55,7 @@ litgpt finetune adapter \
 or for Adapter V2
 
 ```bash
-litgpt finetune adapter_v2 \
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter_v2/my-model-finetuned
 ```
@@ -66,7 +64,7 @@ If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` 
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-litgpt finetune adapter \
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
   --data Alpaca \
   --out_dir out/adapter/my-model-finetuned \
   --precision 32-true
@@ -79,13 +77,15 @@ Note that `mps` as the accelerator will be picked up automatically by Fabric whe
 Optionally, finetuning using quantization can be enabled via the `--quantize` flag, for example using the 4-bit NormalFloat data type:
 
 ```bash
-litgpt finetune adapter --quantize "bnb.nf4"
+litgpt finetune_adapter stabilityai/stablelm-base-alpha-3b \
+  --quantize "bnb.nf4"
 ```
 
-or using adapter_v2 with double-quantization:
+or using `adapter_v2` with double-quantization:
 
 ```bash
-litgpt finetune adapter_v2 --quantize "bnb.nf4-dq"
+litgpt finetune_adapter_v2 stabilityai/stablelm-base-alpha-3b \
+  --quantize "bnb.nf4-dq"
 ```
 
 For additional benchmarks and resource requirements, please see the [Resource Tables](resource-tables.md).
@@ -95,17 +95,16 @@ For additional benchmarks and resource requirements, please see the [Resource Ta
 You can test the finetuned model with your own instructions by running:
 
 ```bash
-litgpt generate adapter \
-    --prompt "Recommend a movie to watch on the weekend." \
-    --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt generate_adapter stabilityai/stablelm-base-alpha-3b \
+    --prompt "Recommend a movie to watch on the weekend."
 ```
 
 or for Adapter V2
 
 ```bash
-litgpt generate adapter_v2 \
-    --prompt "Recommend a movie to watch on the weekend." \
-    --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt generate_adapter_v2 stabilityai/stablelm-base-alpha-3b \
+    --prompt "Recommend a movie to watch on the weekend."
+
 ```
 
 Output:
@@ -135,12 +134,11 @@ You can easily train on your own instruction dataset saved in JSON format.
     ]
     ```
 
-2. Run `litgpt/finetune/adapter.py` or `litgpt/finetune/adapter_v2.py` by passing in the location of your data (and optionally other parameters):
+2. Run `litgpt adapter` or `litgpt adapter_v2` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune adapter \
+    litgpt finetune_adapter tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
-        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
         --out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -16,9 +16,8 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the finetuning
 
 ```bash
-litgpt finetune full \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
-  --checkpoint_dir checkpoints/tiiuae/falcon-7b
 ```
 
 Finetuning the falcon-7b model requires at least 8 GPUs with ~40 GB memory each.
@@ -29,7 +28,7 @@ Depending on the available GPU memory, you can also tune the `micro_batch_size` 
 This script will save checkpoints periodically to the `out_dir` directory. If you are finetuning different models or on your own dataset, you can specify an output directory with your preferred name:
 
 ```bash
-litgpt finetune full \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
   --out_dir out/full/my-model-finetuned
 ```
@@ -38,7 +37,7 @@ If your GPU does not support `bfloat16`, you can pass the `--precision 32-true` 
 For instance, to fine-tune on MPS (the GPU on modern Macs), you can run
 
 ```bash
-litgpt finetune full \
+litgpt finetune_full tiiuae/falcon-7b \
   --data Alpaca \
   --out_dir out/full/my-model-finetuned \
   --precision 32-true
@@ -51,9 +50,8 @@ Note that `mps` as the accelerator will be picked up automatically by Fabric whe
 You can test the finetuned model with your own instructions by running:
 
 ```bash
-litgpt generate full \
+litgpt generate tiiuae/falcon-7b \
     --prompt "Recommend a movie to watch on the weekend." \
-    --checkpoint_dir checkpoints/tiiuae/falcon-7b \
     --finetuned_path out/full/my-model-finetuned/lit_model_finetuned.pth
 ```
 
@@ -84,12 +82,11 @@ You can easily train on your own instruction dataset saved in JSON format.
     ]
     ```
 
-2. Run `litgpt/finetune/full.py` by passing in the location of your data (and optionally other parameters):
+2. Run `litgpt finetune` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune full \
+    litgpt finetune tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
-        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
         --out_dir data/mydata-finetuned
     ```

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -22,7 +22,8 @@ For more information about dataset preparation, also see the [prepare_dataset.md
 ## Running the Finetuning
 
 ```bash
-litgpt finetune lora --data Alpaca
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
+  --data Alpaca
 ```
 
 The finetuning requires at least one GPU with ~24 GB memory (RTX 3090).
@@ -37,13 +38,15 @@ This script will save checkpoints periodically to the folder `out/`.
 Optionally, finetuning using 4-bit quantization (as in QLoRA) can be enabled via the `--quantize` flag, for example using the 4-bit NormalFloat data type:
 
 ```bash
-litgpt finetune lora --quantize "bnb.nf4"
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
+  --quantize "bnb.nf4"
 ```
 
 and optionally with double-quantization:
 
 ```bash
-litgpt finetune lora --quantize "bnb.nf4-dq"
+litgpt finetune_lora stabilityai/stablelm-base-alpha-3b \
+  --quantize "bnb.nf4-dq"
 ```
 
 The table below lists a comparison with different settings on a StableLM 3B model finetuned with LoRA on Alpaca for 1,000 iterations using a microbatch size of 1:
@@ -73,8 +76,7 @@ For additional benchmarks and resource requirements, please see the [Resource Ta
 You can test the finetuned model with your own instructions by running:
 
 ```bash
-litgpt generate base \
-  --checkpoint_dir "out/lora/final" \
+litgpt generate "out/lora/final" \
   --prompt "Recommend a movie to watch on the weekend."
 ```
 
@@ -107,13 +109,12 @@ You can easily train on your own instruction dataset saved in JSON format.
     ]
     ```
 
-2. Run `litgpt/finetune/lora.py` by passing in the location of your data (and optionally other parameters):
+2. Run `litgpt finetune_lora` by passing in the location of your data (and optionally other parameters):
 
     ```bash
-    litgpt finetune lora \
+    litgpt finetune_lora checkpoints/tiiuae/falcon-7b \
         --data JSON \
         --data.json_path data/mydata.json \
-        --checkpoint_dir checkpoints/tiiuae/falcon-7b \
         --out_dir data/mydata-finetuned
     ```
 
@@ -135,6 +136,6 @@ The advantage of this merging process is to streamline inference operations, as 
 For example, after finetuning produced a checkpoint folder `out/lora/step-002000`, merge it as follows:
 
 ```bash
-litgpt merge_lora --checkpoint_dir "out/lora/step-002000"
+litgpt merge_lora "out/lora/step-002000"
 ```
 The command above creates a full `lit_model.pth` checkpoint file.

--- a/tutorials/inference.md
+++ b/tutorials/inference.md
@@ -1,9 +1,10 @@
 # Inference
 
-We demonstrate how to run inference (next token prediction) with the GPT base model in the [`generate.py`](../litgpt/generate/base.py) script:
+We demonstrate how to run inference (next token prediction) with the GPT base model in the [`litgpt generate`](../litgpt/generate/base.py) command:
 
 ```bash
-litgpt generate base --prompt "Hello, my name is" --checkpoint_dir checkpoints/stabilityai/stablelm-base-alpha-3b
+litgpt generate stabilityai/stablelm-base-alpha-3b \
+  --prompt "Hello, my name is"
 ```
 
 Output:
@@ -21,7 +22,7 @@ This will run the 3B pre-trained model and require ~7 GB of GPU memory using the
 You can also chat with the model interactively:
 
 ```bash
-litgpt chat --checkpoint_dir checkpoints/stabilityai/stablelm-tuned-alpha-3b
+litgpt chat stabilityai/stablelm-tuned-alpha-3b
 ```
 
 This script can work with any checkpoint. For the best chat-like experience, we recommend using it with a checkpoints
@@ -39,7 +40,7 @@ Check out our [quantization tutorial](quantize.md).
 
 We offer two scripts to leverage multiple devices for inference.
 
-### [`litgpt/generate/sequentially.py`](../litgpt/generate/sequentially.py)
+### [`litgpt generate_sequentially`](../litgpt/generate/sequentially.py)
 
 Allows you to run models that wouldn't fit in a single card by partitioning the transformer blocks across all your devices and running them sequentially.
 
@@ -47,8 +48,7 @@ For instance, `meta-llama/Llama-2-70b-chat-hf` would require ~140 GB of GPU memo
 With 80 transformer layers, we could partition them across 8, 5, 4, or 2 devices.
 
 ```shell
-litgpt generate sequentially \
-  --checkpoint_dir checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_sequentially meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2
 ```
@@ -67,8 +67,7 @@ Note that the memory usage will also depend on the `max_new_tokens` value used.
 The script also supports quantization, using 4-bit precision, we can now use 2 GPUs
 
 ```shell
-litgpt generate sequentially \
-  --checkpoint_dir checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_sequentially meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2 \
   --quantize bnb.nf4-dq
@@ -83,7 +82,7 @@ litgpt generate sequentially \
 
 Smaller devices can also be used to run inference with this technique.
 
-### [`litgpt/generate/tp.py`](../litgpt/generate/tp.py)
+### [`litgpt generate_tp`](../litgpt/generate/tp.py)
 
 Uses tensor parallelism (TP) to run models that wouldn't fit in a single card by sharding the MLP and Attention QKV linear layers across all your devices.
 
@@ -93,8 +92,7 @@ With an intermediate size of 28672, we can use 2, 4, 7, or 8 devices. With a QKV
 Since the script is configured to shard both, the intersection is used: we can only use 2, 4, or 8 devices.
 
 ```shell
-litgpt generate tp \
-  --checkpoint_dir checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_tp meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2
 ```
@@ -112,8 +110,7 @@ Note that the memory usage will also depend on the `max_new_tokens` value used.
 The script also supports quantization, using 4-bit precision, we can now use 2 GPUs
 
 ```shell
-litgpt generate tp \
-  --checkpoint_dir checkpoints/meta-llama/Llama-2-70b-chat-hf \
+litgpt generate_tp meta-llama/Llama-2-70b-chat-hf \
   --max_new_tokens 256 \
   --num_samples 2 \
   --quantize bnb.nf4-dq

--- a/tutorials/prepare_dataset.md
+++ b/tutorials/prepare_dataset.md
@@ -26,7 +26,7 @@ The steps here only need to be done once before preparing the finetuning dataset
 1. Follow the instructions in the [README](../README.md) to install the dependencies.
 2. Download and convert the weights following our [guide](download_model_weights.md).
 
-For the following examples, we will focus on finetuning with the `litgpt/finetune/lora.py` script and use a Falcon 7B model.
+For the following examples, we will focus on finetuning with the `litgpt finetune_lora` command and use a Falcon 7B model.
 However, the same steps apply to all other models and finetuning scripts.
 Please read the [tutorials/finetune_*.md](.) documents for more information about finetuning models.
 
@@ -47,9 +47,8 @@ In its development, the creators leveraged the data generation methodology from 
 The original [Alpaca](https://crfm.stanford.edu/2023/03/13/alpaca.html) dataset can be used as follows:
 
 ```bash
-litgpt finetune lora \
-  --data Alpaca \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+litgpt finetune_lora tiiuae/falcon-7b \
+  --data Alpaca
 ```
 
 &nbsp;
@@ -68,9 +67,8 @@ By default, the finetuning scripts will determine the size of the longest tokeni
 In this case, a cut-off of 256 may be a reasonable choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -83,15 +81,14 @@ For comparison, the Falcon 7B model requires 23.52 GB of memory for the original
 [Alpaca-2k](https://huggingface.co/datasets/mhenrichsen/alpaca_2k_test) is a smaller, 2000-sample subset of Alpaca described above.
 
 ```bash
-litgpt finetune lora \
-  --data Alpaca2k \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+litgpt finetune_lora "tiiuae/falcon-7b" \
+  --data Alpaca2k
 ```
 
 &nbsp;
 
 > [!TIP]
-> Use `litgpt finetune --data.help Alpaca2k` to list additional dataset-specific command line options.
+> Use `litgpt_finetune --data.help Alpaca2k` to list additional dataset-specific command line options.
 
 &nbsp;
 
@@ -108,15 +105,14 @@ dataset consists of 52,000 instructions and responses.
 The original [Alpaca-GPT4](https://github.com/Instruction-Tuning-with-GPT-4/GPT-4-LLM) dataset can be used as follows:
 
 ```bash
-litgpt finetune lora \
-  --data AlpacaGPT4 \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+litgpt finetune lora "tiiuae/falcon-7b" \
+  --data AlpacaGPT4
 ```
 
 &nbsp;
 
 > [!TIP]
-> Use `litgpt finetune --data.help AlpacaGPT4` to list additional dataset-specific command line options.
+> Use `litgpt_finetune --data.help AlpacaGPT4` to list additional dataset-specific command line options.
 
 &nbsp;
 
@@ -133,11 +129,10 @@ The Alpaca-GPT4 dataset distribution is shown below.
 To use Alpaca Libre instead of the original Alpaca dataset, use the following command:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
-  --data.file_name "alpaca_libre_data_cleaned_archive.json" \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --data.file_name "alpaca_libre_data_cleaned_archive.json"
 ```
 
 &nbsp;
@@ -154,11 +149,10 @@ The Alpaca Libre dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 256 may be a good choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Alpaca \
   --data.file_url "https://raw.githubusercontent.com/mobarski/alpaca-libre/main/data/output/alpaca_libre_ok_tasks_v4.json" \
   --data.file_name "alpaca_libre_data_cleaned_archive.json" \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -170,9 +164,8 @@ The Deita dataset (short for Data-Efficient Instruction Tuning for Alignment) is
 Using Falcon 7b as an example, we can use the dataset as follows:
 
 ```bash
-litgpt finetune lora \
-  --data Deita \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+litgpt finetune_lora tiiuae/falcon-7b \
+  --data Deita
 ```
 
 &nbsp;
@@ -199,9 +192,8 @@ The Deita dataset distribution including multit-turn conversations is depicted i
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Deita \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 512
 ```
 
@@ -214,9 +206,8 @@ The Dolly dataset is a publicly available collection of 15k instruction-followin
 The usage is similar to the Alpaca dataset described above. Using Falcon 7b as an example, we can use the dataset as follows:
 
 ```bash
-litgpt finetune lora \
-  --data Dolly \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
+litgpt finetune_lora tiiuae/falcon-7b \
+  --data Dolly
 ```
 
 &nbsp;
@@ -233,9 +224,8 @@ The Dolly dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data Dolly \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 256
 ```
 
@@ -274,9 +264,8 @@ The LongForm dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 1500 may be a good choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data LongForm \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 1500
 ```
 
@@ -300,7 +289,7 @@ export HF_TOKEN="insert_your_huggingface_token_here"
 
 litgpt finetune lora \
   --data LIMA \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --checkpoint_dir "tiiuae/falcon-7b"
 ```
 
 &nbsp;
@@ -321,9 +310,8 @@ The LIMA dataset distribution is shown below.
 You may want to consider truncating the dataset (see the *Truncating datasets* discussion in the Alpaca section for more information.) For this dataset, a cut-off of 512 may be a good choice:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data LIMA \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b" \
   --train.max_seq_length 512
 ```
 
@@ -337,18 +325,16 @@ FLAN is a collection of several datset subsets by Google. In particular, the pro
 By default, all subsets (1,386,050 samples) and validations sets (367,190 subsets) are combined into a single dataset:
 
 ```bash
-litgpt finetune lora \
-  --data FLAN \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+litgpt finetune_lora tiiuae/falcon-7b \
+  --data FLAN
 ```
 
 However, you can also select individual subsets via comma-separated strings as follows:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune lora tiiuae/falcon-7b \
   --data FLAN \
-  --data.subsets "aeslc_10templates,ag_news_subset_10templates,anli_r1_10templates" \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --data.subsets "aeslc_10templates,ag_news_subset_10templates,anli_r1_10templates"
 ```
 
 &nbsp;
@@ -406,11 +392,10 @@ You can prepare custom dataset using a JSON file where each row is a dictionary 
 Then simply run any of the finetuning scripts with this input:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data JSON \
   --data.json_path path/to/your/data.json \
-  --data.val_split_fraction 0.1 \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --data.val_split_fraction 0.1
 ```
 
 You can also customize how the dataset is read by using these additional parameters
@@ -426,14 +411,13 @@ You can also customize how the dataset is read by using these additional paramet
 To use the settings described above, you can add the respective command line arguments when calling the finetuning scripts as shown in the example below:
 
 ```bash
-litgpt finetune lora \
+litgpt finetune_lora tiiuae/falcon-7b \
   --data JSON \
   --data.json_path path/to/your/data.json \
   --data.val_split_fraction 0.1 \
   --data.seed 42 \
   --data.mask_inputs False \
-  --data.ignore_index -100 \
-  --checkpoint_dir "checkpoints/tiiuae/falcon-7b"
+  --data.ignore_index -100
 ```
 
 You can also pass a directory containing a `train.json` and `val.json` to `--data.json_path` to define a fixed train/val split.

--- a/tutorials/pretrain.md
+++ b/tutorials/pretrain.md
@@ -6,10 +6,10 @@ This document explains how to pretrain LLMs using LitGPT.
 &nbsp;
 ## Using the `litgpt pretrain` command
 
-You can pretrain models in LitGPT using the `litgpt pretrain` API starting with any of the available architectures listed by calling `litgpt pretrain` without any additional arguments:
+You can pretrain models in LitGPT using the `litgpt pretrain` API starting with any of the available architectures listed by calling `litgpt pretrain list` without any additional arguments:
 
 ```bash
-litgpt pretrain
+litgpt pretrain list
 ```
 
 Shown below is an abbreviated list:
@@ -30,8 +30,7 @@ pythia-14m
 For demonstration purposes, we can pretrain a small 14 million-parameter Pythia model on the small TinyStories dataset using the [debug.yaml config file](https://github.com/Lightning-AI/litgpt/blob/main/config_hub/pretrain/debug.yaml) as follows:
 
 ```bash
-litgpt pretrain \
-   --model_name pythia-14m \
+litgpt pretrain pythia-14m \
    --config https://raw.githubusercontent.com/Lightning-AI/litgpt/main/config_hub/pretrain/debug.yaml
 ```
 
@@ -70,17 +69,15 @@ total 3225M
 You can then use the `TextFiles` API to pretrain a model (here a small `pythia-14m` model for illustration purposes) from scratch as follows:
 
 ```bash
-litgpt download \
-  --repo_id EleutherAI/pythia-14m \
+litgpt download EleutherAI/pythia-14m \
   --tokenizer_only true
 
-litgpt pretrain \
-   --model_name pythia-14m \
-   --tokenizer_dir checkpoints/EleutherAI/pythia-14m \
+litgpt pretrain pythia-14m \
+   --tokenizer_dir EleutherAI/pythia-14m \
    --data TextFiles \
    --data.train_data_path custom_pretraining_data \
-   --train.learning_rate 0.005 \
    --train.lr_warmup_steps=200
+   --optimizer.lr 0.005
 ```
 
 
@@ -105,20 +102,20 @@ Often, it makes sense to adopt an existing pretrained model and further pretrain
 For instance, let's assume we download a Pythia model:
 
 ```bash
-litgpt download --repo_id EleutherAI/pythia-14m
+litgpt download EleutherAI/pythia-14m
 ```
 
 Next, assume we have a custom dataset stored in text files similar to the *Pretrain on custom data* above. We can further pretrain the Pythia model via the `--initial_checkpoint_dir` setting as follows:
 
 ```bash
-litgpt pretrain \
-   --model_name pythia-14m \
-   --initial_checkpoint_dir checkpoints/EleutherAI/pythia-14m \
+litgpt pretrain pythia-14m \
+   --initial_checkpoint_dir EleutherAI/pythia-14m \
+   --tokenizer_dir EleutherAI/pythia-14m \
    --out_dir new_phi-2_checkpoint \
    --data TextFiles \
    --data.train_data_path custom_pretraining_data \
-   --train.learning_rate 0.005 \
    --train.lr_warmup_steps=200
+   --optimizer.lr 0.005
 ```
 
 

--- a/tutorials/pretrain_tinyllama.md
+++ b/tutorials/pretrain_tinyllama.md
@@ -58,8 +58,7 @@ pip install '.[all]'
 You will need to have the tokenizer config available:
 
 ```bash
-litgpt download \
-   --repo_id meta-llama/Llama-2-7b-hf \
+litgpt download meta-llama/Llama-2-7b-hf \
    --access_token your_hf_token \
    --tokenizer_only true
 ```
@@ -115,7 +114,7 @@ Note that `pretrain` is not actually a model-specific training script, so feel f
 or change the model type and size by passing a different string to the model name argument, for example:
 
 ```shell
-litgpt pretrain --model_name Gemma-2b
+litgpt pretrain Gemma-2b
 ```
 
 The currently supported model names can be listed by executing `litgpt pretrain` without any additional arguments.
@@ -146,7 +145,7 @@ The checkpoints saved during pretraining contain all the information to resume i
 Simply rerun the script with the `--resume` argument added:
 
 ```bash
-litgpt pretrain \
+litgpt pretrain tiny-llama\
   --config config_hub/pretrain/tinyllama.yaml \
   --resume out/pretrain/tiny-llama/step-00060500
 ```
@@ -158,8 +157,7 @@ litgpt pretrain \
 After training is completed, you can convert the checkpoint to a format that can be loaded for evaluation, inference, finetuning etc.
 
 ```bash
-litgpt convert pretrained_checkpoint \
-  --checkpoint_dir out/pretrain/tiny-llama/step-00060500 \
+litgpt convert_pretrained_checkpoint out/pretrain/tiny-llama/step-00060500 \
   --output_dir checkpoints/tiny-llama/final
 ```
 

--- a/tutorials/quantize.md
+++ b/tutorials/quantize.md
@@ -12,7 +12,9 @@ This document provides different strategies for quantizing the various models av
 It's useful to start with a baseline to have a reference point for memory savings via the various quantization methods.
 
 ```bash
-litgpt generate base --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 32-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --precision 32-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 6.93 sec total, 36.96 tokens/sec.
 Memory used: 28.95 GB
@@ -24,7 +26,9 @@ In short, when `--precision bf16-true` or `--precision 16-true` is used, the mod
 However, this might not be enough for large models or when using GPUs with limited memory.
 
 ```bash
-litgpt generate base --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --precision bf16-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 5.37 sec total, 47.66 tokens/sec.
 Memory used: 14.50 GB
@@ -48,7 +52,10 @@ Uses the normalized float 4 (nf4) data type. This is recommended over "fp4" base
 ```bash
 pip install bitsandbytes
 
-litgpt generate base --quantize bnb.nf4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --quantize bnb.nf4 \
+  --precision bf16-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 6.80 sec total, 37.62 tokens/sec
 Memory used: 5.72 GB
@@ -64,7 +71,11 @@ In average, this amounts to about 0.37 bits per parameter (approximately 3 GB fo
 ```bash
 pip install bitsandbytes
 
-litgpt generate base --quantize bnb.nf4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --quantize bnb.nf4-dq \
+  --precision bf16-true \
+  --max_new_tokens 256
+
 ...
 Time for inference 1: 8.09 sec total, 30.87 tokens/sec
 Memory used: 5.38 GB
@@ -79,7 +90,10 @@ Uses pure FP4 quantization.
 ```bash
 pip install bitsandbytes
 
-litgpt generate base --quantize bnb.fp4 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --quantize bnb.fp4 \
+  --precision bf16-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 6.92 sec total, 36.98 tokens/sec
 Memory used: 5.72 GB
@@ -95,7 +109,10 @@ In average, this amounts to about 0.37 bits per parameter (approximately 3 GB fo
 ```bash
 pip install bitsandbytes
 
-litgpt generate base --quantize bnb.fp4-dq --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision bf16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --quantize bnb.fp4-dq \
+  --precision bf16-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 10.02 sec total, 25.54 tokens/sec
 Memory used: 5.38 GB
@@ -108,7 +125,10 @@ Enabled with [bitsandbytes](https://github.com/TimDettmers/bitsandbytes). Check 
 ```bash
 pip install bitsandbytes
 
-litgpt generate base --quantize bnb.int8 --checkpoint_dir checkpoints/tiiuae/falcon-7b --precision 16-true --max_new_tokens 256
+litgpt generate tiiuae/falcon-7b \
+  --quantize bnb.int8 \
+  --precision 16-true \
+  --max_new_tokens 256
 ...
 Time for inference 1: 20.22 sec total, 12.66 tokens/sec
 Memory used: 8.70 GB

--- a/tutorials/resource-tables.md
+++ b/tutorials/resource-tables.md
@@ -34,7 +34,7 @@ Note that the number of tokens in the training set does not affect the supported
 
 ## Finetuning with LoRA on 1 GPU
 
-The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt/finetune/lora.py` script.
+The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt finetune_lora` command.
 
 | Size  | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |-------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -70,7 +70,7 @@ The following experiments were conducted on 1xA100 with a minibatch size of 128 
 
 ## Finetuning with Adapter on 1 GPU
 
-The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt/finetune/adapter.py` script.
+The following experiments were conducted on 1xA100 with a minibatch size of 128 using the `litgpt finetune_adapter` command.
 
 | Size | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -82,7 +82,7 @@ The following experiments were conducted on 1xA100 with a minibatch size of 128 
 | 7 B  | Llama 2        | bnb.nf4      | 1               | 1,229,760            | 12.68 GB    | 2.93 min           |
 | 7 B  | Llama 2        | bnb.nf4-dq   | 1               | 1,229,760            | 12.38 GB    | 3.00 min           |
 
-The same config, but using the `litgpt/finetune/adapter_v2.py` script.
+The same config, but using the `litgpt finetune_adapter_v2` command.
 
 | Size | Model          | Quantization | Microbatch size | Trainable parameters | Max GPU RAM | Time 1k iterations |
 |------|----------------|--------------|-----------------|----------------------|-------------|--------------------|
@@ -98,7 +98,7 @@ The same config, but using the `litgpt/finetune/adapter_v2.py` script.
 
 ## Finetuning with LoRA on Multiple GPUs
 
-The following experiments were conducted on multiple A100 GPUs with a minibatch size of 128 using the `litgpt/finetune/lora.py` script.
+The following experiments were conducted on multiple A100 GPUs with a minibatch size of 128 using the `litgpt finetune_lora` command.
 
 | Size  | Model          | Quantization | Microbatch size | Trainable parameters | GPU      | Max GPU RAM | Time 1k iterations |
 |-------|----------------|--------------|-----------------|----------------------|----------|-------------|--------------------|


### PR DESCRIPTION
See #1431 and #1444.

After some investigation, I noticed two things:

1. The current download script (litgpg/scripts/download.py), when using safetensors models, does not download the file `model.safetensors.index.json` (which contains the mapping between the parameter name and the corresponding chunk); for Mistral 7B v0.3, this [file](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/blob/main/model.safetensors.index.json) contains the "correct" parameter names, i.e., the ones that LitGPT is able to convert without issues.
2. The issue about parameter naming happens when attempting the conversion from the file `consolidated.safetensors` (which gets 'converted' to `consolidated.bin` in download.py); turns out this file contains the model parameters saved with a different name (I suspect it was created from the original Mistral AI implementation), while the files `model-0000X-of-00003.safetensors` are created from the HF Transformers "MistralForCausalLM" class, so they have the "correct" weight names.

By downloading and using the `model.safetensors.index.json` file in the same way as the `pytorch_model.bin.index.json` file when working with '.bin' models from HF, the `consolidated.bin` file is not used (as the mapping is only necessary for the files `model-0000X-of-00003.safetensors`) and the model can be downloaded and converted without issues.

I was also considering preventing the download of `consolidated.safetensors` for what I said above.
The `huggingface_hub.snapshot_download` function used in download.py accepts the arg `ignore_patterns`, which I would use to ignore this file.