### PR TITLE
add multi turn prompt

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -208,7 +208,7 @@ class Llama3(PromptStyle):
                 "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n\n"
                 "You are a helpful assistant.<|eot_id|>\n"  # The system prompt is optional
                 "<|start_header_id|>user<|end_header_id|>\n\n"
-                f"{prompt}<|eot_id|>\n"
+                f"{prompt}<|eot_id|>"
                 "<|start_header_id|>assistant<|end_header_id|>\n\n"
             )
         elif isinstance(prompt, list):
@@ -236,7 +236,7 @@ class Llama3(PromptStyle):
                 else:
                     raise ValueError(f"Unknown role: '{role}'. Supported roles are 'system', 'assistant' and 'user'")
             template = template.format(system="You are a helpful assistant.")  # fall back to default
-            template += "\n<|start_header_id|>assistant<|end_header_id|>\n\n"
+            template += "<|start_header_id|>assistant<|end_header_id|>\n\n"
             return template
 
     def stop_tokens(self, tokenizer: "Tokenizer") -> Tuple[List[int], ...]:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -141,8 +141,7 @@ def test_multiturn_prompt():
     wo_system_multiturn_output = style.apply(msgs)
     assert "You are a helpful assistant." in wo_system_multiturn_output
 
-
-
+    # Longer turn
     msgs = [
         {"role": "system", "content": "You are a helpful AI assistant for travel tips and recommendations"},
         {"role": "user", "content": "What is France's capital?"},
@@ -154,6 +153,27 @@ def test_multiturn_prompt():
     assert multiturn_output == """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
 
 You are a helpful AI assistant for travel tips and recommendations<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
+
+What is France's capital?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+
+Bonjour! The capital of France is Paris!<|eot_id|><|start_header_id|>user<|end_header_id|>
+
+What can I do there?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+
+"""
+
+    # Longer list without "system"
+    msgs = [
+        {"role": "user", "content": "What is France's capital?"},
+        {"role": "assistant", "content": "Bonjour! The capital of France is Paris!"},
+        {"role": "user", "content": "What can I do there?"},
+    ]
+    multiturn_output = style.apply(msgs)
+
+    assert multiturn_output == """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+You are a helpful assistant.<|eot_id|>
 <|start_header_id|>user<|end_header_id|>
 
 What is France's capital?<|eot_id|><|start_header_id|>assistant<|end_header_id|>

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,6 +6,7 @@ import litgpt.config
 from litgpt import Config
 from litgpt.prompts import (
     Alpaca,
+    Llama3,
     Default,
     PromptStyle,
     has_prompt_style,
@@ -115,3 +116,13 @@ def test_save_load_prompt_style(tmp_path):
     assert contents == {"class_path": "tests.test_prompts.CustomPromptStyle"}
     loaded = load_prompt_style(checkpoint_dir)
     assert isinstance(loaded, CustomPromptStyle)
+
+
+def test_multiturn_prompt():
+    content = "What is the capital of France?"
+    msgs = [{"role": "user", "content": content}]
+    style = Llama3()
+    simple_output = style.apply(content)
+    multiturn_output = style.apply(msgs)
+
+    assert simple_output == multiturn_output

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -119,10 +119,47 @@ def test_save_load_prompt_style(tmp_path):
 
 
 def test_multiturn_prompt():
-    content = "What is the capital of France?"
-    msgs = [{"role": "user", "content": content}]
+    prompt = "What is the capital of France?"
+    msgs = [{"role": "user", "content": prompt}]
     style = Llama3()
-    simple_output = style.apply(content)
+    simple_output = style.apply(prompt)
+    multiturn_output = style.apply(msgs)
+    assert simple_output == multiturn_output
+
+    # override system prompt
+    msgs = [
+        {"role": "system", "content": "You are not a helpful assistant."},
+        {"role": "user", "content": prompt}
+    ]
+    with_system_multiturn_output = style.apply(msgs)
+    assert "You are not a helpful assistant." in with_system_multiturn_output
+
+    # use default system prompt
+    msgs = [
+        {"role": "user", "content": prompt},
+    ]
+    wo_system_multiturn_output = style.apply(msgs)
+    assert "You are a helpful assistant." in wo_system_multiturn_output
+
+
+
+    msgs = [
+        {"role": "system", "content": "You are a helpful AI assistant for travel tips and recommendations"},
+        {"role": "user", "content": "What is France's capital?"},
+        {"role": "assistant", "content": "Bonjour! The capital of France is Paris!"},
+        {"role": "user", "content": "What can I do there?"},
+    ]
     multiturn_output = style.apply(msgs)
 
-    assert simple_output == multiturn_output
+    assert multiturn_output == """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+You are a helpful AI assistant for travel tips and recommendations<|eot_id|>
+<|start_header_id|>user<|end_header_id|>
+
+What is France's capital?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+
+Bonjour! The capital of France is Paris!<|eot_id|><|start_header_id|>user<|end_header_id|>
+
+What can I do there?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+
+"""


### PR DESCRIPTION
This PR adds multi-turn prompt handling for Llama3 as per the official model card prompt format [here](https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3/)