### PR TITLE
Add Rope group size as constexpr to fix thunder tests

### DIFF
--- a/extensions/thunder/unsloth/kernels/rope_embedding.py
+++ b/extensions/thunder/unsloth/kernels/rope_embedding.py
@@ -26,10 +26,11 @@ def _rope_embedding(
     cos, cos_row_stride,
     sin, sin_row_stride,
     seqlen,
-    head_dim      : tl.constexpr,
-    n_heads       : tl.constexpr,
-    BACKWARD_PASS : tl.constexpr,
-    BLOCK_SIZE    : tl.constexpr,
+    head_dim        : tl.constexpr,
+    n_heads         : tl.constexpr,
+    BACKWARD_PASS   : tl.constexpr,
+    BLOCK_SIZE      : tl.constexpr,
+    ROPE_GROUP_SIZE : tl.constexpr,
 ):
     """
         Calculates the RoPE Embedding quickly

--- a/extensions/thunder/unsloth/kernels/rope_embedding.py
+++ b/extensions/thunder/unsloth/kernels/rope_embedding.py
@@ -30,7 +30,7 @@ def _rope_embedding(
     n_heads         : tl.constexpr,
     BACKWARD_PASS   : tl.constexpr,
     BLOCK_SIZE      : tl.constexpr,
-    ROPE_GROUP_SIZE : tl.constexpr,
+    ROPE_GROUP_SIZE : tl.constexpr = 4,
 ):
     """
         Calculates the RoPE Embedding quickly


### PR DESCRIPTION
This is an attempt to fix one of the Thunder tests due to the new stricter triton in the latest PyTorch nightly: https://dev.azure.com/Lightning-AI/lit%20Models/_build/results?buildId=206391&view=logs&j=05e5d4de-bf1b-5a1e-701d-c4191065dd60&t=014e096d-69a7-571e-fca7-00c9b59c1724