### PR TITLE
Remove NumPy < 2.0 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ all = [
     "litdata==0.2.17",           # litgpt.data
     "litserve>=0.1.2",           # litgpt.deploy
     "zstandard>=0.22.0",         # litgpt.data.prepare_slimpajama.py
-    "numpy<2.0.0",               # PyTorch dependency; "pinned" until NumPy 2.0 is tested
     "pandas>=1.9.0",             # litgpt.data.prepare_starcoder.py
     "pyarrow>=15.0.2",           # litgpt.data.prepare_starcoder.py
     "tensorboard>=2.14.0",       # litgpt.pretrain


### PR DESCRIPTION
Following up on #1494 I had a reminder for July to see if we can now remove the old NumPy version pin and support NumPy 2.0.

Fixes #1494