### PR TITLE
Tokenizer: fix issue when decoding a single token at a time

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -125,8 +125,8 @@ class Tokenizer:
         tokens = [tensor.item()] if tensor.ndim == 0 else tensor.tolist()
         # Phi-3 tokenizer strips any spaces if to decode a single token at a time.
         # https://github.com/huggingface/transformers/issues/31643
-        if self.model_name.startswith("Phi-3") and len(tokens) == 1:
-            dummy_token_id = 33 # \x1e
-            dummy_token = self.processor.decode([dummy_token_id])
-            return self.processor.decode([dummy_token_id] + tokens).replace(dummy_token, "")
+        # if self.model_name.startswith("Phi-3") and len(tokens) == 1:
+        #     dummy_token_id = 33 # \x1e
+        #     dummy_token = self.processor.decode([dummy_token_id])
+        #     return self.processor.decode([dummy_token_id] + tokens).replace(dummy_token, "")
         return self.processor.decode(tokens)

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -57,8 +57,10 @@ class Tokenizer:
         # NOTE: A temporary fix until it's resolved on Tokenizers side.
         # LlaMA tokenizer strips leading spaces if to decode a single token at a time.
         # https://github.com/huggingface/transformers/issues/31643
-        with open(checkpoint_dir / "tokenizer_config.json", encoding="utf-8") as fp:
-            self.apply_decoding_fix = "LlamaTokenizer" in json.load(fp)["tokenizer_class"]
+        self.apply_decoding_fix = None
+        if (config_path := checkpoint_dir / "tokenizer_config.json").is_file():
+            with open(config_path, encoding="utf-8") as fp:
+                self.apply_decoding_fix = "LlamaTokenizer" in json.load(fp)["tokenizer_class"]
 
     @property
     def vocab_size(self) -> int:

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -82,6 +82,8 @@ def test_tokenizer_against_hf(config):
         assert actual.tolist() == expected
     assert ours.decode(actual) == theirs.decode(expected, skip_special_tokens=True)
 
+    assert "".join([ours.decode(x) for x in actual]) == ours.decode(actual), type(theirs)
+
 
 def test_tokenizer_input_validation():
     with pytest.raises(NotADirectoryError, match="The checkpoint directory does not exist"):

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -82,7 +82,10 @@ def test_tokenizer_against_hf(config):
         assert actual.tolist() == expected
     assert ours.decode(actual) == theirs.decode(expected, skip_special_tokens=True)
 
-    assert "".join([ours.decode(x) for x in actual]) == ours.decode(actual), type(theirs)
+    decoded_output = "".join([ours.decode(x) for x in actual])
+    if ours.apply_decoding_fix and decoded_output[0] == " ":
+        decoded_output = decoded_output[1:]  # the "hack" adds an empty space to the beginning
+    assert decoded_output == ours.decode(actual), type(theirs)
 
 
 def test_tokenizer_input_validation():
@@ -95,8 +98,9 @@ def test_tokenizer_input_validation():
 @pytest.mark.parametrize("encode_use_eos", (True, False))
 @pytest.mark.parametrize("processor_returns_bos", (True, False))
 @pytest.mark.parametrize("fake_return_ids", ([], [34, 8, 17, 2]))
-def test_tokenizer_bos_eos(tmp_path, use_bos_by_default, encode_use_bos, encode_use_eos, processor_returns_bos, fake_return_ids):
-
+def test_tokenizer_bos_eos(
+    tmp_path, use_bos_by_default, encode_use_bos, encode_use_eos, processor_returns_bos, fake_return_ids
+):
     # let `Tokenizers` create a proper (albeit empty) vocab in json format
     HFTokenizer(BPE()).save(str(tmp_path / "tokenizer.json"))
 


### PR DESCRIPTION
Hi there 👋 

When I was working on Phi-3 integration I've spotted an issue with HF Tokenizer that if to decode a single token at time (like in chat script), then it drops all the spaces and the output looks like a single looooooong string (https://github.com/huggingface/transformers/issues/31643).
So, instead of `This is a test string` the code prints `Thisisateststring`.

As was mentioned in the issue by @itazap, the problem happens with `LlamaTokenizer` and thus affects not only Phi-3, but other models too.

This PR applies the hack from Phi-3 to other models.