### PR TITLE
Test against eager attention on GPTNeoX

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -84,6 +84,7 @@ def test_against_gpt_neox_model(rotary_pct, batch_size, n_embd, parallel_residua
         rotary_pct=ours_config.rotary_percentage,
         vocab_size=ours_config.padded_vocab_size,
         use_parallel_residual=ours_config.parallel_residual,
+        attn_implementation="eager",
     )
 
     state_dict = {}


### PR DESCRIPTION
There was a recent HF release that changed the default attention mechanism in GPTNeoX. So, this PR hardcodes it to the previous one we test against.