### PR TITLE
Fix kv-cache clearing in Python API and Serve

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -266,8 +266,7 @@ class LLM:
                 include_prompt=False,
             )
 
-        for block in self.model.transformer.h:
-            block.attn.kv_cache.reset_parameters()
+        self.model.clear_kv_cache()
 
         if stream:
             return outputs

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -117,8 +117,7 @@ class SimpleLitAPI(BaseLitAPI):
             include_prompt=False
         )
 
-        for block in self.model.transformer.h:
-            block.attn.kv_cache.reset_parameters()
+        self.model.clear_kv_cache()
         return y
 
     def encode_response(self, output: torch.Tensor) -> Dict[str, Any]:
@@ -145,8 +144,7 @@ class StreamLitAPI(BaseLitAPI):
         prompt_length = inputs.size(0)
         max_returned_tokens = prompt_length + self.max_new_tokens
 
-        for block in self.model.transformer.h:
-            block.attn.kv_cache.reset_parameters()
+        self.model.clear_kv_cache()
 
         yield from stream_generate(
             self.model,


### PR DESCRIPTION
I think I found the culprit causing the weird results mentioned in #1595. I think the kv-cache was cleared incompletely. I will try out some more models, but it seems to look promising so far.

Fixes  #1595