### PR TITLE
Fix some issues with circular and relative imports

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -8,8 +8,6 @@ from typing import Any, Literal, Optional, Type, Union
 import torch
 import yaml
 from typing_extensions import Self
-
-import litgpt.model
 from litgpt.utils import find_multiple
 
 
@@ -144,6 +142,7 @@ class Config:
     @property
     def mlp_class(self) -> Type:
         # `self.mlp_class_name` cannot be the type to keep the config serializable
+        import litgpt.model
         return getattr(litgpt.model, self.mlp_class_name)
 
     @property

--- a/litgpt/data/base.py
+++ b/litgpt/data/base.py
@@ -8,7 +8,7 @@ from lightning import LightningDataModule
 from torch import Tensor
 from torch.utils.data import Dataset
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.prompts import PromptStyle
 
 

--- a/litgpt/data/deita.py
+++ b/litgpt/data/deita.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import torch
 from torch.utils.data import DataLoader
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.tokenizer import Tokenizer
 

--- a/litgpt/data/dolly.py
+++ b/litgpt/data/dolly.py
@@ -8,7 +8,7 @@ from typing import Union
 import torch
 from torch.utils.data import random_split
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import Alpaca, SFTDataset
 
 _URL: str = "https://huggingface.co/datasets/databricks/databricks-dolly-15k/resolve/main/databricks-dolly-15k.jsonl"

--- a/litgpt/data/flan.py
+++ b/litgpt/data/flan.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Set, Union
 import torch
 from torch.utils.data import DataLoader
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.data.alpaca import download_if_missing
 from litgpt.tokenizer import Tokenizer

--- a/litgpt/data/json_data.py
+++ b/litgpt/data/json_data.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Tuple, Union
 import torch
 from torch.utils.data import DataLoader, random_split
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.tokenizer import Tokenizer
 

--- a/litgpt/data/lima.py
+++ b/litgpt/data/lima.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import torch
 from torch.utils.data import DataLoader, random_split
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.tokenizer import Tokenizer
 

--- a/litgpt/data/lit_data.py
+++ b/litgpt/data/lit_data.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple, Union
 
 from torch.utils.data import DataLoader
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data import DataModule
 
 

--- a/litgpt/data/longform.py
+++ b/litgpt/data/longform.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 import torch
 from torch.utils.data import DataLoader
 
-from litgpt import PromptStyle
+from litgpt.prompts import PromptStyle
 from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.data.alpaca import download_if_missing
 from litgpt.tokenizer import Tokenizer

--- a/litgpt/data/openwebtext.py
+++ b/litgpt/data/openwebtext.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 from torch.utils.data import DataLoader
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data import DataModule
 
 

--- a/litgpt/data/prepare_slimpajama.py
+++ b/litgpt/data/prepare_slimpajama.py
@@ -5,7 +5,7 @@ import os
 import time
 from pathlib import Path
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data.prepare_starcoder import DataChunkRecipe
 from litgpt.utils import CLI, extend_checkpoint_dir
 

--- a/litgpt/data/prepare_starcoder.py
+++ b/litgpt/data/prepare_starcoder.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from lightning_utilities.core.imports import RequirementCache
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.utils import CLI, extend_checkpoint_dir
 
 _LITDATA_AVAILABLE = RequirementCache("litdata")

--- a/litgpt/data/text_files.py
+++ b/litgpt/data/text_files.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from torch.utils.data import DataLoader
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data import DataModule
 
 

--- a/litgpt/data/tinyllama.py
+++ b/litgpt/data/tinyllama.py
@@ -5,7 +5,7 @@ from typing import Optional, Union
 
 from torch.utils.data import DataLoader
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data import DataModule
 
 

--- a/litgpt/data/tinystories.py
+++ b/litgpt/data/tinystories.py
@@ -10,7 +10,7 @@ from typing import Optional
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
-from litgpt import Tokenizer
+from litgpt.tokenizer import Tokenizer
 from litgpt.data import DataModule
 from litgpt.data.alpaca import download_if_missing
 from litgpt.data.text_files import validate_tokenizer


### PR DESCRIPTION
There were some issues with circular imports and also relative imports when importing form a Jupyter notebook that is in the same location as the cloned litgpt package. This is likely related to a clash between installed and local version of litgpt, but it's a common use case to have the litgpt package in the same folder as a script or Jupyter notebook (I remember Will bumping into this).