### PR TITLE
Add Python API download option

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -89,3 +89,16 @@ def test_llm_load_random_init(tmp_path):
     )
     text = llm.generate("text", max_new_tokens=10)
     assert len(text.split(" ")) > 5
+
+
+def test_llm_load_hub_init(tmp_path):
+
+    torch.manual_seed(123)
+    llm = LLM.load(
+        model="EleutherAI/pythia-14m",
+        accelerator="cpu",
+        devices=1,
+        init="hub"
+    )
+    text = llm.generate("text", max_new_tokens=10)
+    assert len(text) > 0

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -5,18 +5,24 @@ This is a work-in-progress draft describing the current LitGPT Python API (exper
 
 ## Model loading
 
-Download a model using the CLI:
-
-```bash
-litgpt download microsoft/phi-2
-```
-
-Then, load the model in Python:
+If `init="hub"`, the model will be downloaded and loaded automatically.
 
 ```python
 from litgpt import LLM
-llm = LLM.load("microsoft/phi-2", accelerator="cuda")
+llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="hub")
 ```
+
+If you already have a downloaded checkpoint on your computer, use `init="local"`:
+
+```python
+from litgpt import LLM
+llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="local")
+```
+
+&nbsp;
+> [!NOTE]
+> To get a list of all supported models, execute `litgpt download list` in the command line terminal.
+&nbsp;
 
 ## Generate/Chat
 


### PR DESCRIPTION
Adds an option to download the checkpoint from the hub:

```
from litgpt import LLM

llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="hub")
```

In a future PR, we can add support for `init="auto"` where we check if the local path contains a checkpoint, and if not, then download.

Or maybe we should do this already here and skip the download if the path exists ...