### PR TITLE
Bumb version to 0.4.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.10"
+version = "0.4.11"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
Bumb the version to 0.4.11 so we can make a new release with the recent fixes and new combined `generate` functionality.