### PR TITLE
Add Phi-3 Configs

### DIFF
--- a/config_hub/finetune/README.md
+++ b/config_hub/finetune/README.md
@@ -52,7 +52,7 @@ All experiments were conducted using bfloat-16 precision on the Alpaca2k dataset
 | phi-2/lora.yaml                   | phi-2                  | 1      | 512            | 4                | 4xA10G  | 3.78 min         | $0.3 | 13.98 GB    | 0.820           | 2.271                 | 52.4%           |
 | phi-2/qlora.yaml                  | phi-2                  | 1      | 512            | 4                | 1xA10G  | 4.51 min         | $0.1 | 14.27 GB    | 0.837           | 2.310                 | 52.3%           |
 | phi-2/qlora.yaml                  | phi-2                  | 1      | 512            | 4                | 4xA10G  | 4.52 min         | $0.4 | 14.27 GB    | 0.837           | 2.309                 | 52.3%           |
-|
+|                                   |                        |        |                |                  |         |                  |      |             |                 |                       |                 |
 | phi-3/full.yaml                   | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 6.93 min         | $0.2 | 17.01 GB    | 0.714           | 2.043                 | 69.81%          |
 | phi-3/lora.yaml                   | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 6.46 min         | $0.2 | 19.75 GB    | 0.707           | 2.028                 | 69.70%          |
 | phi-3/qlora.yaml                  | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 7.47 min         | $0.2 | 19.13 GB    | 0.729           | 2.074                 | 68.96%          |

--- a/config_hub/finetune/README.md
+++ b/config_hub/finetune/README.md
@@ -52,6 +52,10 @@ All experiments were conducted using bfloat-16 precision on the Alpaca2k dataset
 | phi-2/lora.yaml                   | phi-2                  | 1      | 512            | 4                | 4xA10G  | 3.78 min         | $0.3 | 13.98 GB    | 0.820           | 2.271                 | 52.4%           |
 | phi-2/qlora.yaml                  | phi-2                  | 1      | 512            | 4                | 1xA10G  | 4.51 min         | $0.1 | 14.27 GB    | 0.837           | 2.310                 | 52.3%           |
 | phi-2/qlora.yaml                  | phi-2                  | 1      | 512            | 4                | 4xA10G  | 4.52 min         | $0.4 | 14.27 GB    | 0.837           | 2.309                 | 52.3%           |
+|
+| phi-3/full.yaml                   | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 6.93 min         | $0.2 | 17.01 GB    | 0.714           | 2.043                 | 69.81%          |
+| phi-3/lora.yaml                   | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 6.46 min         | $0.2 | 19.75 GB    | 0.707           | 2.028                 | 69.70%          |
+| phi-3/qlora.yaml                  | Phi-3-mini-4k-instruct | 1      | 512            | 4                | 1xA10G  | 7.47 min         | $0.2 | 19.13 GB    | 0.729           | 2.074                 | 68.96%          |
 |                                   |                        |        |                |                  |         |                  |      |             |                 |                       |                 |
 | stablelm-base-alpha-3b/full.yaml  | stablelm-base-alpha-3b | 1      | 512            | 1                | 4xA10G  | 70.13 min        | $5.6 | 21.23 GB    | 1.513           | 4.540                 | 23.2%           |
 | stablelm-base-alpha-3b/lora.yaml  | stablelm-base-alpha-3b | 4      | 512            | 1                | 1xA10G  | 13.07 min        | $0.4 | 8.58 GB     | 1.361           | 3.900                 | 25.9%           |

--- a/config_hub/finetune/phi-3/full.yaml
+++ b/config_hub/finetune/phi-3/full.yaml
@@ -1,15 +1,15 @@
 
 # The path to the base model's checkpoint directory to load for finetuning. (type: <class 'Path'>, default: checkpoints/stabilityai/stablelm-base-alpha-3b)
-checkpoint_dir: checkpoints/microsoft/phi-2
+checkpoint_dir: checkpoints/microsoft/Phi-3-mini-4k-instruct
 
 # Directory in which to save checkpoints and logs. (type: <class 'Path'>, default: out/finetune/full)
-out_dir: out/finetune/full-phi-2
+out_dir: out/finetune/full-phi-3
 
 # The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true". (type: Optional[str], default: null)
 precision: bf16-true
 
 # How many devices/GPUs to use (type: Union[int, str], default: 1)
-devices: 2
+devices: 1
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
@@ -46,7 +46,7 @@ train:
   max_tokens:
 
   # Limits the number of optimizer steps to run. (type: Optional[int], default: null)
