### PR TITLE
Bumb version for 0.4.4 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.3"
+version = "0.4.4"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
This bumps the version so we can make a new release that includes the latest fixes and additions (like the automatic CLI downloading) that is currently used in the README.