### PR TITLE
Update LitData version and restore previous LitData assertions in tests

### DIFF
--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -49,16 +49,15 @@ class LitData(DataModule):
         return self._dataloader(input_dir=input_dir, train=False)
 
     def _dataloader(self, input_dir: str, train: bool):
-        from litdata.streaming import StreamingDataset, TokensLoader
+        from litdata.streaming import StreamingDataset, StreamingDataLoader, TokensLoader
 
         dataset = StreamingDataset(
             input_dir=input_dir,
             item_loader=TokensLoader(block_size=self.seq_length),
             shuffle=train,
-            drop_last=True,
             seed=self.seed,
         )
-        dataloader = DataLoader(
+        dataloader = StreamingDataLoader(
             dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return dataloader

--- a/litgpt/data/microllama.py
+++ b/litgpt/data/microllama.py
@@ -5,6 +5,7 @@ from typing import Union
 
 from litgpt.data import TinyLlama
 
+
 @dataclass
 class MicroLlama(TinyLlama):
     """The MicroLlama data module is composed of only SlimPajama data."""

--- a/litgpt/data/openwebtext.py
+++ b/litgpt/data/openwebtext.py
@@ -94,7 +94,7 @@ class OpenWebText(DataModule):
         return train_dataloader
 
     def val_dataloader(self) -> DataLoader:
-        from litdata.streaming import StreamingDataset, TokensLoader
+        from litdata.streaming import StreamingDataLoader, StreamingDataset, TokensLoader
 
         val_dataset = StreamingDataset(
             input_dir=self.data_path_val,
@@ -103,7 +103,7 @@ class OpenWebText(DataModule):
             # Consider setting to False, but we would lose some samples due to truncation when world size > 1
             drop_last=True,
         )
-        val_dataloader = DataLoader(
+        val_dataloader = StreamingDataLoader(
             val_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return val_dataloader

--- a/litgpt/data/openwebtext.py
+++ b/litgpt/data/openwebtext.py
@@ -68,14 +68,14 @@ class OpenWebText(DataModule):
             fn=partial(tokenize, split_dataset["train"]),
             inputs=list(range(len(split_dataset["train"]))),
             output_dir=self.data_path_train,
-            num_workers=(os.cpu_count() - 1),
+            num_workers=min(64, os.cpu_count() - 1),
             chunk_bytes="200MB",
         )
         optimize(
             fn=partial(tokenize, split_dataset["val"]),
             inputs=list(range(len(split_dataset["val"]))),
             output_dir=self.data_path_val,
-            num_workers=(os.cpu_count() - 1),
+            num_workers=min(8, os.cpu_count() - 1),
             chunk_bytes="200MB",
         )
 
@@ -86,7 +86,6 @@ class OpenWebText(DataModule):
             input_dir=self.data_path_train,
             item_loader=TokensLoader(block_size=self.seq_length),
             shuffle=True,
-            drop_last=True,
         )
         train_dataloader = StreamingDataLoader(
             train_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
@@ -100,8 +99,6 @@ class OpenWebText(DataModule):
             input_dir=self.data_path_val,
             item_loader=TokensLoader(block_size=self.seq_length),
             shuffle=True,
-            # Consider setting to False, but we would lose some samples due to truncation when world size > 1
-            drop_last=True,
         )
         val_dataloader = StreamingDataLoader(
             val_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True

--- a/litgpt/data/text_files.py
+++ b/litgpt/data/text_files.py
@@ -94,7 +94,6 @@ class TextFiles(DataModule):
             input_dir=str(self.out_path_train),
             item_loader=TokensLoader(block_size=self.max_seq_length),
             shuffle=True,
-            drop_last=True,
         )
 
         train_dataloader = StreamingDataLoader(
@@ -103,16 +102,14 @@ class TextFiles(DataModule):
         return train_dataloader
 
     def val_dataloader(self) -> DataLoader:
-        from litdata.streaming import StreamingDataset, TokensLoader
+        from litdata.streaming import StreamingDataset, StreamingDataLoader, TokensLoader
 
         val_dataset = StreamingDataset(
             input_dir=str(self.out_path_val),
             item_loader=TokensLoader(block_size=self.max_seq_length),
             shuffle=True,
-            # Consider setting to False, but we would lose some samples due to truncation when world size > 1
-            drop_last=True,
         )
-        val_dataloader = DataLoader(
+        val_dataloader = StreamingDataLoader(
             val_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return val_dataloader

--- a/litgpt/data/tinyllama.py
+++ b/litgpt/data/tinyllama.py
@@ -89,16 +89,14 @@ class TinyLlama(DataModule):
         return train_dataloader
 
     def val_dataloader(self) -> DataLoader:
-        from litdata.streaming import StreamingDataset, TokensLoader
+        from litdata.streaming import StreamingDataLoader, StreamingDataset, TokensLoader
 
         val_dataset = StreamingDataset(
             input_dir=self.slimpajama_val,
             item_loader=TokensLoader(block_size=self.seq_length),
             shuffle=True,
-            # Consider setting to False, but we would lose some samples due to truncation when world size > 1
-            drop_last=True,
         )
-        val_dataloader = DataLoader(
+        val_dataloader = StreamingDataLoader(
             val_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return val_dataloader

--- a/litgpt/data/tinystories.py
+++ b/litgpt/data/tinystories.py
@@ -82,7 +82,6 @@ class TinyStories(DataModule):
             input_dir=str(self.data_path_train),
             item_loader=TokensLoader(block_size=self.max_seq_length),
             shuffle=True,
-            drop_last=True,
         )
         train_dataloader = StreamingDataLoader(
             train_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
@@ -90,16 +89,14 @@ class TinyStories(DataModule):
         return train_dataloader
 
     def val_dataloader(self) -> DataLoader:
-        from litdata.streaming import StreamingDataset, TokensLoader
+        from litdata.streaming import StreamingDataset, StreamingDataLoader, TokensLoader
 
         val_dataset = StreamingDataset(
             input_dir=str(self.data_path_val),
             item_loader=TokensLoader(block_size=self.max_seq_length),
             shuffle=True,
-            # Consider setting to False, but we would lose some samples due to truncation when world size > 1
-            drop_last=True,
         )
-        val_dataloader = DataLoader(
+        val_dataloader = StreamingDataLoader(
             val_dataset, batch_size=self.batch_size, pin_memory=True, num_workers=self.num_workers, drop_last=True
         )
         return val_dataloader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ all = [
     "sentencepiece>=0.2.0",      # llama-based models
     "tokenizers>=0.15.2",        # pythia, falcon, redpajama
     "requests>=2.31.0",          # litgpt.data
-    "litdata==0.2.16",           # litgpt.data
+    "litdata==0.2.17",           # litgpt.data
     "litserve>=0.1.2",           # litgpt.deploy
     "zstandard>=0.22.0",         # litgpt.data.prepare_slimpajama.py
     "numpy<2.0.0",               # PyTorch dependency; "pinned" until NumPy 2.0 is tested

--- a/tests/data/test_lit_data.py
+++ b/tests/data/test_lit_data.py
@@ -39,13 +39,20 @@ def test_input_dir_and_splits(dl_mock, tmp_path):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Needs to implement platform agnostic path/url joining")
 @mock.patch("litdata.streaming.StreamingDataset")
-def test_dataset_args(streaming_dataset_mock, tmp_path):
+@mock.patch("litdata.streaming.StreamingDataLoader")
+def test_dataset_args(streaming_dataloader_mock, streaming_dataset_mock, tmp_path):
     data = LitData(data_path=tmp_path, seed=1000)
     data.train_dataloader()
     streaming_dataset_mock.assert_called_with(
         input_dir=str(tmp_path),
         item_loader=ANY,
         shuffle=True,
-        drop_last=True,
         seed=1000,
+    )
+    streaming_dataloader_mock.assert_called_with(
+        streaming_dataset_mock(),
+        batch_size=1,
+        pin_memory=True,
+        num_workers=8,
+        drop_last=True,
     )

--- a/tests/data/test_textfiles.py
+++ b/tests/data/test_textfiles.py
@@ -30,7 +30,7 @@ def test_textfiles_datamodule(tmp_path):
     from litgpt.data.text_files import TextFiles
 
     data_dir = tmp_path / "textfiles"
-    datamodule = TextFiles(train_data_path=data_dir)
+    datamodule = TextFiles(train_data_path=data_dir, num_workers=1)
     datamodule.connect(max_seq_length=2, tokenizer=Tokenizer())
 
     # simulate `datamodule.prepare_data`
@@ -45,16 +45,17 @@ def test_textfiles_datamodule(tmp_path):
     actual = tree_map(torch.Tensor.tolist, list(tr_dataloader))
     # there is 1 sample per index in the data (13)
     assert actual == [
-        [[5, 0, 1]],
-        [[0, 1, 1999]],
-        [[1, 1999, 0]],
-        [[0, 23, 15]],
-        [[63, 0, 73]],
-        [[0, 73, 5]],
+        [[1999, 0, 13]],
         [[0, 13, 12]],
+        [[1, 1999, 0]],
+        [[63, 0, 73]],
+        [[5, 0, 1]],
+        [[0, 73, 5]],
+        [[0, 23, 15]],
+        [[0, 1, 1999]],
         [[15, 63, 0]],
         [[73, 5, 0]],
         [[12, 0, 23]],
         [[23, 15, 63]],
-        [[13, 12, 0]],
+        [[13, 12, 0]]
     ]

--- a/tests/data/test_textfiles.py
+++ b/tests/data/test_textfiles.py
@@ -1,7 +1,3 @@
-import random
-import string
-import os
-
 import torch
 
 from litdata import optimize

--- a/tests/data/test_tinystories.py
+++ b/tests/data/test_tinystories.py
@@ -65,7 +65,7 @@ def test_tinystories_datamodule(tmp_path):
 
     data_dir = tmp_path / "tinystories"
 
-    datamodule = TinyStories(data_dir, seed=42)
+    datamodule = TinyStories(data_dir, seed=42, num_workers=1)
     datamodule.connect(max_seq_length=2)
 
     # simulate `datamodule.prepare_data`
@@ -80,12 +80,17 @@ def test_tinystories_datamodule(tmp_path):
     actual = tree_map(torch.Tensor.tolist, list(tr_dataloader))
     # there is 1 sample per index in the data (13)
     assert actual == [
-        [[0, 1, 1999]],
+        [[1999, 0, 13]],
+        [[0, 13, 12]],
         [[1, 1999, 0]],
+        [[63, 0, 73]],
+        [[5, 0, 1]],
+        [[0, 73, 5]],
+        [[0, 23, 15]],
+        [[0, 1, 1999]],
         [[15, 63, 0]],
         [[73, 5, 0]],
         [[12, 0, 23]],
-        [[0, 73, 5]],
         [[23, 15, 63]],
         [[13, 12, 0]]
     ]


### PR DESCRIPTION
Restores the assertions to what they were before updating LitData in https://github.com/Lightning-AI/litgpt/pull/1573. LitData 0.2.17 has fixes for handling drop_last, which was causing the previous changes in the assertions and number of samples returned. 
This also addresses the comment from @carmocca https://github.com/Lightning-AI/litgpt/pull/1573#discussion_r1675794515