### PR TITLE
Update phi-3 prompt template

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -311,7 +311,7 @@ class Phi2(PromptStyle):
 
 class Phi3(PromptStyle):
     def apply(self, prompt: str, **kwargs: str) -> str:
-        return f'<s><|user|>\n{prompt}<|end|>\n<|assistant|>\n'
+        return f'<|system|>\nYou are a helpful assistant.<|end|>\n<|user|>\n{prompt}<|end|>\n<|assistant|>\n'
 
 
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -75,9 +75,6 @@ def test_tokenizer_against_hf(config):
         # TODO: there's a encoding difference with this model. why? note that the decoding is equal
         # "Hello": 10994, "▁Hello": 15043
         assert [15043 if t == 10994 else t for t in actual.tolist()] == expected
-    elif config.name.startswith("Phi-3"):
-        # Phi-3 tokenizer adds `bos` twice
-        assert [ours.bos_id] + actual.tolist() == expected
     else:
         assert actual.tolist() == expected
     assert ours.decode(actual) == theirs.decode(expected, skip_special_tokens=True)


### PR DESCRIPTION
Coincidentally, after we merged the Phi-3 checkpoint, Microsoft silently made some updates to Phi-3:

<img width="1577" alt="Screenshot 2024-07-02 at 9 38 54 AM" src="https://github.com/Lightning-AI/litgpt/assets/5618407/a6ee3e5e-0961-4fa5-8d2d-5deb6805e19a">


This includes the prompt template, which is now 

```
<|system|>
You are a helpful assistant.<|end|>
<|user|>
hello world
<|assistant|> 
```

and the removal of the double-BOS token.
