### PR TITLE
Restore capability to load alternative weights

### DIFF
--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -49,8 +49,8 @@ def download_from_hub(
         print(f"Unsupported repo_id: {repo_id}. If you are trying to download alternative "
         "weights for a supported model, please specify the corresponding model via the `--model_name` option, "
         "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
-        "\nAlternatively, please choose a valid `repo_id` from the following list:")
-        print("\n".join(sorted(options, key=lambda x: x.lower())))
+        "\nAlternatively, please choose a valid `repo_id` from the list of supported models, which can be obtained via "
+        "`litgpt download list`.")
         return
 
     from huggingface_hub import snapshot_download

--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -46,10 +46,10 @@ def download_from_hub(
         return
 
     if model_name is None and repo_id not in options:
-        print(f"Unsupported repo_id: {repo_id}. If these are alternative "
-        "weights for a supported model, please specify this via the `--model_name` option, "
+        print(f"Unsupported repo_id: {repo_id}. If you are trying to download alternative "
+        "weights for a supported model, please specify the corresponding model via the `--model_name` option, "
         "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
-        "\nAlternatively, please choose a valid repo_id from the following list:")
+        "\nAlternatively, please choose a valid `repo_id` from the following list:")
         print("\n".join(sorted(options, key=lambda x: x.lower())))
         return
 

--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -46,7 +46,8 @@ def download_from_hub(
         return
 
     if model_name is None and repo_id not in options:
-        print(f"Unsupported repo_id: {repo_id}. If you are trying to download alternative "
+        print(f"Unsupported `repo_id`: {repo_id}."
+        "\nIf you are trying to download alternative "
         "weights for a supported model, please specify the corresponding model via the `--model_name` option, "
         "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
         "\nAlternatively, please choose a valid `repo_id` from the list of supported models, which can be obtained via "

--- a/litgpt/scripts/download.py
+++ b/litgpt/scripts/download.py
@@ -45,8 +45,11 @@ def download_from_hub(
         print("\n".join(sorted(options, key=lambda x: x.lower())))
         return
 
-    if repo_id not in options:
-        print(f"Unsupported repo_id: {repo_id}. Please choose a valid repo_id from the following list:")
+    if model_name is None and repo_id not in options:
+        print(f"Unsupported repo_id: {repo_id}. If these are alternative "
+        "weights for a supported model, please specify this via the `--model_name` option, "
+        "for example, `litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B`."
+        "\nAlternatively, please choose a valid repo_id from the following list:")
         print("\n".join(sorted(options, key=lambda x: x.lower())))
         return
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -44,7 +44,7 @@ def test_download_model():
     # Also test valid but unsupported repo IDs
     command = ["litgpt", "download", "CohereForAI/aya-23-8B"]
     output = run_command(command)
-    assert "Unsupported repo_id" in output
+    assert "Unsupported `repo_id`" in output
 
 
 @pytest.mark.dependency()


### PR DESCRIPTION
This restores the capability to load custom checkpoints via the `--model_name` option, for example:

```bash
litgpt download NousResearch/Hermes-2-Pro-Llama-3-8B --model_name Llama-3-8B
```

