### PR TITLE
Issue a warning if a local folder with the same name as the litgpt package exists

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,13 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
+import importlib
+import os
+import warnings
+
+# Check if litgpt is installed as a package and exists as directory with the same name in the current working directory
+package_installed = importlib.util.find_spec("litgpt") is not None
+directory_exists = os.path.isdir("litgpt")
+if package_installed and directory_exists:
+    warnings.warn(
+        "The package 'litgpt' is installed and a directory with the same name exists in the working directory. "
+        "Please rename the 'litgpt' directory or move it to a subdirectory to avoid import conflicts.", UserWarning)

--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -1,9 +1,12 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 #
 # This file implements the LitGPT Python API
+import importlib
+import os
 from pathlib import Path
 import sys
 from typing import Any, List, Literal, Optional, Union
+import warnings
 
 import torch
 import lightning as L
@@ -25,6 +28,14 @@ from litgpt.utils import (
     get_default_supported_precision,
     load_checkpoint,
 )
+
+# Check if litgpt is installed as a package and exists as directory with the same name in the current working directory
+package_installed = importlib.util.find_spec("litgpt") is not None
+directory_exists = os.path.isdir("litgpt")
+if package_installed and directory_exists:
+    warnings.warn(
+        "The package 'litgpt' is installed and a directory with the same name exists in the working directory. "
+        "Please rename the 'litgpt' directory or move it to a subdirectory to avoid import conflicts.", UserWarning)
 
 
 class LLM:


### PR DESCRIPTION
It sometimes happened that users cloned the litgpt repository, installed it locally as a package, and then tried to run code from the main directory that contains the `litgpt` repo. This will naturally result in an error:
 
```python
ImportError: cannot import name 'LLM' from 'litgpt'
```

However, while this is expected behavior, this is confusing to users. So, by adding an `__init__.py` file into the main repo we can at least issue a warning:

I.e.,

```python
from litgpt import LLM
```

raises:

```
[/teamspace/studios/this_studio/litgpt/__init__.py:11]...: UserWarning: The package 'litgpt' is installed and a 
directory with the same name exists in the working directory. Please rename the 'litgpt' directory or move it to a 
subdirectory to avoid import conflicts.
  warnings.warn(

---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[1], [line 1](vscode-notebook-cell:?execution_count=1&line=1)
----> [1](vscode-notebook-cell:?execution_count=1&line=1) from litgpt import LLM
      [3](vscode-notebook-cell:?execution_count=1&line=3) llm = LLM.load(
      [4](vscode-notebook-cell:?execution_count=1&line=4)     model="EleutherAI/pythia-14m",
      [5](vscode-notebook-cell:?execution_count=1&line=5)     distribute=None
      [6](vscode-notebook-cell:?execution_count=1&line=6) )
      [8](vscode-notebook-cell:?execution_count=1&line=8) llm.distribute(devices=2, generate_strategy="sequential")

ImportError: cannot import name 'LLM' from 'litgpt' (/teamspace/studios/this_studio/litgpt/__init__.py)
```

If LitGPT is installed correctly, then importing as `from litgpt.api import LLM` would still work despite the subfolder, so I added the warning also to `api.py` code so that in this case it issues a warning as well:

```python
from litgpt.api import LLM
```

```
[/tmp/ipykernel_8649/1815565553.py:11](...: UserWarning: The package 'litgpt' is installed and a directory with the
 same name exists in the working directory. Please rename the 'litgpt' directory or move it to a subdirectory to avoid 
import conflicts.
  warnings.warn(
```

CC @awaelchli 