### PR TITLE
Update test_readme.py

### DIFF
--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -31,12 +31,6 @@ def run_command(command):
         raise RuntimeError(error_message) from None
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win") or
-    sys.platform == "darwin" or
-    'AGENT_NAME' in os.environ,
-    reason="Does not run on Windows, macOS, or Azure Pipelines"
-)
 @pytest.mark.dependency()
 def test_download_model():
     repo_id = str(REPO_ID).replace("\\", "/")  # fix for Windows CI

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -58,7 +58,7 @@ def test_download_books():
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model"])
 def test_chat_with_model():
-    command = ["litgpt", "generate", f"checkpoints" / REPO_ID]
+    command = ["litgpt", "generate", "checkpoints" / REPO_ID]
     prompt = "What do Llamas eat?"
     result = subprocess.run(command, input=prompt, text=True, capture_output=True, check=True)
     assert "What food do llamas eat?" in result.stdout

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,16 +1,15 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
-from pathlib import Path
 import os
-from unittest import mock
-
-import pytest
-import requests
 import subprocess
 import sys
 import threading
 import time
+from pathlib import Path
+from unittest import mock
 
+import pytest
+import requests
 
 REPO_ID = Path("EleutherAI/pythia-14m")
 CUSTOM_TEXTS_DIR = Path("custom_texts")

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -97,7 +97,7 @@ def test_finetune_model():
 @pytest.mark.skipif(
     sys.platform.startswith("win") or
     sys.platform == "darwin",
-    reason="`torch.compile` is not supported"
+    reason="`torch.compile` is not supported on this OS."
 )
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])
@@ -122,7 +122,7 @@ def test_pretrain_model():
 @pytest.mark.skipif(
     sys.platform.startswith("win") or
     sys.platform == "darwin",
-    reason="`torch.compile` is not supported"
+    reason="`torch.compile` is not supported on this OS."
 )
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -95,6 +95,11 @@ def test_finetune_model():
     assert (OUT_DIR/"final"/"lit_model.pth").exists(), "Model file was not created"
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or
+    sys.platform == "darwin",
+    reason="`torch.compile` is not supported"
+)
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])
 def test_pretrain_model():
@@ -115,6 +120,11 @@ def test_pretrain_model():
     assert (OUT_DIR / "final" / "lit_model.pth").exists(), "Model file was not created"
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win") or
+    sys.platform == "darwin",
+    reason="`torch.compile` is not supported"
+)
 @mock.patch.dict(os.environ, {"LT_ACCELERATOR": "cpu"})
 @pytest.mark.dependency(depends=["test_download_model", "test_download_books"])
 def test_continue_pretrain_model():


### PR DESCRIPTION
Hi there 👋 

Currently `tests/test_readme.py::test_download_model` skips Windows and MacOS platforms, and since the test is a dependency for other tests they are skipped too.
But model download should work on all platforms without problems.

This PR fixes it.
Plus adds a skip (for non-Linux OS) for pretraining tests since pretraining requires `torch.compile` which is supported only on Linux. 