### PR TITLE
Add slow interconnect warning

### DIFF
--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -26,6 +26,7 @@ from litgpt.tokenizer import Tokenizer
 from litgpt.utils import (
     auto_download_checkpoint,
     CycleIterator,
+    check_nvlink_connectivity,
     check_valid_checkpoint_dir,
     choose_logger,
     chunked_cross_entropy,
@@ -131,6 +132,10 @@ def setup(
         loggers=logger,
         plugins=plugins,
     )
+
+    if devices > 1:
+        check_nvlink_connectivity(fabric)
+
     fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -26,6 +26,7 @@ from litgpt.tokenizer import Tokenizer
 from litgpt.utils import (
     auto_download_checkpoint,
     CycleIterator,
+    check_nvlink_connectivity,
     check_valid_checkpoint_dir,
     choose_logger,
     chunked_cross_entropy,
@@ -131,6 +132,10 @@ def setup(
         loggers=logger,
         plugins=plugins,
     )
+
+    if devices > 1:
+        check_nvlink_connectivity(fabric)
+
     fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -22,6 +22,7 @@ from litgpt.tokenizer import Tokenizer
 from litgpt.utils import (
     auto_download_checkpoint,
     CycleIterator,
+    check_nvlink_connectivity,
     check_valid_checkpoint_dir,
     choose_logger,
     chunked_cross_entropy,
@@ -105,7 +106,17 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(devices=devices, num_nodes=num_nodes, strategy=strategy, precision=precision, loggers=logger)
+    fabric = L.Fabric(
+        devices=devices,
+        num_nodes=num_nodes,
+        strategy=strategy,
+        precision=precision,
+        loggers=logger
+    )
+
+    if devices > 1:
+        check_nvlink_connectivity(fabric)
+
     fabric.launch(main, devices, resume, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -26,6 +26,7 @@ from litgpt.scripts.merge_lora import merge_lora
 from litgpt.tokenizer import Tokenizer
 from litgpt.utils import (
     auto_download_checkpoint,
+    check_nvlink_connectivity,
     CycleIterator,
     check_valid_checkpoint_dir,
     choose_logger,
@@ -161,6 +162,8 @@ def setup(
         loggers=logger,
         plugins=plugins,
     )
+    if devices > 1:
+        check_nvlink_connectivity(fabric)
     fabric.launch(main, devices, seed, config, data, checkpoint_dir, out_dir, train, eval, optimizer)
 
 


### PR DESCRIPTION
Lots of users asked/raised issues whether there is a bug because multi-GPU training can be slower than single-GPU training. This is not due to a LitGPT bug but because machines with slow GPU connections were used. 

This adds a warning if there is a slow GPU interconnect and suggests to use a different machine for multi-GPU training.

CC @apaz-cli 