### PR TITLE
Tokenizer: prefer HF Tokenizer

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -101,7 +101,8 @@ class Tokenizer:
             bos_id = self.bos_id
             if bos_id is None:
                 raise NotImplementedError("This tokenizer does not have a defined a bos token")
-            tokens = [bos_id] + tokens
+            if tokens[0] != bos_id:
+                tokens = [bos_id] + tokens
         if eos:
             tokens = tokens + [self.eos_id]
         if max_length > 0:

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -17,16 +17,8 @@ class Tokenizer:
         self.bos_id = None
         self.eos_id = None
 
-        # some checkpoints have both files, `.model` takes precedence
-        if (vocabulary_path := checkpoint_dir / "tokenizer.model").is_file():
-            from sentencepiece import SentencePieceProcessor
-
-            self.processor = SentencePieceProcessor(model_file=str(vocabulary_path))
-            self.backend = "sentencepiece"
-            self.bos_id = self.processor.bos_id()
-            self.eos_id = self.processor.eos_id()
-
-        elif (vocabulary_path := checkpoint_dir / "tokenizer.json").is_file():
+        # some checkpoints have both files, `.json` takes precedence
+        if (vocabulary_path := checkpoint_dir / "tokenizer.json").is_file():
             from tokenizers import Tokenizer as HFTokenizer
 
             self.processor = HFTokenizer.from_file(str(vocabulary_path))
@@ -46,6 +38,14 @@ class Tokenizer:
                     self.bos_id = config.get("bos_token_id")
                 if self.eos_id is None:
                     self.eos_id = config.get("eos_token_id")
+
+        elif (vocabulary_path := checkpoint_dir / "tokenizer.model").is_file():
+            from sentencepiece import SentencePieceProcessor
+
+            self.processor = SentencePieceProcessor(model_file=str(vocabulary_path))
+            self.backend = "sentencepiece"
+            self.bos_id = self.processor.bos_id()
+            self.eos_id = self.processor.eos_id()
         else:
             raise NotImplementedError
 

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -103,7 +103,10 @@ class Tokenizer:
                 raise NotImplementedError("This tokenizer does not have a defined a bos token")
             if tokens[0] != bos_id:
                 tokens = [bos_id] + tokens
-        if eos:
+        if tokens is None:
+            raise ValueError("`tokens` is None")
+
+        if eos and (not tokens or tokens[-1] != eos_id):
             tokens = tokens + [self.eos_id]
         if max_length > 0:
             tokens = tokens[:max_length]

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -28,8 +28,12 @@ class Tokenizer:
                 with open(special_tokens_path, encoding="utf-8") as fp:
                     config = json.load(fp)
                 bos_token = config.get("bos_token")
-                self.bos_id = self.token_to_id(bos_token) if bos_token is not None else None
                 eos_token = config.get("eos_token")
+                if bos_token is not None and isinstance(bos_token, dict):
+                    bos_token = bos_token.get("content")
+                if eos_token is not None and isinstance(eos_token, dict):
+                    eos_token = eos_token.get("content")
+                self.bos_id = self.token_to_id(bos_token) if bos_token is not None else None
                 self.eos_id = self.token_to_id(eos_token) if eos_token is not None else None
             if (special_tokens_path := checkpoint_dir / "generation_config.json").is_file():
                 with open(special_tokens_path, encoding="utf-8") as fp:

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -106,7 +106,7 @@ class Tokenizer:
         if tokens is None:
             raise ValueError("`tokens` is None")
 
-        if eos and (not tokens or tokens[-1] != eos_id):
+        if eos and (not tokens or tokens[-1] != self.eos_id):
             tokens = tokens + [self.eos_id]
         if max_length > 0:
             tokens = tokens[:max_length]

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -11,7 +11,7 @@ import litgpt.config as config_module
 from litgpt.tokenizer import Tokenizer
 
 
-@pytest.mark.flaky(reruns=5)
+@pytest.mark.flaky(reruns=5, rerun_except=["AssertionError", "assert"])
 @pytest.mark.parametrize("config", config_module.configs, ids=[c["hf_config"]["name"] for c in config_module.configs])
 def test_tokenizer_against_hf(config):
     access_token = os.getenv("HF_TOKEN")

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -8,6 +8,7 @@ from transformers import AutoTokenizer
 from transformers.utils import cached_file
 
 import litgpt.config as config_module
+from litgpt import PromptStyle
 from litgpt.tokenizer import Tokenizer
 
 
@@ -67,6 +68,7 @@ def test_tokenizer_against_hf(config):
         assert ours.eos_id == theirs.eos_token_id
 
     prompt = "Hello, readers of this test!"
