### PR TITLE
Bumb version to 0.4.6 for next release (Gemma 2 and Llama 3.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.5"
+version = "0.4.6"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
Bumps version for the next release that will include Gemma 2 and Llama 3.1 support