### PR TITLE
Fix prompt docstring in Python API

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -195,7 +195,7 @@ class LLM:
 
         Arguments:
             model: The model to use.
-            prompt: Tensor of shape (T) with indices of the prompt sequence.
+            prompt: The prompt string to use for generating the samples.
             max_new_tokens: The maximum number of tokens to generate.
             temperature: Scales the predicted logits by 1 / temperature.
             top_k: If specified, only sample among the tokens with the k highest probabilities.


### PR DESCRIPTION
The docstring incorrectly said it was accepting a processed tensor as a prompt, but it should be a string.