-  max_steps: 100
+  max_steps:
 
   # Limits the length of samples. Off by default (type: Optional[int], default: null)
   max_seq_length: 512

--- a/config_hub/finetune/phi-3/lora.yaml
+++ b/config_hub/finetune/phi-3/lora.yaml
@@ -1,21 +1,52 @@
 
 # The path to the base model's checkpoint directory to load for finetuning. (type: <class 'Path'>, default: checkpoints/stabilityai/stablelm-base-alpha-3b)
-checkpoint_dir: checkpoints/microsoft/phi-2
+checkpoint_dir: checkpoints/microsoft/Phi-3-mini-4k-instruct
 
-# Directory in which to save checkpoints and logs. (type: <class 'Path'>, default: out/finetune/full)
-out_dir: out/finetune/full-phi-2
+# Directory in which to save checkpoints and logs. (type: <class 'Path'>, default: out/lora)
+out_dir: out/finetune/lora-phi-3
 
 # The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true". (type: Optional[str], default: null)
 precision: bf16-true
 
-# How many devices/GPUs to use (type: Union[int, str], default: 1)
-devices: 2
+# If set, quantize the model with this algorithm. See ``tutorials/quantize.md`` for more information. (type: Optional[Literal['nf4', 'nf4-dq', 'fp4', 'fp4-dq', 'int8-training']], default: null)
+quantize:
+
+# How many devices/GPUs to use. (type: Union[int, str], default: 1)
+devices: 1
+
+# The LoRA rank. (type: int, default: 8)
+lora_r: 8
+
+# The LoRA alpha. (type: int, default: 16)
+lora_alpha: 16
+
+# The LoRA dropout value. (type: float, default: 0.05)
+lora_dropout: 0.05
+
+# Whether to apply LoRA to the query weights in attention. (type: bool, default: True)
+lora_query: true
+
+# Whether to apply LoRA to the key weights in attention. (type: bool, default: False)
+lora_key: true
+
+# Whether to apply LoRA to the value weights in attention. (type: bool, default: True)
+lora_value: true
+
+# Whether to apply LoRA to the output projection in the attention block. (type: bool, default: False)
+lora_projection: true
+
+# Whether to apply LoRA to the weights of the MLP in the attention block. (type: bool, default: False)
+lora_mlp: true
+
+# Whether to apply LoRA to output head in GPT. (type: bool, default: False)
+lora_head: true
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
   class_path: litgpt.data.Alpaca2k
   init_args:
     mask_prompt: false
+    val_split_fraction: 0.03847
     prompt_style: alpaca
     ignore_index: -100
     seed: 42
@@ -25,19 +56,19 @@ data:
 train:
 
   # Number of optimizer steps between saving checkpoints (type: Optional[int], default: 1000)
-  save_interval: 200
+  save_interval: 800
 
   # Number of iterations between logging calls (type: int, default: 1)
   log_interval: 1
 
-  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 64)
+  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 128)
   global_batch_size: 8
 
-  # Number of samples per data-parallel rank (type: int, default: 1)
+  # Number of samples per data-parallel rank (type: int, default: 4)
   micro_batch_size: 4
 
   # Number of iterations with learning rate warmup active (type: int, default: 100)
-  lr_warmup_steps: 200
+  lr_warmup_steps: 10
 
   # Number of epochs to train on (type: Optional[int], default: 5)
   epochs: 1
@@ -46,7 +77,7 @@ train:
   max_tokens:
 
   # Limits the number of optimizer steps to run. (type: Optional[int], default: null)
-  max_steps: 100
+  max_steps:
 
   # Limits the length of samples. Off by default (type: Optional[int], default: null)
   max_seq_length: 512
@@ -63,8 +94,8 @@ train:
 # Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details
 eval:
 
-  # Number of optimizer steps between evaluation calls (type: int, default: 600)
-  interval: 25
+  # Number of optimizer steps between evaluation calls (type: int, default: 100)
+  interval: 100
 
   # Number of tokens to generate (type: Optional[int], default: 100)
   max_new_tokens: 100
@@ -95,7 +126,7 @@ optimizer:
     lr: 0.0002
     
     #   (type: float, default: 0.01)
-    weight_decay: 0.1
+    weight_decay: 0.0
     
     #   (type: tuple, default: (0.9,0.999))
     betas:

--- a/config_hub/finetune/phi-3/qlora.yaml
+++ b/config_hub/finetune/phi-3/qlora.yaml
@@ -1,21 +1,52 @@
 
 # The path to the base model's checkpoint directory to load for finetuning. (type: <class 'Path'>, default: checkpoints/stabilityai/stablelm-base-alpha-3b)
