### PR TITLE
Properly clear kv-cache

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -231,7 +231,7 @@ class LLM:
                 self.kvcache_initialized = False
             else:
                 for block in self.model.transformer.h:
-                    block.attn.kv_cache = None
+                    block.attn.kv_cache.reset_parameters()
 
         # Create, clear or grow the kv cache if necessary.
         max_model_supported = self.model.max_seq_length


### PR DESCRIPTION
Turned out the kv-cache issues were back ... I.e., the model would generate nonsensical outputs if the cache was cleared, not rebuilt. It seems with this update, the issue is finally fixed.