### PR TITLE
Add distribute=None to python-api.md

### DIFF
--- a/tutorials/python-api.md
+++ b/tutorials/python-api.md
@@ -102,7 +102,8 @@ the `generate_strategy="sequential"` setting to load different parts of the mode
 from litgpt.api import LLM
 
 llm = LLM.load(
-    "microsoft/phi-2"
+    "microsoft/phi-2",
+    distribute=None
 )
 
 llm.distribute(


### PR DESCRIPTION
Adds a `distribute=None` when using the sequential API so that it would also work with models too large to fit into memory of a single GPU.