### PR TITLE
Print warning about unsupported repo_ids

### DIFF
--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple
 import torch
 from lightning_utilities.core.imports import RequirementCache
 
+from litgpt.config import configs
 from litgpt.scripts.convert_hf_checkpoint import convert_hf_checkpoint
 
 _SAFETENSORS_AVAILABLE = RequirementCache("safetensors")
@@ -37,13 +38,15 @@ def download_from_hub(
         model_name: The existing config name to use for this repo_id. This is useful to download alternative weights of
             existing architectures.
     """
-    print("repo_id:", repo_id)
+    options = [f"{config['hf_config']['org']}/{config['hf_config']['name']}" for config in configs]
 
     if repo_id == "list":
-        from litgpt.config import configs
-
-        options = [f"{config['hf_config']['org']}/{config['hf_config']['name']}" for config in configs]
         print("Please specify --repo_id <repo_id>. Available values:")
+        print("\n".join(sorted(options, key=lambda x: x.lower())))
+        return
+
+    if repo_id not in options:
+        print(f"Unsupported repo_id: {repo_id}. Please choose a valid repo_id from the following list:")
         print("\n".join(sorted(options, key=lambda x: x.lower())))
         return
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -41,6 +41,11 @@ def test_download_model():
     assert f"Saving converted checkpoint to {str(s)}" in output
     assert ("checkpoints" / REPO_ID).exists()
 
+    # Also test valid but unsupported repo IDs
+    command = ["litgpt", "download", "CohereForAI/aya-23-8B"]
+    output = run_command(command)
+    assert "Unsupported repo_id" in output
+
 
 @pytest.mark.dependency()
 def test_download_books():


### PR DESCRIPTION
In the last few days, there were a few internal and external confusions about using unsupported models in LitGPT. Currently, LitGPT lets one download unsupported models, but then fails in the conversion. E.g.,

```
litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B

...

# downloads model
...

Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.8/dist-packages/litserve/server.py", line 332, in inference_worker
    lit_api.setup(device)
  File "/app/server.py", line 12, in setup
    self.llm = LLM.load(
  File "/usr/local/lib/python3.8/dist-packages/litgpt/api.py", line 112, in load
    checkpoint_dir = auto_download_checkpoint(model_name=model, access_token=access_token)
  File "/usr/local/lib/python3.8/dist-packages/litgpt/utils.py", line 588, in auto_download_checkpoint
    download_from_hub(repo_id=str(model_name), access_token=access_token)
  File "/usr/local/lib/python3.8/dist-packages/litgpt/scripts/download.py", line 112, in download_from_hub
    convert_hf_checkpoint(checkpoint_dir=directory, dtype=dtype, model_name=model_name)
  File "/usr/local/lib/python3.8/dist-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/litgpt/scripts/convert_hf_checkpoint.py", line 401, in convert_hf_checkpoint
    config = Config.from_name(model_name)
  File "/usr/local/lib/python3.8/dist-packages/litgpt/config.py", line 105, in from_name
    raise ValueError(f"{name!r} is not a supported config name")
ValueError: 'Hermes-2-Pro-Llama-3-8B' is not a supported config name
```

The same happened in #1615

This PR adds a message about unsupported models.

Fixes #1615

