### PR TITLE
Validate version of pinned dependencies

### DIFF
--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -545,7 +545,7 @@ def extend_checkpoint_dir(checkpoint_dir: Path) -> Path:
 
 
 def validate_pinned_dependencies() -> None:
-    """"Checks installed version of a pinned dependency. Validate only imported ones."""
+    """"Checks installed version of pinned dependencies. Validate only imported ones."""
 
     with open(Path(__file__).parents[1] / "pyproject.toml", "r", encoding="utf-8") as f:
         dep_pattern = re.compile(r"\"(.+?==.+?)\"")

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -548,8 +548,7 @@ def validate_pinned_dependencies() -> None:
     """"Checks installed version of pinned dependencies. Validate only imported ones."""
 
     with open(Path(__file__).parents[1] / "pyproject.toml", "r", encoding="utf-8") as f:
-        dep_pattern = re.compile(r"\"(.+?==.+?)\"")
-        for dependency in dep_pattern.findall(f.read()):
+        for dependency in re.findall(r"\"(.+?==.+?)\"", f.read()):
             dependency = dependency.split(";")[0]  # e.g. "name==version; python_version >= '3.10'"
             package_name, _, version = dependency.rpartition("==")
             if package_name in sys.modules and not RequirementCache(dependency):

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -549,9 +549,8 @@ def validate_pinned_dependencies() -> None:
 
     with open(Path(__file__).parents[1] / "pyproject.toml", "r", encoding="utf-8") as f:
         dep_pattern = re.compile(r"\"(.+?==.+?)\"")
-        for line in f:
-            if dependency := dep_pattern.search(line):
-                dependency = dependency.group(1).split(";")[0]  # e.g. "name==version; python_version >= '3.10'"
-                package_name, _, version = dependency.rpartition("==")
-                if package_name in sys.modules and not RequirementCache(dependency):
-                    warnings.warn(f"LitGPT only supports {package_name} v{version}. This may result in errors.")
+        for dependency in dep_pattern.findall(f.read()):
+            dependency = dependency.split(";")[0]  # e.g. "name==version; python_version >= '3.10'"
+            package_name, _, version = dependency.rpartition("==")
+            if package_name in sys.modules and not RequirementCache(dependency):
+                warnings.warn(f"LitGPT only supports {package_name} v{version}. This may result in errors.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ all = [
     "lm-eval>=0.4.2",            # litgpt.evaluate
     "safetensors>=0.4.3",        # download
     "huggingface_hub[hf_transfer]>=0.21.0"  # download
-    "toml>=0.10.2",              # validate pinned dependencies
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ all = [
     "lm-eval>=0.4.2",            # litgpt.evaluate
     "safetensors>=0.4.3",        # download
     "huggingface_hub[hf_transfer]>=0.21.0"  # download
+    "toml>=0.10.2",              # validate pinned dependencies
 ]
 
 [build-system]


### PR DESCRIPTION
Hi there 👋 

This is a result of my comment: https://github.com/Lightning-AI/litgpt/pull/1468#issuecomment-2155020974.

Some users might have an issue if they manually updated to the latest version of a dependency, while the code expects a specific version.
Currently we check bitsandbytes, but we have a couple more pinned dependencies.

The code parses `pyproject.toml` file, checks pinned version (with `==` sign) and if it was imported (mitigate false positives) and doesn't match to the pinned version - raise a warning.

The question is (before I go too deep with the PR): isn't it too complicated?

TODO:
- [ ] figure out where it's better to call the function 