### PR TITLE
Fix Twine Build Issue

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Build source and wheel distributions
         run: |
           python -m pip install --upgrade build twine
+          pip install importlib_metadata==7.2.1
           python -m build
           twine check --strict dist/*
       - name: Publish distribution to PyPI


### PR DESCRIPTION
There's currently a build issue with Twine:

```
...
adding 'litgpt-0.4.2.dist-info/RECORD'
removing build/bdist.linux-x86_64/wheel
Successfully built litgpt-0.4.2.tar.gz and litgpt-0.4.2-py3-none-any.whl
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.4/x64/bin/twine", line 5, in <module>
    from twine.__main__ import main
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/twine/__init__.py", line 40, in <module>
    __uri__ = metadata["home-page"]
              ~~~~~~~~^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.4/x64/lib/python3.12/site-packages/importlib_metadata/_adapters.py", line 54, in __getitem__
    raise KeyError(item)
KeyError: 'home-page'
Error: Process completed with exit code 1.
```

See https://github.com/pypa/twine/issues/977 for details.