### PR TITLE
Version bumb for Gemma 2 2B release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.7"
+version = "0.4.8"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
Bumps to a new version so we can make a new release that includes the newly released Gemma 2 2B model which is now supported in LitGPT