-checkpoint_dir: checkpoints/microsoft/phi-2
+checkpoint_dir: checkpoints/microsoft/Phi-3-mini-4k-instruct
 
-# Directory in which to save checkpoints and logs. (type: <class 'Path'>, default: out/finetune/full)
-out_dir: out/finetune/full-phi-2
+# Directory in which to save checkpoints and logs. (type: <class 'Path'>, default: out/lora)
+out_dir: out/finetune/qlora-phi-3
 
 # The precision to use for finetuning. Possible choices: "bf16-true", "bf16-mixed", "32-true". (type: Optional[str], default: null)
 precision: bf16-true
 
-# How many devices/GPUs to use (type: Union[int, str], default: 1)
-devices: 2
+# If set, quantize the model with this algorithm. See ``tutorials/quantize.md`` for more information. (type: Optional[Literal['nf4', 'nf4-dq', 'fp4', 'fp4-dq', 'int8-training']], default: null)
+quantize: bnb.nf4
+
+# How many devices/GPUs to use. (type: Union[int, str], default: 1)
+devices: 1
+
+# The LoRA rank. (type: int, default: 8)
+lora_r: 8
+
+# The LoRA alpha. (type: int, default: 16)
+lora_alpha: 16
+
+# The LoRA dropout value. (type: float, default: 0.05)
+lora_dropout: 0.05
+
+# Whether to apply LoRA to the query weights in attention. (type: bool, default: True)
+lora_query: true
+
+# Whether to apply LoRA to the key weights in attention. (type: bool, default: False)
+lora_key: true
+
+# Whether to apply LoRA to the value weights in attention. (type: bool, default: True)
+lora_value: true
+
+# Whether to apply LoRA to the output projection in the attention block. (type: bool, default: False)
+lora_projection: true
+
+# Whether to apply LoRA to the weights of the MLP in the attention block. (type: bool, default: False)
+lora_mlp: true
+
+# Whether to apply LoRA to output head in GPT. (type: bool, default: False)
+lora_head: true
 
 # Data-related arguments. If not provided, the default is ``litgpt.data.Alpaca``.
 data:
   class_path: litgpt.data.Alpaca2k
   init_args:
     mask_prompt: false
+    val_split_fraction: 0.03847
     prompt_style: alpaca
     ignore_index: -100
     seed: 42
@@ -25,19 +56,19 @@ data:
 train:
 
   # Number of optimizer steps between saving checkpoints (type: Optional[int], default: 1000)
-  save_interval: 200
+  save_interval: 800
 
   # Number of iterations between logging calls (type: int, default: 1)
   log_interval: 1
 
-  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 64)
+  # Number of samples between optimizer steps across data-parallel ranks (type: int, default: 128)
   global_batch_size: 8
 
-  # Number of samples per data-parallel rank (type: int, default: 1)
+  # Number of samples per data-parallel rank (type: int, default: 4)
   micro_batch_size: 4
 
   # Number of iterations with learning rate warmup active (type: int, default: 100)
-  lr_warmup_steps: 200
+  lr_warmup_steps: 10
 
   # Number of epochs to train on (type: Optional[int], default: 5)
   epochs: 1
@@ -46,7 +77,7 @@ train:
   max_tokens:
 
   # Limits the number of optimizer steps to run. (type: Optional[int], default: null)
-  max_steps: 100
+  max_steps:
 
   # Limits the length of samples. Off by default (type: Optional[int], default: null)
   max_seq_length: 512
@@ -63,8 +94,8 @@ train:
 # Evaluation-related arguments. See ``litgpt.args.EvalArgs`` for details
 eval:
 
-  # Number of optimizer steps between evaluation calls (type: int, default: 600)
-  interval: 25
+  # Number of optimizer steps between evaluation calls (type: int, default: 100)
+  interval: 100
 
   # Number of tokens to generate (type: Optional[int], default: 100)
   max_new_tokens: 100
@@ -95,7 +126,7 @@ optimizer:
     lr: 0.0002
     
     #   (type: float, default: 0.01)
-    weight_decay: 0.1
+    weight_decay: 0.0
     
     #   (type: tuple, default: (0.9,0.999))
     betas:


### PR DESCRIPTION
This adds configuration files for the newly added Phi-3 model. Note that the `full` finetuning uses less memory than the LoRA one, which is interesting. The microbatch size is the same, and I also reran this 2 times to make sure.