### PR TITLE
Fix kv-cache issue in Python API streaming mode

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -219,6 +219,9 @@ class LLM:
         prompt_length = input_ids.size(0)
         max_returned_tokens = prompt_length + max_new_tokens
 
+        if self.model.mask_cache is not None:
+            self.model.clear_kv_cache()
+
         first_turn = self.model.mask_cache is None
         if first_turn or max_returned_tokens > self.model.max_seq_length:
             self.model.max_seq_length = max_returned_tokens
@@ -261,8 +264,6 @@ class LLM:
                 eos_id=self.preprocessor.tokenizer.eos_id,
                 include_prompt=False,
             )
-
-        self.model.clear_kv_cache()
 
         if stream:
             return outputs


### PR DESCRIPTION
Fixes an issue with setting the kv-cache when using the Python API when `streaming=True`:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], [line 2](vscode-notebook-cell:?execution_count=2&line=2)
      [1](vscode-notebook-cell:?execution_count=2&line=1) result = llm.generate("What is 1 + 2?", stream=True)
----> [2](vscode-notebook-cell:?execution_count=2&line=2) for e in result:
      [3](vscode-notebook-cell:?execution_count=2&line=3)     print(e, end="", flush=True)

File ~/litgpt2/litgpt/api.py:247, in LLM.generate.<locals>.iterator()
    [245](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/api.py:245)     yield from outputs
    [246](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/api.py:246) else:
--> [247](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/api.py:247)     for output in outputs:
    [248](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/api.py:248)         yield self.preprocessor.tokenizer.decode(output)
    [249](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/api.py:249) return

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:35, in _wrap_generator.<locals>.generator_context(*args, **kwargs)
     [32](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:32) try:
     [33](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:33)     # Issuing `None` to a generator fires it up
     [34](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:34)     with ctx_factory():
---> [35](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:35)         response = gen.send(None)
     [37](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:37)     while True:
     [38](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:38)         try:
     [39](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:39)             # Forward the response to our caller and get its next request

File ~/litgpt2/litgpt/chat/base.py:79, in generate(model, prompt, max_returned_tokens, temperature, top_k, top_p, stop_tokens)
     [77](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/chat/base.py:77) token = prompt
     [78](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/chat/base.py:78) for t in range(1, max_returned_tokens - T + 1):
---> [79](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/chat/base.py:79)     token = next_token(model, input_pos, token.view(1, -1), temperature=temperature, top_k=top_k, top_p=top_p)
     [80](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/chat/base.py:80)     tokens.append(token)
     [81](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/chat/base.py:81)     # check the stop condition

File ~/litgpt2/litgpt/generate/base.py:77, in next_token(model, input_pos, x, **kwargs)
     [76](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/generate/base.py:76) def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
---> [77](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/generate/base.py:77)     logits = model(x, input_pos)
     [78](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/generate/base.py:78)     next = sample(logits, **kwargs)
     [79](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/generate/base.py:79)     return next.to(dtype=x.dtype)

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1511, in Module._wrapped_call_impl(self, *args, **kwargs)
   [1509](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1509)     return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   [1510](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1510) else:
-> [1511](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1511)     return self._call_impl(*args, **kwargs)

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1520, in Module._call_impl(self, *args, **kwargs)
   [1515](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1515) # If we don't have any hooks, we want to skip the rest of the logic in
   [1516](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1516) # this function, and just call forward.
   [1517](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/nn/modules/module.py:1517) if not (self._backward_hooks or self._backward_pre_hooks or self._forward_hooks or self._forward_pre_hooks
...
---> [82](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/model.py:82)         raise TypeError("You need to call `gpt.set_kv_cache()`")
     [83](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/model.py:83)     mask = self.mask_cache.index_select(2, input_pos)
     [84](https://vscode-remote+vscode-002d01j33eabry5h6bsyvfqn84g9rv-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt2/litgpt/model.py:84) else:

TypeError: You need to call `gpt.set_kv_cache()`
```

I think that this PR will address your issue @aniketmaurya 