### PR TITLE
Add `resume="auto"`

### DIFF
--- a/config_hub/finetune/llama-2-7b/full.yaml
+++ b/config_hub/finetune/llama-2-7b/full.yaml
@@ -12,7 +12,9 @@ precision: bf16-true
 devices: 4
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.

--- a/config_hub/finetune/llama-3-8b/full.yaml
+++ b/config_hub/finetune/llama-3-8b/full.yaml
@@ -12,7 +12,9 @@ precision: bf16-true
 devices: 4
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.

--- a/config_hub/finetune/phi-2/full.yaml
+++ b/config_hub/finetune/phi-2/full.yaml
@@ -12,7 +12,9 @@ precision: bf16-true
 devices: 2
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.

--- a/config_hub/pretrain/debug.yaml
+++ b/config_hub/pretrain/debug.yaml
@@ -19,7 +19,9 @@ precision: bf16-mixed
 initial_checkpoint_dir:
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.

--- a/config_hub/pretrain/microllama.yaml
+++ b/config_hub/pretrain/microllama.yaml
@@ -19,7 +19,9 @@ precision: bf16-mixed
 initial_checkpoint_dir:
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.

--- a/config_hub/pretrain/tinyllama.yaml
+++ b/config_hub/pretrain/tinyllama.yaml
@@ -19,7 +19,9 @@ precision: bf16-mixed
 initial_checkpoint_dir:
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.

--- a/config_hub/pretrain/tinystories.yaml
+++ b/config_hub/pretrain/tinystories.yaml
@@ -35,7 +35,9 @@ precision: bf16-mixed
 initial_checkpoint_dir:
 
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
-# from the latest checkpoint in ``out_dir``. (type: Union[bool, Path], default: False)
+# from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
+# ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
+# (type: Union[bool, Literal["auto"], Path], default: False)
 resume: false
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.TinyLlama``.

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -29,6 +29,7 @@ from litgpt.utils import (
     chunked_cross_entropy,
     copy_config_files,
     extend_checkpoint_dir,
+    find_resume_path,
     get_default_supported_precision,
     init_out_dir,
     instantiate_torch_optimizer,
@@ -211,11 +212,7 @@ def main(
         "step_count": 0,
     }
 
-    if resume == "auto":
-        ckpts = list(out_dir.rglob("step-*/*.pth"))
-        resume = max(ckpts, key=(lambda p: int(p.parent.name.split("-")[1]))) if ckpts else False
-    if resume is True:
-        resume = max(out_dir.rglob("step-*/*.pth"), key=(lambda p: int(p.parent.name.split("-")[1])))
+    resume = find_resume_path(resume, out_dir)
     if resume:
         fabric.print(f"Resuming training from {resume}")
         fabric.load(resume, state)

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -124,7 +124,7 @@ def setup(
     tokenizer = Tokenizer(tokenizer_dir) if tokenizer_dir is not None else None
 
     logger = choose_logger(
-        logger_name, out_dir, name=f"pretrain-{config.name}", resume=resume, log_interval=train.log_interval
+        logger_name, out_dir, name=f"pretrain-{config.name}", resume=bool(resume), log_interval=train.log_interval
     )
 
     if devices > 1:

--- a/litgpt/pretrain.py
+++ b/litgpt/pretrain.py
@@ -20,7 +20,7 @@ from typing_extensions import Literal
 from litgpt import Tokenizer
 from litgpt.args import EvalArgs, TrainArgs
 from litgpt.config import name_to_config
-from litgpt.data import DataModule, TinyLlama, MicroLlama
+from litgpt.data import DataModule, TinyLlama
 from litgpt.model import GPT, Block, CausalSelfAttention, Config, LLaMAMLP
 from litgpt.utils import (
     CycleIterator,

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -39,8 +39,7 @@ def find_resume_path(resume: Union[bool, Literal["auto"], Path], out_dir: Path) 
     if not resume or isinstance(resume, Path):
         return resume
 
-    ckpts = list(out_dir.rglob("step-*/*.pth"))
-    resume_path = max(ckpts, key=(lambda p: int(p.parent.name.split("-")[1]))) if ckpts else None
+    resume_path = max(out_dir.rglob("step-*/*.pth"), key=(lambda p: int(p.parent.name.split("-")[1])), default=None)
     if resume == "auto":
         return resume_path
     if resume is True and resume_path is None:

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -35,6 +35,21 @@ def init_out_dir(out_dir: Path) -> Path:
     return out_dir
 
 
+def find_resume_path(resume: Union[bool, Literal["auto"], Path], out_dir: Path) -> Optional[Path]:
+    if not resume or isinstance(resume, Path):
+        return resume
+
+    ckpts = list(out_dir.rglob("step-*/*.pth"))
+    resume_path = max(ckpts, key=(lambda p: int(p.parent.name.split("-")[1]))) if ckpts else None
+    if resume == "auto":
+        return resume_path
+    if resume is True and resume_path is None:
+        raise FileNotFoundError(
+            f"You passed `--resume=True`, but no checkpont file was found in `--out_dir={out_dir}`."
+        )
+    return resume_path
+
+
 def find_multiple(n: int, k: int) -> int:
     assert k > 0
     if n % k == 0:


### PR DESCRIPTION
The current resuming logic allows the user to pass `--resume=True` to find the latest checkpoint in the `out_dir` folder. However, this requires the checkpoint to exist, and is safe to ensure the user loads a checkpoint when intended. However, in a job where we auto-resume, we can't set `resume=True` because an initial checkpoint never exists. This PR adds `--resume='auto'` that does the same as `--resume=True` except it won't error if no checkpoint is found.

When it's reviewed, I'll add it to the other scripts.