### PR TITLE
Use Python API in serve code

### DIFF
--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -2,12 +2,12 @@
 from pathlib import Path
 from pprint import pprint
 from typing import Dict, Any, Optional
-from litgpt.utils import check_valid_checkpoint_dir
 
 import lightning as L
 from lightning_utilities.core.imports import RequirementCache
 import torch
 
+from litgpt.api import LLM
 
 from litgpt.model import GPT  # needs to be imported before config
 from litgpt.config import Config
@@ -30,13 +30,15 @@ else:
 
 
 class BaseLitAPI(LitAPI):
-    def __init__(self,
-                 checkpoint_dir: Path,
-                 precision: Optional[str] = None,
-                 temperature: float = 0.8,
-                 top_k: int = 50,
-                 top_p: float = 1.0,
-                 max_new_tokens: int = 50) -> None:
+    def __init__(
+        self,
+        checkpoint_dir: Path,
+        precision: Optional[str] = None,
+        temperature: float = 0.8,
+        top_k: int = 50,
+        top_p: float = 1.0,
+        max_new_tokens: int = 50
+    ) -> None:
 
         if not _LITSERVE_AVAILABLE:
             raise ImportError(str(_LITSERVE_AVAILABLE))
@@ -50,44 +52,25 @@ class BaseLitAPI(LitAPI):
         self.top_p = top_p
 
     def setup(self, device: str) -> None:
-        # Setup the model so it can be called in `predict`.
-        config = Config.from_file(self.checkpoint_dir / "model_config.yaml")
-        device = torch.device(device)
-        torch.set_float32_matmul_precision("high")
+        if ":" in device:
+            accelerator, device = device.split(":")
+            device = f"[{int(device)}]"
+        else:
+            accelerator = device
+            device = 1
 
-        precision = self.precision or get_default_supported_precision(training=False)
-
-        fabric = L.Fabric(
-            accelerator=device.type,
-            devices=1 if device.type == "cpu" else [device.index],
-            precision=precision,
+        print("Initializing model...")
+        self.llm = LLM.load(
+            self.checkpoint_dir,
+            accelerator=accelerator,
+            precision=self.precision
         )
-        checkpoint_path = self.checkpoint_dir / "lit_model.pth"
-        self.tokenizer = Tokenizer(self.checkpoint_dir)
-        self.prompt_style = (
-            load_prompt_style(self.checkpoint_dir)
-            if has_prompt_style(self.checkpoint_dir)
-            else PromptStyle.from_config(config)
-        )
-        with fabric.init_module(empty_init=True):
-            model = GPT(config)
-
-        # This should be set if we add a compile feature later
-        # with fabric.init_tensor():
-        #     model.set_kv_cache(batch_size=1)
-
-        model.eval()
-
-        self.model = fabric.setup_module(model)
-        load_checkpoint(fabric, self.model, checkpoint_path)
-        self.device = fabric.device
+        print("Model successfully initialized.")
 
     def decode_request(self, request: Dict[str, Any]) -> Any:
         # Convert the request payload to your model input.
         prompt = str(request["prompt"])
-        prompt = self.prompt_style.apply(prompt)
-        encoded = self.tokenizer.encode(prompt, device=self.device)
-        return encoded
+        return prompt
 
 
 class SimpleLitAPI(BaseLitAPI):
@@ -103,34 +86,19 @@ class SimpleLitAPI(BaseLitAPI):
     def setup(self, device: str):
         super().setup(device)
 
-    def predict(self, inputs: torch.Tensor) -> Any:
-        # Run the model on the input and return the output.
-        prompt_length = inputs.size(0)
-        max_returned_tokens = prompt_length + self.max_new_tokens
-
-        first_turn = self.model.mask_cache is None
-        if first_turn or max_returned_tokens > self.model.max_seq_length:
-            self.model.max_seq_length = max_returned_tokens
-            self.model.set_kv_cache(batch_size=1, device=self.device)
-
-        y = plain_generate(
-            self.model,
+    def predict(self, inputs: str) -> Any:
+        output = self.llm.generate(
             inputs,
-            max_returned_tokens,
             temperature=self.temperature,
             top_k=self.top_k,
             top_p=self.top_p,
-            eos_id=self.tokenizer.eos_id,
-            include_prompt=False
+            max_new_tokens=self.max_new_tokens
         )
+        return output
 
-        self.model.clear_kv_cache()
-        return y
-
-    def encode_response(self, output: torch.Tensor) -> Dict[str, Any]:
+    def encode_response(self, output: str) -> Dict[str, Any]:
         # Convert the model output to a response payload.
-        decoded_output = self.tokenizer.decode(output)
-        return {"output": decoded_output}
+        return {"output": output}
 
 
 class StreamLitAPI(BaseLitAPI):
@@ -148,30 +116,18 @@ class StreamLitAPI(BaseLitAPI):
 
     def predict(self, inputs: torch.Tensor) -> Any:
         # Run the model on the input and return the output.
-        prompt_length = inputs.size(0)
-        max_returned_tokens = prompt_length + self.max_new_tokens
-
-        first_turn = self.model.mask_cache is None
-        if first_turn or max_returned_tokens > self.model.max_seq_length:
-            self.model.max_seq_length = max_returned_tokens
-            self.model.set_kv_cache(batch_size=1, device=self.device)
-
-        try:
-            yield from stream_generate(
-                self.model,
-                inputs,
-                max_returned_tokens,
-                temperature=self.temperature,
-                top_k=self.top_k,
-                top_p=self.top_p,
-                stop_tokens=([self.tokenizer.eos_id],)
-            )
-        finally:
-            self.model.clear_kv_cache()
+        yield from self.llm.generate(
+            inputs,
+            temperature=self.temperature,
+            top_k=self.top_k,
+            top_p=self.top_p,
+            max_new_tokens=self.max_new_tokens,
+            stream=True
+        )
 
     def encode_response(self, output):
         for out in output:
-            yield {"output": self.tokenizer.decode(out)}
+            yield {"output": out}
 
 
 def run_server(


### PR DESCRIPTION
This replaces the custom code in `litgpt serve` by the Python `LLM` API. 

The goal of this is to lower maintenance and duplication efforts, because this way we don't have to apply modifications and fixes in two places separately.