### PR TITLE
Enable unbalanced number of layers in sequential generation

### DIFF
--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -5,6 +5,7 @@ import logging
 import re
 import sys
 import time
+import math
 from collections import OrderedDict
 from functools import partial
 from pathlib import Path
@@ -32,14 +33,17 @@ from litgpt.utils import (
 
 @torch.inference_mode()
 def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int):
-    if model.config.n_layer % devices:
-        # TODO: support smarter partitioning schemes
-        raise NotImplementedError(
-            f"Only balanced partitioning is implemented: n_layer={model.config.n_layer}, devices {devices}"
+    if model.config.n_layer < devices:
+        raise RuntimeError(
+            f"The number of layers in the model must be larger than the number of devices, but got"
+            f" n_layer={model.config.n_layer} and devices={devices}."
         )
-    layers_per_rank = model.config.n_layer // devices
+        
+    # The last device might get fewer layers if number of layers not evenly divisible by device count
+    max_layers_per_device = math.ceil(model.config.n_layer / devices)
     # dictates where each block should be instantiated
-    mapping = layer_to_device(model, chunk_on=Block, chunk_size=layers_per_rank)
+    mapping = layer_to_device(model, chunk_on=Block, chunk_size=max_layers_per_device)
+    num_layers_per_device = {i: sum(1 for v in mapping.values() if v == i) for i in range(devices)}
 
     # materialize each block on the appropriate device
     for path, target_index in mapping.items():
@@ -67,7 +71,7 @@ def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int
         # install hooks to move layer inputs/output between devices
         for layer_num, (path, target_index) in enumerate(mapping.items()):
             submodule = model.get_submodule(path)
-            if layer_num >= layers_per_rank:
+            if layer_num >= num_layers_per_device[target_index]:
                 # we need to move the block input on the boundaries between devices
                 # and also on every non-root device because the RoPE and mask cache is shared
                 # TODO: the second case could be optimized and then we would only need this hook for

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -45,6 +45,12 @@ def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int
     mapping = layer_to_device(model, chunk_on=Block, chunk_size=max_layers_per_device)
     num_layers_per_device = {i: sum(1 for v in mapping.values() if v == i) for i in range(devices)}
 
+    if set(num_layers_per_device.values()) != set(range(devices)):
+        raise RuntimeError(
+            f"Not able to distribute the {model.config.n_layer} layers across {devices} devices."
+            " Try running with a lower number of devices."
+        )
+
     # materialize each block on the appropriate device
     for path, target_index in mapping.items():
         submodule = model.get_submodule(path)

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -34,7 +34,7 @@ from litgpt.utils import (
 @torch.inference_mode()
 def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int):
     if model.config.n_layer < devices:
-        raise RuntimeError(
+        raise ValueError(
             f"The number of layers in the model must be larger than the number of devices, but got"
             f" n_layer={model.config.n_layer} and devices={devices}."
         )

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -45,6 +45,7 @@ def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int
     mapping = layer_to_device(model, chunk_on=Block, chunk_size=max_layers_per_device)
 
     if set(mapping.values()) != set(range(devices)):
+        # TODO: support smarter partitioning schemes
         raise RuntimeError(
             f"Not able to distribute the {model.config.n_layer} layers across {devices} devices."
             " Try running with a lower number of devices."

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -43,13 +43,14 @@ def sequential(model: GPT, root: torch.device, max_seq_length: int, devices: int
     max_layers_per_device = math.ceil(model.config.n_layer / devices)
     # dictates where each block should be instantiated
     mapping = layer_to_device(model, chunk_on=Block, chunk_size=max_layers_per_device)
-    num_layers_per_device = {i: sum(1 for v in mapping.values() if v == i) for i in range(devices)}
 
-    if set(num_layers_per_device.values()) != set(range(devices)):
+    if set(mapping.values()) != set(range(devices)):
         raise RuntimeError(
             f"Not able to distribute the {model.config.n_layer} layers across {devices} devices."
             " Try running with a lower number of devices."
         )
+
+    num_layers_per_device = {i: sum(1 for v in mapping.values() if v == i) for i in range(devices)}
 
     # materialize each block on the appropriate device
     for path, target_index in mapping.items():

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -1,6 +1,7 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import itertools
+import math
 import subprocess
 import sys
 from collections import defaultdict
@@ -23,18 +24,37 @@ from litgpt.scripts.download import download_from_hub
 @pytest.mark.parametrize(
     ("n_layer", "devices", "expected"),
     [
+        (6, 1, {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0}),
         (6, 2, {0: 0, 1: 0, 2: 0, 3: 1, 4: 1, 5: 1}),
         (6, 3, {0: 0, 1: 0, 2: 1, 3: 1, 4: 2, 5: 2}),
-        (6, 1, {0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0}),
+        (6, 4, {0: 0, 1: 0, 2: 1, 3: 1, 4: 2, 5: 2}),
+        (6, 5, {0: 0, 1: 0, 2: 1, 3: 1, 4: 2, 5: 2}),
+        (6, 6, {0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5}),
     ],
 )
 def test_layer_to_device(n_layer, devices, expected):
     with torch.device("meta"):
         model = GPT.from_name("pythia-14m", n_layer=n_layer)
 
-    actual = layer_to_device(model, Block, chunk_size=n_layer // devices)
+    max_layers_per_device = math.ceil(n_layer / devices)
+    actual = layer_to_device(model, Block, chunk_size=max_layers_per_device)
     expected = {f"transformer.h.{i}": v for i, v in expected.items()}
     assert actual == expected
+
+
+def test_sequential_layer_to_device_mapping_not_possible():
+    # Fewer layers than devices
+    config = Config(n_layer=1)
+    with torch.device("meta"):
+        model = GPT(config)
+    with pytest.raises(RuntimeError, match="number of layers in the model must be larger than the number of devices"):
+        sequential(model, root=torch.device("cpu"), max_seq_length=128, devices=2)
+
+    config = Config(n_layer=6)
+    with torch.device("meta"):
+        model = GPT(config)
+    with pytest.raises(RuntimeError, match="Not able to distribute the 6 layers across 4 devices"):
+        sequential(model, root=torch.device("cpu"), max_seq_length=128, devices=4)
 
 
 def path_to_device(model):

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -47,7 +47,7 @@ def test_sequential_layer_to_device_mapping_not_possible():
     config = Config(n_layer=1)
     with torch.device("meta"):
         model = GPT(config)
-    with pytest.raises(RuntimeError, match="number of layers in the model must be larger than the number of devices"):
+    with pytest.raises(ValueError, match="number of layers in the model must be larger than the number of devices"):
         sequential(model, root=torch.device("cpu"), max_seq_length=128, devices=2)
 
     # Last device would get 0 layers

--- a/tests/test_generate_sequentially.py
+++ b/tests/test_generate_sequentially.py
@@ -50,6 +50,7 @@ def test_sequential_layer_to_device_mapping_not_possible():
     with pytest.raises(RuntimeError, match="number of layers in the model must be larger than the number of devices"):
         sequential(model, root=torch.device("cpu"), max_seq_length=128, devices=2)
 
+    # Last device would get 0 layers
     config = Config(n_layer=6)
     with torch.device("meta"):
         model = GPT(config)


### PR DESCRIPTION
Previously, running a model with a number of layers that was not evenly divisible by the number of devices used was not supported. This PR makes it possible by packing more layers on the first n-1 GPUs and allowing the last one to have fewer layers as the remainder. There will still be edge cases where we wouldn't be able to do that as the remainder could be 0, but this PR keeps it simple and excludes these cases. 


Example:
Enables running Meta-Llama-3.1-405B. It has 126 layers, which is not divisible by 8. So prior implementation couldn't distribute that. This implementation will pack ceil(126 / 8) = 16 layers on the first 7 GPUs each, and 126 - 7 * 16 = 14 layers on the last GPU. 


```
litgpt generate_sequentially checkpoints/meta-llama/Meta-Llama-3.1-405B --devices 8 --precision bf16-true --quantize bnb.nf4
```
