### PR TITLE
Add num_nodes argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/falcon-7b/lora.yaml
+++ b/config_hub/finetune/falcon-7b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/falcon-7b/qlora.yaml
+++ b/config_hub/finetune/falcon-7b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/gemma-2b/full.yaml
+++ b/config_hub/finetune/gemma-2b/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 4
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
   class_path: litgpt.data.Alpaca2k

--- a/config_hub/finetune/gemma-2b/lora.yaml
+++ b/config_hub/finetune/gemma-2b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 8
 

--- a/config_hub/finetune/gemma-2b/qlora.yaml
+++ b/config_hub/finetune/gemma-2b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 16
 

--- a/config_hub/finetune/gemma-7b/lora.yaml
+++ b/config_hub/finetune/gemma-7b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 16
 

--- a/config_hub/finetune/gemma-7b/qlora.yaml
+++ b/config_hub/finetune/gemma-7b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 16
 

--- a/config_hub/finetune/llama-2-7b/full.yaml
+++ b/config_hub/finetune/llama-2-7b/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use (type: Union[int, str], default: 1)
 devices: 4
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
 # from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
 # ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.

--- a/config_hub/finetune/llama-2-7b/lora.yaml
+++ b/config_hub/finetune/llama-2-7b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/llama-2-7b/qlora.yaml
+++ b/config_hub/finetune/llama-2-7b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/llama-3-8b/full.yaml
+++ b/config_hub/finetune/llama-3-8b/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use (type: Union[int, str], default: 1)
 devices: 4
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
 # from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
 # ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.

--- a/config_hub/finetune/llama-3-8b/lora.yaml
+++ b/config_hub/finetune/llama-3-8b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/llama-3-8b/qlora.yaml
+++ b/config_hub/finetune/llama-3-8b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/mistral-7b-v0.2/lora.yaml
+++ b/config_hub/finetune/mistral-7b-v0.2/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/mistral-7b-v0.2/qlora.yaml
+++ b/config_hub/finetune/mistral-7b-v0.2/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/mistral-7b/lora.yaml
+++ b/config_hub/finetune/mistral-7b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/mistral-7b/qlora.yaml
+++ b/config_hub/finetune/mistral-7b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/phi-2/full.yaml
+++ b/config_hub/finetune/phi-2/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use (type: Union[int, str], default: 1)
 devices: 2
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
 # from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
 # ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.

--- a/config_hub/finetune/phi-2/lora.yaml
+++ b/config_hub/finetune/phi-2/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 8
 

--- a/config_hub/finetune/phi-2/qlora.yaml
+++ b/config_hub/finetune/phi-2/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 8
 

--- a/config_hub/finetune/stablelm-base-alpha-3b/full.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 2
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
   class_path: litgpt.data.Alpaca2k

--- a/config_hub/finetune/stablelm-base-alpha-3b/lora.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/stablelm-base-alpha-3b/qlora.yaml
+++ b/config_hub/finetune/stablelm-base-alpha-3b/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/tiny-llama/full.yaml
+++ b/config_hub/finetune/tiny-llama/full.yaml
@@ -11,6 +11,9 @@ precision: bf16-true
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
   class_path: litgpt.data.Alpaca2k

--- a/config_hub/finetune/tiny-llama/lora.yaml
+++ b/config_hub/finetune/tiny-llama/lora.yaml
@@ -14,6 +14,9 @@ quantize:
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/finetune/tiny-llama/qlora.yaml
+++ b/config_hub/finetune/tiny-llama/qlora.yaml
@@ -14,6 +14,9 @@ quantize: bnb.nf4
 # How many devices/GPUs to use. (type: Union[int, str], default: 1)
 devices: 1
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # The LoRA rank. (type: int, default: 8)
 lora_r: 32
 

--- a/config_hub/pretrain/debug.yaml
+++ b/config_hub/pretrain/debug.yaml
@@ -105,6 +105,9 @@ optimizer:
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
 # module require this. (type: Optional[Path], default: null)
 tokenizer_dir: checkpoints/EleutherAI/pythia-14m

--- a/config_hub/pretrain/microllama.yaml
+++ b/config_hub/pretrain/microllama.yaml
@@ -106,6 +106,9 @@ optimizer:
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
 # module require this. (type: Optional[Path], default: null)
 tokenizer_dir: checkpoints/meta-llama/Llama-2-7b-hf

--- a/config_hub/pretrain/tinyllama.yaml
+++ b/config_hub/pretrain/tinyllama.yaml
@@ -105,6 +105,9 @@ optimizer:
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
 # module require this. (type: Optional[Path], default: null)
 tokenizer_dir: checkpoints/meta-llama/Llama-2-7b-hf

--- a/config_hub/pretrain/tinystories.yaml
+++ b/config_hub/pretrain/tinystories.yaml
@@ -121,6 +121,9 @@ optimizer:
 # How many devices/GPUs to use. Uses all GPUs by default. (type: Union[int, str], default: auto)
 devices: auto
 
