### PR TITLE
Update how evaluate tasks are listed

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -56,14 +56,6 @@ def convert_and_evaluate(
         save_filepath: The file where the results will be saved.
             Saves to `out_dir/results.json` by default.
     """
-    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
-    pprint(locals())
-
-    if not (isinstance(batch_size, int) and batch_size > 0) and not (isinstance(batch_size, str) and batch_size.startswith("auto")):
-        raise ValueError("batch_size must be a positive integer, 'auto', or in the format 'auto:N'.")
-
-    from lm_eval import evaluator
-
     if tasks is None:
         from lm_eval.tasks import TaskManager
         taskm = TaskManager()
@@ -72,9 +64,17 @@ def convert_and_evaluate(
             "\n\nTo evaluate multiple tasks, you can chain the task names "
             "listed above via a comma-separated list."
             "\nFor example: `--tasks 'hellaswag,truthfulqa_mc2,mmlu'`. "
-            "\nTo search for a specific task, use `litgpt evaluate | grep task_name`."
+            "\nTo search for a specific task, use `litgpt evaluate list | grep task_name`."
         )
         return
+
+    checkpoint_dir = extend_checkpoint_dir(checkpoint_dir)
+    pprint(locals())
+
+    if not (isinstance(batch_size, int) and batch_size > 0) and not (isinstance(batch_size, str) and batch_size.startswith("auto")):
+        raise ValueError("batch_size must be a positive integer, 'auto', or in the format 'auto:N'.")
+
+    from lm_eval import evaluator
 
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -461,7 +461,6 @@ Time for inference: 1.14 sec total, 26.26 tokens/sec, 30 tokens
 
 LitGPT comes with a handy `litgpt evaluate` command to evaluate models with [Eleuther AI's Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness). For example, to evaluate the previously downloaded `microsoft/phi-2` model on several tasks available from the Evaluation Harness, you can use the following command:
 
-- TODO: Explain root dir
 
 ```bash
 litgpt evaluate microsoft/phi-2

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -67,7 +67,7 @@ response = requests.post(
     stream=True
 )
 
-# stream the response
+# stream the responseclear
 for line in response.iter_lines(decode_unicode=True):
     if line:
         print(json.loads(line)["output"], end="")

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -67,7 +67,7 @@ response = requests.post(
     stream=True
 )
 
-# stream the responseclear
+# stream the response
 for line in response.iter_lines(decode_unicode=True):
     if line:
         print(json.loads(line)["output"], end="")

--- a/tutorials/evaluation.md
+++ b/tutorials/evaluation.md
@@ -71,8 +71,8 @@ litgpt evaluate microsoft/phi-2/ \
 &nbsp;
 
 > [!TIP]
-> Run `litgpt evaluate ...` without specifying `--tasks` to print a list
-> of the supported tasks. 
+> Run `litgpt evaluate list` to print a list
+> of the supported tasks. To filter for a specific subset of tasks, e.g., MMLU, use `litgpt evaluate list | grep mmlu`.
 
 > [!TIP]
 > The evaluation may take a long time, and for testing purpoes, you may want to reduce the number of tasks


### PR DESCRIPTION
This updates the instruction on how users can get the task list in `litgpt evaluate`. I.e., 


```bash
litgpt evaluate list | grep mmlu
```

```
mmlu_philosophy_generative
mmlu_humanities_generative
mmlu_high_school_european_history_generative
mmlu_moral_disputes_generative
mmlu_anatomy_generative
mmlu_stem_generative
mmlu_business_ethics_generative
...
```