### PR TITLE
Filter out false positive PyTorch scheduler warning

### DIFF
--- a/litgpt/__main__.py
+++ b/litgpt/__main__.py
@@ -1,5 +1,26 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import warnings
+import re
+# There is currently a PyTorch bug that raises a false-positive warning.
+# For more information, see https://github.com/Lightning-AI/litgpt/issues/1561
+warning_message = (
+    "The epoch parameter in `scheduler.step()` was not necessary and is being deprecated "
+    "where possible. Please use `scheduler.step()` to step the scheduler. During the deprecation, "
+    "if epoch is different from None, the closed form is used instead of the new chainable form, "
+    "where available. Please open an issue if you are unable to replicate your use case: "
+    "https://github.com/pytorch/pytorch/issues/new/choose."
+)
+
+
+def custom_filter(warning):
+    return issubclass(warning.category, UserWarning) and re.match(re.escape(warning_message), str(warning.message))
+
+
+warnings.filterwarnings("ignore", category=UserWarning, module="torch.optim.lr_scheduler")
+warnings.showwarning = custom_filter
+
+
 import torch
 
 from litgpt.chat.base import main as chat_fn
@@ -54,6 +75,7 @@ def main() -> None:
     set_config_read_mode(urls_enabled=True)
 
     torch.set_float32_matmul_precision("high")
+
     CLI(parser_data)
 
 


### PR DESCRIPTION
Filters out a false positive warning for PyTorch's scheduler.

Fixes #1561