### PR TITLE
Add automatic checkpoint downloading in Python API

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -106,10 +106,9 @@ class LLM:
                 "Support for multiple devices is currently not implemented, yet."
             )
 
-        if init == "auto":
-            pass
+        allowed_init = {"auto", "hub_HF", "local"}
 
-        elif init == "hub_HF":
+        if init == "hub_HF":
             from litgpt.scripts.download import download_from_hub  # Moved here due to the circular import issue in LitGPT that we need to solve some time
 
             checkpoint_dir = extend_checkpoint_dir(Path(model))

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -75,7 +75,7 @@ def reset_parameters(module: nn.Module) -> None:
             mod.reset_parameters()
 
 
-def check_valid_checkpoint_dir(checkpoint_dir: Path, model_filename: str = "lit_model.pth") -> None:
+def check_valid_checkpoint_dir(checkpoint_dir: Path, model_filename: str = "lit_model.pth", verbose: bool = True, raise_error: bool = False) -> None:
     files = {
         model_filename: (checkpoint_dir / model_filename).is_file(),
         "model_config.yaml": (checkpoint_dir / "model_config.yaml").is_file(),
@@ -99,13 +99,18 @@ def check_valid_checkpoint_dir(checkpoint_dir: Path, model_filename: str = "lit_
     else:
         extra = ""
 
-    error_message = (
-        f"checkpoint_dir {str(checkpoint_dir.absolute())!r}{problem}."
-        "\nFind download instructions at https://github.com/Lightning-AI/litgpt/blob/main/tutorials\n"
-        f"{extra}\nSee all download options by running:\n litgpt download"
-    )
-    print(error_message, file=sys.stderr)
-    raise SystemExit(1)
+    if verbose:
+        error_message = (
+            f"checkpoint_dir {str(checkpoint_dir.absolute())!r}{problem}."
+            "\nFind download instructions at https://github.com/Lightning-AI/litgpt/blob/main/tutorials\n"
+            f"{extra}\nSee all download options by running:\n litgpt download"
+        )
+        print(error_message, file=sys.stderr)
+
+    if raise_error:
+        raise FileNotFoundError(f"checkpoint_dir {str(checkpoint_dir.absolute())!r}{problem}.")
+    else:
+        raise SystemExit(1)
 
 
 class SavingProxyForStorage:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,7 +98,7 @@ def test_llm_load_hub_init(tmp_path):
         model="EleutherAI/pythia-14m",
         accelerator="cpu",
         devices=1,
-        init="hub"
+        init="hub_HF"
     )
     text = llm.generate("text", max_new_tokens=10)
     assert len(text) > 0

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -5,19 +5,16 @@ This is a work-in-progress draft describing the current LitGPT Python API (exper
 
 ## Model loading
 
-If `init="hub"`, the model will be downloaded and loaded automatically.
 
 ```python
 from litgpt import LLM
-llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="hub")
+llm = LLM.load("microsoft/phi-2", accelerator="cuda")
 ```
 
-If you already have a downloaded checkpoint on your computer, use `init="local"`:
-
-```python
-from litgpt import LLM
-llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="local")
-```
+&nbsp;
+> [!TIP]
+> The command above will download the model automatically if it doesn't already exist at `"microsoft/phi-2"` or `"checkpoints/microsoft/phi-2"`. If you want to suppress automatic downloads, pass the additional `init="local"` setting: `llm = LLM.load("microsoft/phi-2", accelerator="cuda", init="local")`
+&nbsp;
 
 &nbsp;
 > [!NOTE]


### PR DESCRIPTION
Adds the following behavior


#### a) Initialize a random model (no pretrained weights)

```python
LLM(model="microsoft/phi-2", init="random")
```

#### b) DEFAULT: Download a model from the hub , but don’t download if a model exists locally via the "microsoft/phi-2" path:

```python
LLM(model="microsoft/phi-2")
```

#### c) Load a model from a local directory:

Same as above, if model exists via the "microsoft/phi-2" path:

```python
LLM(model="microsoft/phi-2")
```

#### d) Pro user can optionally suppress automatic download

```python
LLM(model="microsoft/phi-2", init="local")
```

CC @lantiga @williamFalcon 