### PR TITLE
Update LLM import and make stream/non-stream option consistent

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -144,7 +144,6 @@ class LLM:
         top_k: Optional[int] = None,
         top_p: float = 1.0,
         eos_id: Optional[int] = None,
-        include_prompt: bool = True,
         return_as_token_ids: bool = False,
         stream: bool = False
     ) -> Union[str, torch.Tensor]:
@@ -172,7 +171,6 @@ class LLM:
                 For more details, see https://arxiv.org/abs/1904.09751
                 or https://huyenchip.com/2024/01/16/sampling.html#top_p
             eos_id: If specified, stop generating any more token once the <eos> token is triggered.
-            include_prompt: If true (default) prepends the prompt (after applying the prompt style) to the output.
             return_as_token_ids: If true. returns the generated tokens as IDs rather then detokenized text.
 
         """
@@ -216,7 +214,7 @@ class LLM:
                 top_k=top_k,
                 top_p=top_p,
                 eos_id=self.preprocessor.tokenizer.eos_id,
-                include_prompt=include_prompt,
+                include_prompt=False,
             )
 
         for block in self.model.transformer.h:

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -8,14 +8,14 @@ This is a work-in-progress draft describing the current LitGPT Python API (exper
 Download a model using the CLI:
 
 ```bash
-litgpt download EleutherAI/pythia-160m
+litgpt download microsoft/phi-2
 ```
 
 Then, load the model in Python:
 
 ```python
-from litgpt.api import LLM
-llm = LLM.load("EleutherAI/pythia-160m", accelerator="cuda")
+from litgpt import LLM
+llm = LLM.load("microsoft/phi-2", accelerator="cuda")
 ```
 
 ## Generate/Chat
@@ -23,20 +23,22 @@ llm = LLM.load("EleutherAI/pythia-160m", accelerator="cuda")
 Generate output using the `.generate` method:
 
 ```python
-text = llm.generate("What do Llamas eat?", top_k=1)
+text = llm.generate("What do Llamas eat?", top_k=1, max_new_tokens=30)
 print(text)
 ```
 
 ```
-What do Llamas eat?
-
-"A lot of people, the Llamas, I was, a Llamas, a lama, a lama, a lama, a lama, a lama, a lama, a lama, a
+Llamas are herbivores and primarily eat grass, leaves, and shrubs. They have a specialized digestive system that allows them to efficiently extract
 ```
 
-Generate with response streaming:
+Alternative, stream the response one token at a time:
 
-```
+```python
 result = llm.generate("hi", stream=True)
 for e in result:
     print(e, end="", flush=True)
+```
+
+```
+Llamas are herbivores and primarily eat grass, leaves, and shrubs. They have a specialized digestive system that allows them to efficiently extract
 ```


### PR DESCRIPTION
Changes the suggested import from 

```
from litgpt.api import LLM
```

to

```
from litgpt import LLM
```

Also, it makes the response consistent whether stream is selected or not. That means, the input tokens are not prepended to the returned output (if someone wants that, it's easy to do manually)