### PR TITLE
Update Lightning version to 2.4.0 pre

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = { file = "LICENSE" }
 
 dependencies = [
     "torch>=2.2.0",
-    "lightning==2.3.0.dev20240428",
+    "lightning==2.4.0.dev20240728",
     "jsonargparse[signatures]>=4.27.6",
     "huggingface_hub>=0.23.5",          # download models
     "safetensors>=0.4.3",               # download models


### PR DESCRIPTION
Includes the fix: https://github.com/Lightning-AI/pytorch-lightning/pull/20121 @rasbt 
There will be a 2.4 release soon.

Closes #1604 (?)