### PR TITLE
Version bump for new release to fix NumPy issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.1.dev0"
+version = "0.4.1"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
This bumps the version so I can make a new release so that we can fix the NumPy 2.0 version issue (#1494) for people who install LitGPT from PyPI. 