### PR TITLE
✅ Issue #1557: Fixed warning during model download and conversion.

### DIFF
--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -78,8 +78,6 @@ def download_from_hub(
         snapshot_download(
             repo_id,
             local_dir=directory,
-            local_dir_use_symlinks=False,
-            resume_download=True,
             allow_patterns=download_files,
             token=access_token,
         )

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -9,6 +9,7 @@ import shutil
 import sys
 from dataclasses import asdict, is_dataclass
 from io import BytesIO
+from packaging import version
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
 import warnings
@@ -256,7 +257,14 @@ class incremental_save:
         if storage.device.type != "cpu":
             storage = storage.cpu()
         num_bytes = storage.nbytes()
-        self.zipfile.write_record(name, storage, num_bytes)
+
+        current_version = version.parse(torch.__version__)
+        threshold_version = version.parse("2.2.2")
+        if current_version <= threshold_version:
+            self.zipfile.write_record(name, storage.data_ptr(), num_bytes)
+        else:
+            self.zipfile.write_record(name, storage, num_bytes)
+
         return key
 
     def __exit__(self, type, value, traceback):

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -256,7 +256,7 @@ class incremental_save:
         if storage.device.type != "cpu":
             storage = storage.cpu()
         num_bytes = storage.nbytes()
-        self.zipfile.write_record(name, storage.data_ptr(), num_bytes)
+        self.zipfile.write_record(name, storage, num_bytes)
         return key
 
     def __exit__(self, type, value, traceback):


### PR DESCRIPTION
Resolved Issue [#1557](https://github.com/Lightning-AI/litgpt/issues/1557) posted by @Andrei-Aksionov regarding warnings from depricated codebase.

- Removed depricated params scripts/download.py
- passed Storage obj instead of ptr in utils.py

Tests:
✅ test_convert_hf_checkpoint.py
✅ test_convert_lit_checkpoint.py
✅ test_convert_pretrained_checkpoint.py
Also tested manually downloading the model for warnings.
