### PR TITLE
Add missing super() call in data modules

### DIFF
--- a/litgpt/data/alpaca.py
+++ b/litgpt/data/alpaca.py
@@ -47,6 +47,7 @@ class Alpaca(DataModule):
     test_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
 

--- a/litgpt/data/deita.py
+++ b/litgpt/data/deita.py
@@ -40,6 +40,7 @@ class Deita(DataModule):
     test_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
 

--- a/litgpt/data/dolly.py
+++ b/litgpt/data/dolly.py
@@ -37,11 +37,6 @@ class Dolly(Alpaca):
     file_name: str = field(repr=False, default="dolly_data_cleaned.json")
     """The name of the dataset file to download."""
 
-    def __post_init__(self) -> None:
-        super().__init__()
-        if isinstance(self.prompt_style, str):
-            self.prompt_style = PromptStyle.from_name(self.prompt_style)
-
     def setup(self, stage: str = "") -> None:
         with open(self.download_dir / self.file_name, "r", encoding="utf-8") as file:
             data = file.readlines()

--- a/litgpt/data/dolly.py
+++ b/litgpt/data/dolly.py
@@ -38,6 +38,7 @@ class Dolly(Alpaca):
     """The name of the dataset file to download."""
 
     def __post_init__(self) -> None:
+        super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
 

--- a/litgpt/data/flan.py
+++ b/litgpt/data/flan.py
@@ -46,6 +46,7 @@ class FLAN(DataModule):
     test_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
+        super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
 

--- a/litgpt/data/json_data.py
+++ b/litgpt/data/json_data.py
@@ -42,6 +42,7 @@ class JSON(DataModule):
     val_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
+        super().__init__()
         if self.json_path.is_file() and self.val_split_fraction is None:
             raise ValueError(
                 "If `json_path` is a file, you must set `val_split_fraction` to a value between 0 and 1 to split the"

--- a/litgpt/data/lima.py
+++ b/litgpt/data/lima.py
@@ -43,6 +43,7 @@ class LIMA(DataModule):
     test_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self):