+    prompt = PromptStyle.from_config(config).apply(prompt)
     actual = ours.encode(prompt)
     expected = theirs.encode(prompt)
     if config.name.startswith("CodeLlama-70b"):

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -45,12 +45,12 @@ def test_tokenizer_against_hf(config):
     )
     ours = Tokenizer(checkpoint_dir)
 
+    assert ours.vocab_size == theirs.vocab_size
     if config.name.startswith("CodeLlama-70b-Instruct"):
         # TODO: the HF tokenizer returns 1 less token for this model. why?
-        assert ours.vocab_size == theirs.vocab_size + 1
+        assert ours.vocab_size == config.vocab_size - 1
     else:
-        assert ours.vocab_size == theirs.vocab_size
-    assert ours.vocab_size == config.vocab_size
+        assert ours.vocab_size == config.vocab_size
 
     if config.name.startswith("falcon") or config.name.startswith("stablecode"):
         # even though their config defines it, it's set as None in HF


### PR DESCRIPTION
Hi there 👋 

This PR changes the default tokenizer from SentencePiece to Tokenizers by HF.
There are mainly three reasons why it's a good idea:
1. Tokenizers library is faster* than SentencePiece
2. Easier to maintain
3. Easier to extend (if necessary)

> [!IMPORTANT]
> If a PR is created from a fork, then the `HF_TOKEN` is not shared. That means that tests for models/tokenizers from gated repos are skipped. **Before merging someone from the core team has to copy this branch to a new one, create a PR and run tests.** Like it was done in #1342.

### 1. Speed

Let's validate it with a simple benchmark:

```python
from time import perf_counter

import requests
from huggingface_hub import snapshot_download
from sentencepiece import SentencePieceProcessor
from tokenizers import Tokenizer as HFTokenizer
from transformers import PreTrainedTokenizerFast

# download tokenizer vocabs
snapshot_download(repo_id="TinyLlama/TinyLlama-1.1B-Chat-v1.0", local_dir=".", allow_patterns=["tokenizer.json", "tokenizer.model"])

# download data to encode
data = requests.get("https://raw.githubusercontent.com/karpathy/ng-video-lecture/master/input.txt").text
print(f"Number of chars to encode: {len(data):,}")
print("-" * 50)

# tokenizers to benchmark
sentencepiece_tokenizer = SentencePieceProcessor(model_file="tokenizer.model")
hf_tokenizer = HFTokenizer.from_file(path="tokenizer.json")
fast_tokenizer = PreTrainedTokenizerFast(tokenizer_file="tokenizer.json")

def bench(func: callable, repeats: int = 30) -> float:
    start = perf_counter()
    for _ in range(repeats):
        func()
    return (perf_counter() - start) / repeats


print("SentencePiece encode time: ", bench(lambda: sentencepiece_tokenizer.encode(data)))
print("HF Tokenizer  encode time: ", bench(lambda: hf_tokenizer.encode(data)))
print("FastTokenizer encode time: ", bench(lambda: fast_tokenizer.encode(data)))
print("-" * 50)

sp_ids = sentencepiece_tokenizer.encode(data)
hf_ids = hf_tokenizer.encode(data).ids
ft_ids = fast_tokenizer.encode(data)

print("SentencePiece decode time: ", bench(lambda: sentencepiece_tokenizer.decode(sp_ids)))
print("HF Tokenizer  decode time: ", bench(lambda: hf_tokenizer.decode(hf_ids)))
print("FastTokenizer decode time: ", bench(lambda: fast_tokenizer.decode(hf_ids)))
```

```text
Number of chars to encode: 1,115,394
--------------------------------------------------
SentencePiece encode time:  1.2004516734004331
HF Tokenizer  encode time:  0.5400692415996067
FastTokenizer encode time:  0.5723549843329238
--------------------------------------------------
SentencePiece decode time:  0.30017661056675327
HF Tokenizer  decode time:  0.39618176593309423
FastTokenizer decode time:  2.1387836453999625
```

As one can see, `HF Tokenizer` is ~2.3 times faster to encode, but ~1.32 times slower to decode (kinda odd).
Anyway, from my POV, given that the focus of LitGPT is training, it's a worthy change.


### 2. Maintenance

Vocabs for Tokenizers (`tokenizer.json`) usually has a full set of tokens in comparison to SentencePiece (`tokenizer.model`)

### 3. Extensibility

If the vocab is not full (missing added tokens) and we need to extend it, then it's way-way easier to do with Tokenizers (it has `.add_tokens` method). With SentencePiece we need to first read the file (which is in a protobuf format btw) with a special tool, add additional tokens with corresponding weights, save the file, and only then open it in SentencePiece processor. Should be doable, but not well documented.

For those who are curious, AutoTokenizer from HF doesn't use SentencePiece for encoding/decoding. If only an SP vocab is provided (or `is_slow=True` argument is specified), then the code first loads the vocab into the SP tokenizer, then the vocab is extracted and passed to the HF Tokenizer instance.