### PR TITLE
Make number of generated tokens consistent with CLI

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -580,13 +580,12 @@ class LLM(torch.nn.Module):
                     gen_outputs.append(e)
                 outputs = "".join(gen_outputs)
             else:
-                outputs = self.generate(**kwargs, )
+                outputs = self.generate(**kwargs,)
             benchmark_dict.setdefault("Seconds total", []).append(time.perf_counter() - t0)
 
             benchmark_dict.setdefault("Seconds to first token", []).append(time_to_first_token)
-            benchmark_dict.setdefault("Tokens generated", []).append(
-                self.preprocessor.encode(outputs).size(0) - self._text_to_token_ids(kwargs.get("prompt")).size(0)
-            )
+            tokens_generated = self.preprocessor.encode(outputs).size(0)
+            benchmark_dict.setdefault("Tokens generated", []).append(tokens_generated)
             benchmark_dict.setdefault("Inference speed in tokens/sec", []).append(
                 benchmark_dict["Tokens generated"][-1] / benchmark_dict["Seconds total"][-1]
             )


### PR DESCRIPTION
Updated the `llm.benchmark()` method to make the number of generated tokens used for the calculation consistent with those in the CLI via `litgpt generate` and `litgpt chat`.