### PR TITLE
Update Azure workflow to use the latest stable PyTorch version

### DIFF
--- a/.github/azure-gpu-test-thunder.yml
+++ b/.github/azure-gpu-test-thunder.yml
@@ -9,9 +9,10 @@ pr:
     include:
       - "main"
       - "wip"
+      - "carmocca/*"
 
 jobs:
-  - job: GPU tests
+  - job: testing
     timeoutInMinutes: "30"
     cancelTimeoutInMinutes: "2"
     pool: "lit-rtx-3090"
@@ -44,14 +45,19 @@ jobs:
         pip install '.[all,test]'
       displayName: 'Install dependencies'
 
+    - script: |
+        pip uninstall -y torchvision torchaudio
+        pip install --pre 'nvfuser-cu121[torch]' --extra-index-url https://pypi.nvidia.com
+      displayName: 'Install PyTorch nightly'
+
     - bash: |
         set -e
         pip list
         python -c "import torch ; mgpu = torch.cuda.device_count() ; assert mgpu == 2, f'GPU: {mgpu}'"
       displayName: "Env details"
 
-    - bash: pytest -v --disable-pytest-warnings --strict-markers --color=yes --ignore-glob='test_thunder*.py'
-      displayName: 'Ordinary tests'
+    - bash: pytest -v --disable-pytest-warnings --strict-markers --color=yes test_thunder*.py
+      displayName: 'Thunder ordinary tests'
       env:
         PL_RUN_CUDA_TESTS: "1"
       timeoutInMinutes: "5"
@@ -60,5 +66,5 @@ jobs:
       workingDirectory: tests
       env:
         PL_RUN_CUDA_TESTS: "1"
-      displayName: "Standalone tests"
+      displayName: "Thunder standalone tests"
       timeoutInMinutes: "10"

--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -9,7 +9,6 @@ pr:
     include:
       - "main"
       - "wip"
-      - "carmocca/*"
 
 jobs:
   - job: testing
@@ -45,10 +44,10 @@ jobs:
         pip install '.[all,test]'
       displayName: 'Install dependencies'
 
-    - script: |
-        pip uninstall -y torchvision torchaudio
-        pip install --pre 'nvfuser-cu121[torch]' --extra-index-url https://pypi.nvidia.com
-      displayName: 'Install PyTorch nightly'
+    #- script: |
+    #    pip uninstall -y torchvision torchaudio
+    #    pip install --pre 'nvfuser-cu121[torch]' --extra-index-url https://pypi.nvidia.com
+    #  displayName: 'Install PyTorch nightly'
 
     - bash: |
         set -e

--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -62,4 +62,3 @@ jobs:
         PL_RUN_CUDA_TESTS: "1"
       displayName: "Standalone tests"
       timeoutInMinutes: "10"
- 

--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -62,3 +62,4 @@ jobs:
         PL_RUN_CUDA_TESTS: "1"
       displayName: "Standalone tests"
       timeoutInMinutes: "10"
+ 

--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -9,6 +9,7 @@ pr:
     include:
       - "main"
       - "wip"
+      - "carmocca/*"
 
 jobs:
   - job: testing
@@ -18,7 +19,7 @@ jobs:
     variables:
       DEVICES: $( python -c 'print("$(Agent.Name)".split("_")[-1])' )
     container:
-      image: "pytorchlightning/pytorch_lightning:base-cuda-py3.10-torch2.2-cuda12.1.0"
+      image: "pytorchlightning/pytorch_lightning:base-cuda-py3.11-torch2.3-cuda12.1.0"
       options: "--gpus=all --shm-size=8gb"
     workspace:
       clean: all


### PR DESCRIPTION
This updates the GPU workflow to allow us testing on the latest stable PyTorch version. As discussed with @Andrei-Aksionov  in #1585 I think the nightly dev build can be nice as a heads-up for future changes, but we actually need to be testing the version that is actually being used, and that is the latest stable version, which is installed via the pyproject.toml. Let's update the azure version to that. We can always test things on the dev version locally every few weeks or so. Changes in the dev version should not affect users until the stable version launches anyways.