+# How many nodes to use. (type: int, default: 1)
+num_nodes: 1
+
 # Optional path to the tokenizer dir that was used for preprocessing the dataset. Only some data
 # module require this. (type: Optional[Path], default: null)
 tokenizer_dir: checkpoints/meta-llama/Llama-2-7b-hf

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -47,6 +47,7 @@ def setup(
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: Union[int, str] = 1,
+    num_nodes: int = 1,
     data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
         save_interval=1000,
@@ -71,6 +72,7 @@ def setup(
         precision: The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true".
         quantize: If set, quantize the model with this algorithm. See ``tutorials/quantize.md`` for more information.
         devices: How many devices/GPUs to use.
+        num_nodes: How many nodes the code is being run on.
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
@@ -103,11 +105,11 @@ def setup(
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
 
-    if devices > 1:
+    if devices * num_nodes > 1:
         if quantize:
             raise NotImplementedError(
-                "Quantization is currently not supported for multi-GPU training. Please set devices=1 when using the"
-                " --quantize flag."
+                "Quantization is currently not supported for multi-GPU training. Please set devices=1 and num_nodes=1"
+                " when using the --quantize flag."
             )
         strategy = FSDPStrategy(
             auto_wrap_policy={Block},
@@ -119,7 +121,14 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
+    fabric = L.Fabric(
+        devices=devices,
+        num_nodes=num_nodes,
+        strategy=strategy,
+        precision=precision,
+        loggers=logger,
+        plugins=plugins,
+    )
     fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
@@ -148,7 +157,7 @@ def main(
         os.makedirs(out_dir, exist_ok=True)
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
-    with fabric.init_module(empty_init=(devices > 1)):
+    with fabric.init_module(empty_init=(fabric.world_size > 1)):
         model = GPT(config)
     mark_only_adapter_as_trainable(model)
 

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -47,6 +47,7 @@ def setup(
     precision: Optional[str] = None,
     quantize: Optional[Literal["bnb.nf4", "bnb.nf4-dq", "bnb.fp4", "bnb.fp4-dq", "bnb.int8-training"]] = None,
     devices: Union[int, str] = 1,
+    num_nodes: int = 1,
     data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
         save_interval=1000,
@@ -71,6 +72,7 @@ def setup(
         precision: The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true".
         quantize: If set, quantize the model with this algorithm. See ``tutorials/quantize.md`` for more information.
         devices: How many devices/GPUs to use.
+        num_nodes: How many nodes the code is being run on.
         data: Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
         train: Training-related arguments. See ``litgpt.args.TrainArgs`` for details.
         eval: Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details.
@@ -103,11 +105,11 @@ def setup(
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
 
-    if devices > 1:
+    if devices * num_nodes > 1:
         if quantize:
             raise NotImplementedError(
-                "Quantization is currently not supported for multi-GPU training. Please set devices=1 when using the"
-                " --quantize flag."
+                "Quantization is currently not supported for multi-GPU training. Please set devices=1 and num_nodes=1"
+                " when using the --quantize flag."
             )
         strategy = FSDPStrategy(
             auto_wrap_policy={Block},
@@ -119,7 +121,14 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger, plugins=plugins)
+    fabric = L.Fabric(
+        devices=devices,
+        num_nodes=num_nodes,
+        strategy=strategy,
+        precision=precision,
+        loggers=logger,
+        plugins=plugins,
+    )
     fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
@@ -148,7 +157,7 @@ def main(
         os.makedirs(out_dir, exist_ok=True)
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
-    with fabric.init_module(empty_init=(devices > 1)):
+    with fabric.init_module(empty_init=(fabric.world_size > 1)):
         model = GPT(config)
     mark_only_adapter_v2_as_trainable(model)
 

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -42,6 +42,7 @@ def setup(
     out_dir: Path = Path("out/finetune/full"),
     precision: Optional[str] = None,
     devices: Union[int, str] = 1,
+    num_nodes: int = 1,
     resume: Union[bool, Literal["auto"], Path] = False,
     data: Optional[DataModule] = None,
     train: TrainArgs = TrainArgs(
@@ -66,6 +67,7 @@ def setup(
             /teamspace/jobs/<job-name>/share.
         precision: The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true".
         devices: How many devices/GPUs to use
+        num_nodes: How many nodes the code is being run on.
         resume: Path to a checkpoint directory to resume from in case training was interrupted, or ``True`` to resume
             from the latest checkpoint in ``out_dir``. An error will be raised if no checkpoint is found. Passing
             ``'auto'`` will resume from the latest checkpoint but not error if no checkpoint exists.
@@ -90,7 +92,7 @@ def setup(
         logger_name, out_dir, name=f"finetune-{config.name}", resume=bool(resume), log_interval=train.log_interval
     )
 
-    if devices > 1:
+    if devices * num_nodes > 1:
         strategy = FSDPStrategy(
             auto_wrap_policy={Block},
             activation_checkpointing_policy={Block},
@@ -101,7 +103,7 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(devices=devices, strategy=strategy, precision=precision, loggers=logger)
+    fabric = L.Fabric(devices=devices, num_nodes=num_nodes, strategy=strategy, precision=precision, loggers=logger)
     fabric.launch(main, devices, resume, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 
@@ -131,7 +133,7 @@ def main(
         os.makedirs(out_dir, exist_ok=True)
 
     checkpoint_path = checkpoint_dir / "lit_model.pth"
-    with fabric.init_module(empty_init=(devices > 1)):
+    with fabric.init_module(empty_init=(fabric.world_size > 1)):
         model = GPT(config)
 
     fabric.print(f"Number of trainable parameters: {num_parameters(model, requires_grad=True):,}")

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -318,6 +318,7 @@ Running the previous finetuning command will initiate the finetuning process, wh
  'lora_query': True,
  'lora_r': 8,
  'lora_value': True,
+ 'num_nodes': 1,
  'out_dir': PosixPath('out/finetune/lora-phi-2'),
  'precision': 'bf16-true',
  'quantize': None,


### PR DESCRIPTION
Make code run correctly in the multi-node setting.

This mainly introduces the `num_nodes` argument ~~and fixes all
occurrences of `TrainArgs` method calls that were previously only
supplied the number of devices instead of the world size (which we now
access using `fabric.world_size`)~~.

~~Because we no longer need to pass the `devices` integer around, this
argument is removed from all signatures.~~

~~I also took the liberty to rename the `devices` argument of the methods
of `TrainArgs` to `world_size` for future clarity.~~