### PR TITLE
Add `batched_next_token()` and `batched_sample()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 ![cpu-tests](https://github.com/lightning-AI/lit-stablelm/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/lit-stablelm/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/1077906959069626439)](https://discord.gg/VptPCZkGNa)
 
 <p align="center">
+  <a href="https://lightning.ai/">Lightning AI</a> •
   <a href="#quick-start">Quick start</a> •
   <a href="#choose-from-20-llms">Models</a> •
   <a href="#finetune-an-llm">Finetune</a> • 
@@ -26,7 +27,6 @@
   <a href="#all-workflows">All workflows</a> • 
   <a href="#state-of-the-art-features">Features</a> •
   <a href="#training-recipes">Recipes (YAML)</a> •
-  <a href="https://lightning.ai/">Lightning AI</a> •
     <a href="#tutorials">Tutorials</a>
 </p>
 

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -79,6 +79,56 @@ def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: A
     return next.to(dtype=x.dtype)
 
 
+def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[dict]) -> list[torch.Tensor]:
+    assert len(logits) == len(kwargs), "logits and kwargs must have the same length."
+    return [sample(l, **sample_args).to(dtype=dtype) for sample_args, l in zip(kwargs, logits)]
+
+
+def batched_next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor | list[torch.Tensor], kwargs: dict | list[dict]) -> list[torch.Tensor]:
+    # TODO: Take input_pos as a tensor.
+    # This means making the rope cache and kvcache work with batches.
+    # This is relatively complicated, given the current implementation.
+    # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115
+    # We will also need the same with tensor.index_copy_(). These do not work for batches.
+
+    # This is where we would pad the input positions into a batch.
+    # See the above comment. Until then, we can only accept prompts that are all the same length.
+    assert input_pos.ndim == 1, "Passing input_pos as a tensor is not yet supported."
+    if isinstance(x, list):
+        assert all(t.size(0) == input_pos.size(0) for t in x), "For now, all input sequences must have the same length as input_pos."
+    else:
+        assert x.size(0) == input_pos.size(0), "For now, all input sequences must have the same length as input_pos."
+
+    # After this problem is resolved, there will be another problem. That being, continuous batched prefill.
+    # If you have any ideas on this, let me know. I don't think that padding input_pos is viable.
+
+    # Pad the contexts into a batch.
+    if isinstance(x, list):
+        assert all(isinstance(t, torch.Tensor) for t in x), "x must be a list of tensors."
+        x = [t.squeeze() for t in x]
+        assert all(t.ndim == 1 for t in x), "x must be a list of tensors that can be squeezed to 1D."
+        x = torch.nn.utils.rnn.pad_sequence([t.squeeze() for t in x], batch_first=True)
+
+    # Make sure we converted all the arguments correctly.
+    assert x.ndim == 2, "Could not create a 2D tensor from x."
+    assert input_pos.dtype == torch.int64, "input_pos must be a tensor with dtype int64."
+    assert x.dtype == torch.int64, "x must be a tensor with dtype int64."
+
+    if not isinstance(kwargs, list):
+        kwargs = [kwargs] * x.size(0)
+    assert all(isinstance(k, dict) for k in kwargs), "kwargs must be a dictionary or list of dictionaries."
+
+    # Run the model on the batch.
+    logits_stack = model(x, input_pos)
+
+    # Unbind the logits stack into a list of logits.
+    logits_list = [logits_stack] if logits_stack.ndim == 1 else logits_stack.unbind(0)
+    logits_list = [l.unsqueeze(0) for l in logits_list]
+
+    # Return the next token for each sample in the batch.
+    return batched_sample(logits_list, dtype=x.dtype, kwargs=kwargs)
+
+
 @torch.inference_mode()
 def generate_fn(
     model: GPT,

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -75,8 +75,135 @@ def sample(
 
 def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
     logits = model(x, input_pos)
-    next = sample(logits, **kwargs)
-    return next.to(dtype=x.dtype)
+    _next = sample(logits, **kwargs)
+    return _next.to(dtype=x.dtype)
+
+
+def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[dict]) -> list[torch.Tensor]:
+    return [sample(logits, **sample_args).to(dtype=dtype) for sample_args, logits in zip(kwargs, logits)]
+
+
+def batched_next_token(model: GPT, input_pos: torch.Tensor | list[torch.Tensor], x: torch.Tensor | list[torch.Tensor], kwargs: dict | list[dict]) -> list[torch.Tensor]:
+    # Pad the contexts into a batch.
+    if isinstance(input_pos, list):
+        assert all(isinstance(t, torch.Tensor) for t in input_pos), "input_pos must be a list of tensors."
+        input_pos = [t.squeeze() for t in input_pos]
+        assert all(t.ndim == 1 for t in input_pos), "input_pos must be a list of tensors that can be squeezed to 1D."
+        input_pos = torch.nn.utils.rnn.pad_sequence(input_pos, batch_first=True)
+
+    # Pad the input positions into a batch.
+    # The first token generated is the prefill token, so the input position for this token is the width of the entire prompt.
+    # In the continuous batching case, when we mix prefill and subsequent tokens, we pad everything to the biggest prefill prompt length.
+    # This is bad. I do not want to do this. Let me know if you know the better way to do this.
+    if isinstance(x, list):
+        assert all(isinstance(t, torch.Tensor) for t in x), "x must be a list of tensors."
+        x = [t.squeeze() for t in x]
+        assert all(t.ndim == 1 for t in x), "x must be a list of tensors that can be squeezed to 1D."
+        x = torch.nn.utils.rnn.pad_sequence([t.squeeze() for t in x], batch_first=True)
+
+    # Make sure we converted all the arguments correctly.
+    assert isinstance(input_pos, torch.Tensor)
+    assert isinstance(x, torch.Tensor)
+    assert input_pos.ndim == 2, "Could not create a 2D tensor from input_pos."
+    assert x.ndim == 2, "Could not create a 2D tensor from x."
+    assert x.size(0) == input_pos.size(0), "Batch size mismatch between input_pos and x."
+    assert x.size(1) == input_pos.size(1), "Max sequence length mismatch between input_pos and x."
+    assert input_pos.dtype == torch.int32, "input_pos must be a tensor with dtype int32."
+    assert x.dtype == torch.int32, "x must be a tensor with dtype int32."
+
+    if not isinstance(kwargs, list):
+        kwargs = [kwargs] * x.size(0)
+    assert all(isinstance(k, dict) for k in kwargs), "kwargs must be a dictionary or list of dictionaries."
+
+    # Run the model on the batch.
+    logits_stack = model(x, input_pos) # Explodes for the moment. Working on it.
+
+    # Unbind the logits stack into a list of logits.
+    logits_list = [logits_stack] if logits_stack.ndim == 1 else logits_stack.unbind(0)
+
+    # Return the next token for each sample in the batch.
+    return batched_sample(logits_list, dtype=x.dtype, kwargs=kwargs)
+
+
+@torch.inference_mode()
+def generate_fn(
+    model: GPT,
+    prompt: torch.Tensor,
+    max_returned_tokens: int,
+    *,
+    temperature: float = 1.0,
+    top_k: Optional[int] = None,
+    top_p: float = 1.0,
+    stop_tokens: Tuple[List[int], ...] = (),
+    include_prompt: bool,
+    include_eos: bool,
+) -> Iterator[torch.Tensor]:
+    prompt_size = prompt.size(0)
+    device = prompt.device
+
+    assert max_returned_tokens > prompt_size, f"Not enough space for {prompt_size} prompt tokens in a context length of {max_returned_tokens}."
+    assert max_returned_tokens > prompt_size, f"Not enough space for {prompt_size} prompt tokens in a context length of {max_returned_tokens}."
+    if model.max_seq_length < max_returned_tokens - 1:
+        raise NotImplementedError(f"max_seq_length {model.max_seq_length} needs to be >= {max_returned_tokens - 1}")
+
+    # Yield the prompt if include_prompt is True
+    if include_prompt:
+        yield prompt
+
+    stop_progress = [0] * len(stop_tokens)
+    yielded_idx = 0
+
+    # Generate output tokens.
+    # The first token generated is the prefill token.
+    # The input_pos for this token is the width of the entire prompt.
+    # For subsequent iterations, it's the index in the context for the token that we're generating.
+    tokens = []
+    token = prompt
+    prefill_token = True
+    input_pos = torch.arange(0, prompt_size, device=device)
+    for current_idx in range(max_returned_tokens - prompt_size):
+
+        # Generate the token
+        token = next_token(model, input_pos, token.view(1, -1), temperature=temperature, top_k=top_k, top_p=top_p)
+        tokens.append(token)
+        int_token = token.item()
+
+        # Check for stop sequences
+        # For each stop sequence, we keep a running total of how many are matched in stop_progress.
+        # If the current token matches the next token in the stop sequence, we increment the
+        # running total and hold off on yielding the token.
+        for i, seq in enumerate(stop_tokens):
+            if int_token == seq[stop_progress[i]]:
+                stop_progress[i] += 1
+                if stop_progress[i] == len(seq):
+                    if include_eos:
+                        yield from tokens[yielded_idx:]
+                    return
+            else:
+                stop_progress[i] = 0
+
+        # Yield tokens that are not part of a stop sequence in progress.
+        # If there are no stop sequences, then that's all of them.
+        if stop_tokens:
+            safe_idx = len(tokens) - max(stop_progress)
+        else:
+            safe_idx = current_idx + 1 # include the token just generated
+        
+        if yielded_idx < safe_idx:
+            y_tokens = tokens[yielded_idx : safe_idx]
+            yield from y_tokens
+            yielded_idx = safe_idx
+
+        # Update input_pos for the next iteration.
+        if prefill_token:
+            prefill_token = False
+            input_pos = torch.tensor([prompt_size], device=device)
+        else:
+            input_pos = input_pos.add_(1)
+
+    # Yield any remaining tokens
+    if yielded_idx < len(tokens):
+        yield from tokens[yielded_idx:]
 
 
 def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[dict]) -> list[torch.Tensor]:

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -71,7 +71,7 @@ class GPT(nn.Module):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
     def forward(self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None) -> torch.Tensor:
-        T = idx.size(1)
+        T = idx.size(-1)
         if self.max_seq_length < T:
             raise ValueError(f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}.")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,9 @@ import torch
 from unittest.mock import MagicMock
 from tests.conftest import RunIf
 
+
+from litgpt.api import LLM, calculate_number_of_devices
+
 from lightning.fabric.accelerators import CUDAAccelerator
 from litgpt.api import (
     LLM,
@@ -151,44 +154,21 @@ def test_model_not_initialized(tmp_path):
 
 
 @RunIf(min_cuda_gpus=2)
-def test_more_than_1_device_for_sequential_gpu(tmp_path):
-
-    device_count = CUDAAccelerator.auto_device_count()
-
-    if device_count <= 2:
-        model_name = "EleutherAI/pythia-14m"
-    else:
-        model_name = "EleutherAI/pythia-160m"
-    llm = LLM.load(
-        model=model_name,
-    )
-
-    with pytest.raises(NotImplementedError, match=f"Support for multiple devices is currently only implemented for generate_strategy='sequential'|'tensor_parallel'."):
-        llm.distribute(devices=2)
-
-    llm.distribute(devices=2, generate_strategy="sequential")
-    assert isinstance(llm.generate("What do llamas eat?"), str)
-    assert str(llm.model.transformer.h[0].mlp.fc.weight.device) == "cuda:0"
-    last_layer_idx = len(llm.model.transformer.h) - 1
-    assert str(llm.model.transformer.h[last_layer_idx].mlp.fc.weight.device) == f"cuda:1"
-
-    # Also check with default (devices="auto") setting
-    llm.distribute(generate_strategy="sequential")
-    assert isinstance(llm.generate("What do llamas eat?"), str)
-    assert str(llm.model.transformer.h[0].mlp.fc.weight.device) == "cuda:0"
-    assert str(llm.model.transformer.h[last_layer_idx].mlp.fc.weight.device) == f"cuda:{device_count-1}"
-
-
-@RunIf(min_cuda_gpus=2)
-def test_more_than_1_device_for_tensor_parallel_gpu(tmp_path):
+def test_more_than_1_device_for_sequential_tp_gpu(tmp_path):
     llm = LLM.load(
         model="EleutherAI/pythia-14m",
     )
 
+    llm.distribute(devices=2, generate_strategy="sequential")
+    assert isinstance(llm.generate("What do llamas eat?"), str)
+
     if os.getenv("CI") != "true":
-        # this crashes the CI, maybe because of process forking; works fine locally though
+        # this crashes the CI, maybe because of process forking; works fien locally though
         llm.distribute(devices=2, generate_strategy="tensor_parallel")
         assert isinstance(llm.generate("What do llamas eat?"), str)
+
+    with pytest.raises(NotImplementedError, match=f"Support for multiple devices is currently only implemented for generate_strategy='sequential'|'tensor_parallel'."):
+        llm.distribute(devices=2)
 
 
 @RunIf(min_cuda_gpus=1)
@@ -243,7 +223,6 @@ def test_quantization_is_applied(tmp_path):
     assert "NF4Linear" in strtype, strtype
 
 
-@RunIf(min_cuda_gpus=1)
 def test_fixed_kv_cache(tmp_path):
     llm = LLM.load(
         model="EleutherAI/pythia-14m",


### PR DESCRIPTION
This is a mergeable v0 implementation. Looking for feedback. See the comments and talk to me for caveats. There are many. This only works where `input_pos` can be shared. That is to say, no continual batching, both prompts the same length. To get the rope cache and kvcache to work with this, it may be a little bit of an ordeal.