### PR TITLE
Fix pip upgrade command on windows

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install minimal dependencies
       run: |
-        python -m pip install --upgrade pip
+        # python -m pip install --upgrade pip
         pip install .
         pip list
         # make sure all modules are still importable with only the minimal dependencies available

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Install minimal dependencies
       run: |
-        pip install --upgrade pip
+        python -m pip install --upgrade pip
         pip install .
         pip list
         # make sure all modules are still importable with only the minimal dependencies available


### PR DESCRIPTION
There are some issues with upgrading pip in the Windows CI. Trying to fix it.

```
Run pip install --upgrade pip
Requirement already satisfied: pip in c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages (24.0)
Collecting pip
  Downloading pip-24.1-py3-none-any.whl.metadata (3.6 kB)
Downloading pip-24.1-py3-none-any.whl (1.8 MB)
   ---------------------------------------- 1.8/1.8 MB 29.2 MB/s eta 0:00:00
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe -m pip install --upgrade pip
```