### PR TITLE
Tutorial `convert_from_litgpt` doc fix to remove `output_dir` command argument

### DIFF
--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -516,8 +516,7 @@ Output: Example input.
 Sometimes, it can be useful to convert LitGPT model weights for third-party and external tools. For example, we can convert a LitGPT model to the Hugging Face format and save it via `.safetensors` files, which we can do as follows:
 
 ```bash
-litgpt convert_from_litgpt microsoft/phi-2 \
-    --output_dir out/converted_model/
+litgpt convert_from_litgpt microsoft/phi-2 out/converted_model/
 ```
 
 Certain tools like the `.from_pretrained` method in Hugging Face `transformers` also require the original `config.json` file that originally came with the downloaded model:

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -4,7 +4,7 @@ LitGPT weights need to be converted to a format that Hugging Face understands wi
 
 We provide a helpful command to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
 
-```sh
+```bash
 litgpt convert_from_litgpt checkpoint_dir converted_dir
 ```
 

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -5,8 +5,7 @@ LitGPT weights need to be converted to a format that Hugging Face understands wi
 We provide a helpful command to convert models LitGPT models back to their equivalent Hugging Face Transformers format:
 
 ```sh
-litgpt convert_from_litgpt checkpoint_dir \
-    --output_dir converted_dir
+litgpt convert_from_litgpt checkpoint_dir converted_dir
 ```
 
 These paths are just placeholders, you will need to customize them based on which finetuning or pretraining command you ran and its configuration.
@@ -98,8 +97,7 @@ litgpt merge_lora $finetuned_dir/final
 4. Convert the finetuning model back into a HF format:
 
 ```bash
-litgpt convert from_litgpt $finetuned_dir/final/ \
-   --output_dir out/hf-tinyllama/converted \
+litgpt convert_from_litgpt $finetuned_dir/final/ out/hf-tinyllama/converted
 ```
 
 


### PR DESCRIPTION
This PR provides a minor documentation fix for `convert_from_litgpt` command examples to remove the `output_dir` flag.  This flag is no longer supported by the CLI, instead the output is specified as the second position argument.