### PR TITLE
Optionally return benchmark info in Python API

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -355,6 +355,8 @@ class LLM:
         assert self.model is not None
 
         if benchmark:
+            if stream:
+                raise NotImplementedError("The `benchmark=True` setting is not supported when `stream=True`.")
             benchmark_dict = {}
             t0 = time.perf_counter()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,7 +145,6 @@ def test_more_than_1_device_for_sequential_gpu(tmp_path):
     llm.distribute(devices=2, generate_strategy="sequential")
     assert isinstance(llm.generate("What do llamas eat?"), str)
 
-
     with pytest.raises(NotImplementedError, match="Support for multiple devices is currently only implemented for generate_strategy='sequential'."):
         llm.distribute(devices=2)
 
@@ -206,8 +205,8 @@ def test_returned_benchmark_dir(tmp_path):
         model="EleutherAI/pythia-14m",
     )
 
-    text, bench_d = llm.generate("hello world", benchmark=True)
+    text, bench_d = llm.benchmark(prompt="hello world")
     assert isinstance(bench_d["Inference speed in tokens/sec"], float)
 
-    with pytest.raises(NotImplementedError, match="The `benchmark=True` setting is not supported when `stream=True`."):
-        output_text = llm.generate("hello world", stream=True, benchmark=True)
+    text, bench_d = llm.benchmark(prompt="hello world", stream=True)
+    assert isinstance(bench_d["Inference speed in tokens/sec"], float)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -208,3 +208,6 @@ def test_returned_benchmark_dir(tmp_path):
 
     text, bench_d = llm.generate("hello world", benchmark=True)
     assert isinstance(bench_d["Inference speed in tokens/sec"], float)
+
+    with pytest.raises(NotImplementedError, match="The `benchmark=True` setting is not supported when `stream=True`."):
+        output_text = llm.generate("hello world", stream=True, benchmark=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -199,3 +199,12 @@ def test_invalid_accelerator(tmp_path):
     )
     with pytest.raises(ValueError, match="Invalid accelerator"):
         llm.distribute(accelerator="invalid")
+
+
+def test_returned_benchmark_dir(tmp_path):
+    llm = LLM.load(
+        model="EleutherAI/pythia-14m",
+    )
+
+    text, bench_d = llm.generate("hello world", benchmark=True)
+    assert isinstance(bench_d["Inference speed in tokens/sec"], float)

--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -123,3 +123,34 @@ print(text)
 ```
  Llamas are herbivores and their diet consists mainly of grasses, plants, and leaves.
 ```
+
+&nbsp;
+## Speed and resource estimates
+
+Use the `.benchmark()` method to compare the computational performance of different settings. The `.benchmark()` method takes the same arguments as the `.generate()` method. For example, we can estimate the speed and GPU memory consumption as follows (the resulting numbers were obtained on an A10G GPU):
+
+```python
+from litgpt.api import LLM
+from pprint import pprint
+
+llm = LLM.load(
+    model="microsoft/phi-2",
+    distribute=None
+)
+
+llm.distribute(fixed_kv_cache_size=500)
+
+text, bench_d = llm.benchmark(prompt="What do llamas eat?", top_k=1, stream=True)
+print(text)
+pprint(bench_d)
+
+
+# Llamas are herbivores and primarily eat grass, leaves, and shrubs. They have a specialized 
+# digestive system that allows them to efficiently extract nutrients from plant material.
+
+# {'Inference speed in tokens/sec': 15.687777681894985,
+#  'Seconds to first token': 0.5756612900004257,
+#  'Seconds total': 1.5935972900006163,
+#  'Tokens generated': 25,
+#  'Total GPU memory allocated in GB': 11.534106624}
+```


### PR DESCRIPTION
This adds `benchmark=True|False` arg to the `llm.generate()` method to optionally return some basic benchmark info:

```python
from litgpt.api import LLM
from pprint import pprint

llm = LLM.load(
    model="microsoft/phi-2",
)

text, bench_d = llm.generate("What do llamas eat?", benchmark=True, top_k=1, max_new_tokens=500)
print(text)
pprint(bench_d)
```

```
 Llamas are herbivores and primarily eat grass, leaves, and shrubs. They have a unique digestive system that allows them to efficiently extract nutrients from tough plant material.

{'GPU memory used in GB': 7.545283072,
 'Inference speed in tokens/sec': 40.97021835066597,
 'Seconds total': 0.659015282000837,
 'Tokens generated': 27}
```

And

```python
del llm

llm = LLM.load(
    model="microsoft/phi-2",
    distribute=None
)

llm.distribute(devices=4, generate_strategy="sequential")

text, bench_d = llm.generate("What do llamas eat?", benchmark=True, top_k=1, max_new_tokens=500)
print(text)
pprint(bench_d)
```

```
Using 4 devices
Moving '_forward_module.transformer.h.31' to cuda:3: 100%|██████████| 32/32 [00:00<00:00, 32.41it/s]
 Llamas are herbivores and primarily eat grass, leaves, and shrubs. They have a specialized digestive system that allows them to efficiently extract nutrients from plant material.

{'GPU memory used in GB': 5.923797504,
 'Inference speed in tokens/sec': 27.07074143435894,
 'Seconds total': 0.9604465419997723,
 'Tokens generated': 26}
```

Is this what you were looking for @apaz-cli ?

PS: I also see that sequential/non-sequential has a 1-generated token difference (26 vs 27). I will investigate.