### PR TITLE
Add warning about pretrain preprocessing

### DIFF
--- a/litgpt/data/text_files.py
+++ b/litgpt/data/text_files.py
@@ -4,7 +4,6 @@ import os
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
-from tqdm import tqdm
 from typing import Optional
 
 from torch.utils.data import DataLoader
@@ -76,6 +75,13 @@ class TextFiles(DataModule):
                 num_workers=use_workers,
                 chunk_bytes="50MB",
             )
+        else:
+            print(
+                f"\nWarning: Preprocessed training data found in {self.out_path_train}."
+                " For efficiency, reprocessing is skipped. If your text input has changed since"
+                " the last `litgpt pretrain` command, remove the preprocessed file(s) to trigger"
+                f" reprocessing: `rm -rf {self.out_path_train}`\n"
+            )
         use_workers = min(num_workers, len(val_files))
         if not Path(self.out_path_val).is_dir():
             validate_tokenizer(self.tokenizer)
@@ -85,6 +91,13 @@ class TextFiles(DataModule):
                 output_dir=str(self.out_path_val),
                 num_workers=use_workers,
                 chunk_bytes="50MB",
+            )
+        else:
+            print(
+                f"\nWarning: Preprocessed validation data found in {self.out_path_val}."
+                " For efficiency, reprocessing is skipped. If your text input has changed since"
+                " the last `litgpt pretrain` command, remove the preprocessed file(s) to trigger"
+                f" reprocessing: `rm -rf {self.out_path_val}`\n"
             )
 
     def train_dataloader(self) -> DataLoader:

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -123,10 +123,15 @@ def test_pretrain_model():
         "--eval.max_iters", "1",         # to accelerate things for CI
         "--out_dir", str(OUT_DIR)
     ]
-    run_command(pretrain_command)
+    output = run_command(pretrain_command)
 
+    assert "Warning: Preprocessed training data found" not in output
     assert (OUT_DIR / "final").exists(), "Pretraining output directory was not created"
     assert (OUT_DIR / "final" / "lit_model.pth").exists(), "Model file was not created"
+
+    # Test that warning is displayed when running it a second time
+    output = run_command(pretrain_command)
+    assert "Warning: Preprocessed training data found" not in output
 
 
 @pytest.mark.skipif(

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -131,7 +131,7 @@ def test_pretrain_model():
 
     # Test that warning is displayed when running it a second time
     output = run_command(pretrain_command)
-    assert "Warning: Preprocessed training data found" not in output
+    assert "Warning: Preprocessed training data found" in output
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
For efficiency purposes, `litgpt pretrain` skips the expensive dataset preprocessing if it is run a second time on the same dataset folder. However, users may have changed the input text files since the last time they ran the command, which could cause issues. So in this case, there is now a warning about the skipped preprocessing and a note about how to trigger reprocessing.

Fixes #1450