+        super().__init__()
         if self.access_token is None:
             raise ValueError(
                 "LIMA requires authentication, please set the `HF_TOKEN=your_token` environment"

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -31,6 +31,7 @@ class LitData(DataModule):
     seq_length: int = field(init=False, repr=False, default=2048)
 
     def __post_init__(self) -> None:
+        super().__init__()
         if self.split_names is not None and len(self.split_names) != 2:
             raise ValueError("If provided `split_names` must be a tuple of two strings, for example: ('train', 'val').")
 

--- a/litgpt/data/longform.py
+++ b/litgpt/data/longform.py
@@ -40,6 +40,7 @@ class LongForm(DataModule):
     test_dataset: Optional[SFTDataset] = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
 

--- a/litgpt/data/openwebtext.py
+++ b/litgpt/data/openwebtext.py
@@ -30,6 +30,7 @@ class OpenWebText(DataModule):
     seq_length: int = field(default=2048, repr=False, init=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         # Could be a remote path (s3://) or a local path
         self.data_path_train = str(self.data_path).rstrip("/") + "/train"
         self.data_path_val = str(self.data_path).rstrip("/") + "/val"

--- a/litgpt/data/text_files.py
+++ b/litgpt/data/text_files.py
@@ -36,6 +36,7 @@ class TextFiles(DataModule):
     max_seq_length: int = field(default=-1, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         self.out_path_train = self.train_data_path / "train"
         if self.val_data_path is None:
             self.out_path_val = self.train_data_path / "val"

--- a/litgpt/data/tinyllama.py
+++ b/litgpt/data/tinyllama.py
@@ -31,6 +31,7 @@ class TinyLlama(DataModule):
     seq_length: int = field(init=False, repr=False, default=2048)
 
     def __post_init__(self):
+        super().__init__()
         # Could be a remote path (s3://) or a local path
         self.slimpajama_train = str(self.data_path).rstrip("/") + "/slimpajama/train"
         self.slimpajama_val = str(self.data_path).rstrip("/") + "/slimpajama/val"

--- a/litgpt/data/tinystories.py
+++ b/litgpt/data/tinystories.py
@@ -36,6 +36,7 @@ class TinyStories(DataModule):
     max_seq_length: int = field(default=-1, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        super().__init__()
         self.data_path_train = self.data_path / "train"
         self.data_path_val = self.data_path / "val"
 

--- a/tests/data/test_alpaca.py
+++ b/tests/data/test_alpaca.py
@@ -25,3 +25,6 @@ def test_alpaca(mock_tokenizer, alpaca_path):
 
     assert isinstance(train_dataloader.dataset.prompt_style, AlpacaPromptStyle)
     assert isinstance(val_dataloader.dataset.prompt_style, AlpacaPromptStyle)
+
+    # has attributes from super class `LightningDataModule`
+    assert alpaca.prepare_data_per_node

--- a/tests/data/test_deita.py
+++ b/tests/data/test_deita.py
@@ -67,3 +67,6 @@ def test_deita(_, format_dataset_mock, mock_tokenizer, tmp_path):
 
     assert isinstance(train_dataloader.dataset.prompt_style, AlpacaPromptStyle)
     assert isinstance(val_dataloader.dataset.prompt_style, AlpacaPromptStyle)
+
+    # has attributes from super class `LightningDataModule`
+    assert deita.prepare_data_per_node

--- a/tests/data/test_dolly.py
+++ b/tests/data/test_dolly.py
@@ -5,14 +5,14 @@ from litgpt.prompts import Alpaca as AlpacaPromptStyle
 
 
 def test_dolly(mock_tokenizer, dolly_path):
-    alpaca = Dolly(val_split_fraction=0.5, download_dir=dolly_path.parent, file_name=dolly_path.name, num_workers=0)
-    assert isinstance(alpaca.prompt_style, AlpacaPromptStyle)
-    alpaca.connect(mock_tokenizer, batch_size=2, max_seq_length=10)
-    alpaca.prepare_data()
-    alpaca.setup()
+    dolly = Dolly(val_split_fraction=0.5, download_dir=dolly_path.parent, file_name=dolly_path.name, num_workers=0)
+    assert isinstance(dolly.prompt_style, AlpacaPromptStyle)
+    dolly.connect(mock_tokenizer, batch_size=2, max_seq_length=10)
+    dolly.prepare_data()
+    dolly.setup()
 
-    train_dataloader = alpaca.train_dataloader()
-    val_dataloader = alpaca.val_dataloader()
+    train_dataloader = dolly.train_dataloader()
+    val_dataloader = dolly.val_dataloader()
 
     assert len(train_dataloader) == 3
     assert len(val_dataloader) == 3
@@ -26,3 +26,6 @@ def test_dolly(mock_tokenizer, dolly_path):
 
     assert isinstance(train_dataloader.dataset.prompt_style, AlpacaPromptStyle)
     assert isinstance(val_dataloader.dataset.prompt_style, AlpacaPromptStyle)
+
+    # has attributes from super class `LightningDataModule`
+    assert dolly.prepare_data_per_node

--- a/tests/data/test_json.py
+++ b/tests/data/test_json.py
@@ -61,6 +61,9 @@ def test_json(as_jsonl, tmp_path, mock_tokenizer):
     assert isinstance(train_dataloader.dataset.prompt_style, Style)
     assert isinstance(val_dataloader.dataset.prompt_style, Style)
 
+    # has attributes from super class `LightningDataModule`
+    assert data.prepare_data_per_node
+
 
 def test_json_input_validation(tmp_path):
     with pytest.raises(FileNotFoundError, match="The `json_path` must be a file or a directory"):

--- a/tests/data/test_longform.py
+++ b/tests/data/test_longform.py
@@ -4,14 +4,14 @@ from litgpt.prompts import Longform as LongFormPromptStyle
 
 
 def test_longform(mock_tokenizer, longform_path):
-    alpaca = LongForm(download_dir=longform_path, num_workers=0)
-    assert isinstance(alpaca.prompt_style, LongFormPromptStyle)
-    alpaca.connect(mock_tokenizer, batch_size=2, max_seq_length=10)
-    alpaca.prepare_data()
-    alpaca.setup()
+    longform = LongForm(download_dir=longform_path, num_workers=0)
+    assert isinstance(longform.prompt_style, LongFormPromptStyle)
+    longform.connect(mock_tokenizer, batch_size=2, max_seq_length=10)
+    longform.prepare_data()
+    longform.setup()
 
-    train_dataloader = alpaca.train_dataloader()
-    val_dataloader = alpaca.val_dataloader()
+    train_dataloader = longform.train_dataloader()
+    val_dataloader = longform.val_dataloader()
 
     assert len(train_dataloader) == 9
     assert len(val_dataloader) == 5
@@ -25,3 +25,6 @@ def test_longform(mock_tokenizer, longform_path):
 
     assert isinstance(train_dataloader.dataset.prompt_style, LongFormPromptStyle)
     assert isinstance(val_dataloader.dataset.prompt_style, LongFormPromptStyle)
+
+    # has attributes from super class `LightningDataModule`
+    assert longform.prepare_data_per_node

--- a/tests/data/test_openwebtext.py
+++ b/tests/data/test_openwebtext.py
@@ -60,3 +60,6 @@ def test_openwebtext(_, __, optimize_mock, tmp_path, mock_tokenizer):
     val_dataloader = data.val_dataloader()
     assert isinstance(val_dataloader, DataLoader)
     assert isinstance(val_dataloader.dataset, StreamingDataset)
+
+    # has attributes from super class `LightningDataModule`
+    assert data.prepare_data_per_node

--- a/tests/data/test_tinyllama.py
+++ b/tests/data/test_tinyllama.py
@@ -35,3 +35,6 @@ def test_tinyllama(_, tmp_path):
     val_dataloader = data.val_dataloader()
     assert isinstance(val_dataloader, DataLoader)
     assert isinstance(val_dataloader.dataset, StreamingDataset)
+
+    # has attributes from super class `LightningDataModule`
+    assert data.prepare_data_per_node


### PR DESCRIPTION
The LitGPT datamodules inherit from LightningDataModule, but most of them are dataclasses and we forgot to call `super().__init__()`. When attempting to use the data module with the Lightning Trainer, we get:

```
AttributeError: 'Alpaca' object has no attribute 'prepare_data_per_node'
```

This PR adds the missing super call and ensures the modules can be used with Lightning Trainer.