### PR TITLE
Fix error raising where max_returned_tokens > max_seq_length_setting

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -236,13 +236,6 @@ class LLM:
         # Create, clear or grow the kv cache if necessary.
         max_model_supported = self.model.max_seq_length
 
-        if max_returned_tokens > max_model_supported:
-            raise ValueError(
-                    f"Cannot generate a response with {max_returned_tokens} tokens.\n"
-                    f"This model has a maximum context length of {max_model_supported} tokens.\n"
-                    f"The prompt contains {prompt_length} tokens, leaving {max_model_supported - prompt_length} for the response, which is not enough."
-                )
-
         if max_seq_length == "dynamic":
             max_seq_length_setting = max_returned_tokens
 
@@ -258,6 +251,13 @@ class LLM:
             max_seq_length_setting = max_seq_length
         else:
             raise ValueError(f"Invalid max_seq_length: {max_seq_length}")
+
+        if max_returned_tokens > max_seq_length_setting:
+            raise ValueError(
+                    f"Cannot generate a response with {max_returned_tokens} tokens.\n"
+                    f"This model has a maximum context length of {max_seq_length_setting} tokens.\n"
+                    f"The prompt contains {prompt_length} tokens, leaving {max_seq_length_setting - prompt_length} for the response, which is not enough."
+                )
 
         if not self.kvcache_initialized or self.prev_generated_seq_length != max_returned_tokens:
             self.model.set_kv_cache(batch_size=1, max_seq_length=max_seq_length_setting, device=self.fabric.device)


### PR DESCRIPTION
In some scenarios, no error was raised when too many tokens were requested. Or rather, it led to a cryptic error:

```
from litgpt.api import LLM

llm = LLM.load("EleutherAI/pythia-160m")
llm.generate("What do llamas eat?", max_seq_length=10)
```

```python
RuntimeError                              Traceback (most recent call last)
Cell In[5], line 1
----> 1 llm.generate("What do llamas eat?", max_seq_length=30)

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:115, in context_decorator.<locals>.decorate_context(*args, **kwargs)
    112 @functools.wraps(func)
    113 def decorate_context(*args, **kwargs):
    114     with ctx_factory():
--> 115         return func(*args, **kwargs)

File ~/litgpt/litgpt/api.py:294, in LLM.generate(self, prompt, max_new_tokens, max_seq_length, temperature, top_k, top_p, return_as_token_ids, stream)
    292     outputs = iterator()
    293 else:
--> 294     outputs = generate_fn(
    295         model=self.model,
    296         prompt=input_ids.to(self.fabric.device),
    297         max_returned_tokens=max_returned_tokens,
    298         temperature=temperature,
    299         top_k=top_k,
    300         top_p=top_p,
    301         eos_id=self.preprocessor.tokenizer.eos_id,
    302         include_prompt=False,
    303     )
    305 if stream:
    306     return outputs

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:115, in context_decorator.<locals>.decorate_context(*args, **kwargs)
    112 @functools.wraps(func)
    113 def decorate_context(*args, **kwargs):
    114     with ctx_factory():
--> 115         return func(*args, **kwargs)

File ~/litgpt/litgpt/generate/base.py:140, in generate(model, prompt, max_returned_tokens, temperature, top_k, top_p, eos_id, include_prompt)
    138 tokens.append(token)
    139 for _ in range(2, max_returned_tokens - T + 1):
--> 140     token = next_token(
    141         model, input_pos, token.view(1, -1), temperature=temperature, top_k=top_k, top_p=top_p
    142     ).clone()
    143     tokens.append(token)
    144     if token == eos_id:

File ~/litgpt/litgpt/generate/base.py:77, in next_token(model, input_pos, x, **kwargs)
     76 def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
---> 77     logits = model(x, input_pos)
...
RuntimeError: CUDA error: device-side assert triggered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

With this fix, the appropriate error will be raised:

```python
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], [line 1](vscode-notebook-cell:?execution_count=2&line=1)
----> [1](vscode-notebook-cell:?execution_count=2&line=1) llm.generate("What do llamas eat?", max_seq_length=10)

File /home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:115, in context_decorator.<locals>.decorate_context(*args, **kwargs)
    [112](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:112) @functools.wraps(func)
    [113](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:113) def decorate_context(*args, **kwargs):
    [114](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:114)     with ctx_factory():
--> [115](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/torch/utils/_contextlib.py:115)         return func(*args, **kwargs)

File ~/litgpt/litgpt/api.py:256, in LLM.generate(self, prompt, max_new_tokens, max_seq_length, temperature, top_k, top_p, return_as_token_ids, stream)
    [253](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:253)     raise ValueError(f"Invalid max_seq_length: {max_seq_length}")
    [255](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:255) if max_returned_tokens > max_seq_length_setting:
--> [256](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:256)     raise ValueError(
    [257](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:257)             f"Cannot generate a response with {max_returned_tokens} tokens.\n"
    [258](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:258)             f"This model has a maximum context length of {max_seq_length_setting} tokens.\n"
    [259](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:259)             f"The prompt contains {prompt_length} tokens, leaving {max_seq_length_setting - prompt_length} for the response, which is not enough."
    [260](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:260)         )
    [262](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:262) if not self.kvcache_initialized or self.prev_generated_seq_length != max_returned_tokens:
    [263](https://vscode-remote+vscode-002d01j3zappssbnw39ds60j2fr0n2-002estudio-002elightning-002eai.vscode-resource.vscode-cdn.net/teamspace/studios/this_studio/~/litgpt/litgpt/api.py:263)     self.model.set_kv_cache(batch_size=1, max_seq_length=max_seq_length_setting, device=self.fabric.device)

ValueError: Cannot generate a response with 56 tokens.
This model has a maximum context length of 10 tokens.
The prompt contains 6 tokens, leaving 4 for the response, which is not enough.
```