### PR TITLE
Dynamically set kv-cache size in serve

### DIFF
--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -71,9 +71,11 @@ class BaseLitAPI(LitAPI):
         )
         with fabric.init_module(empty_init=True):
             model = GPT(config)
-        with fabric.init_tensor():
-            # enable the kv cache
-            model.set_kv_cache(batch_size=1)
+
+        # This should be set if we add a compile feature later
+        # with fabric.init_tensor():
+        #     model.set_kv_cache(batch_size=1)
+
         model.eval()
 
         self.model = fabric.setup_module(model)
@@ -105,6 +107,11 @@ class SimpleLitAPI(BaseLitAPI):
         # Run the model on the input and return the output.
         prompt_length = inputs.size(0)
         max_returned_tokens = prompt_length + self.max_new_tokens
+
+        first_turn = self.model.mask_cache is None
+        if first_turn or max_returned_tokens > self.model.max_seq_length:
+            self.model.max_seq_length = max_returned_tokens
+            self.model.set_kv_cache(batch_size=1, device=self.device)
 
         y = plain_generate(
             self.model,
@@ -144,17 +151,23 @@ class StreamLitAPI(BaseLitAPI):
         prompt_length = inputs.size(0)
         max_returned_tokens = prompt_length + self.max_new_tokens
 
-        self.model.clear_kv_cache()
+        first_turn = self.model.mask_cache is None
+        if first_turn or max_returned_tokens > self.model.max_seq_length:
+            self.model.max_seq_length = max_returned_tokens
+            self.model.set_kv_cache(batch_size=1, device=self.device)
 
-        yield from stream_generate(
-            self.model,
-            inputs,
-            max_returned_tokens,
-            temperature=self.temperature,
-            top_k=self.top_k,
-            top_p=self.top_p,
-            stop_tokens=([self.tokenizer.eos_id],)
-        )
+        try:
+            yield from stream_generate(
+                self.model,
+                inputs,
+                max_returned_tokens,
+                temperature=self.temperature,
+                top_k=self.top_k,
+                top_p=self.top_p,
+                stop_tokens=([self.tokenizer.eos_id],)
+            )
+        finally:
+            self.model.clear_kv_cache()
 
     def encode_response(self, output):
         for out in output:


### PR DESCRIPTION
This fixes a high memory-usage issue in `litgpt serve` where the kv cache was always set to the maximum block size. (Analogous to #1583)