### PR TITLE
Add `batched_next_token()` and `batched_sample()`

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -75,9 +75,8 @@ def sample(
 
 def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
     logits = model(x, input_pos)
-    next = sample(logits, **kwargs)
-    return next.to(dtype=x.dtype)
-
+    _next = sample(logits, **kwargs)
+    return _next.to(dtype=x.dtype)
 
 
 def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[dict]) -> list[torch.Tensor]:
@@ -86,7 +85,8 @@ def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[
 
 
 def batched_next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor | list[torch.Tensor], kwargs: dict | list[dict]) -> list[torch.Tensor]:
-    # TODO: Take input_pos as a 2d tensor or list of tensors.
+    # TODO: Take input_pos as a list of tensors.
+    # The desired API is input_pos: torch.Tensor | list[torch.Tensor]
     # This means making the rope cache and kvcache forward() work with batches. Currently, they do not.
     # This is relatively complicated, given the current implementation. It will require some rewriting.
     # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115


### PR DESCRIPTION
This is part of a v0 implementation of batching. Looking for feedback. See the comments and talk to me for caveats. There are many.

This only works where `input_pos` can be shared. That is to say, no continual batching, and both prompts need to be the same length. The second one is a rather onerous requirement. It's not that we can't pad to combine the prompts. We acn do that. But we cannot yet pad to combine input_pos. Still figuring that out. It will require rewriting the rope cache and kvcache to work with an input_pos with a batch dimension. The `index_copy_` and `index_select` operations cannot be used, because they expect vectors and don't work with batches of data.

So after talking about it, this broken implementation was the v0 that @lantiga and I decided to go with.

Next steps, roughly in order:
1. Write `batched_generate_fn()`, mask off the garbage tokens after EOS.
   * For the V0, may just implement checking tokenizer eos id for each item in the batch. Checking for stop sequences greatly complicates things. As evidenced by how long it took to write `generate_fn()` the first time.
2. Hook up to litserve, build a demo.
3. Make `batched_generate_fn()` work for models with stop sequences.
4. Make `batched_next_token()` accept `input_pos` as a list. This means we'll be able to continuously batch non-prefill tokens. This requires the fix to the kvcache and the mask cache. See the comment for inspiration on how to implement that.
5. Hook `batched_generate_fn()` up to the `LLM` api somehow, then switch the container over to using that frontend function.
6. Figure out a plan for continuously batched prefill. This gives us a reasonable time to first token.

After all of this, we'll be able to serve inference to real users, at reasonable latencies. Let me know if anything in the roadmap seems out of place or out of order.

@rasbt @lantiga @Andrei-Aksionov 