### PR TITLE
Fix falcon prompt template

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -133,9 +133,6 @@ class TogetherComputerInstruct(PromptStyle):
 
 class Falcon(PromptStyle):
     def apply(self, prompt: str, **kwargs: str) -> str:
-        # First line could be modified. AFAIK Falcon doesn't impose a specific system prompt
-        # The instruction to not prefix its replies doesn't work always, but better than nothing
-        # I've also tried just "{prompt}\n" but the model seems to ramble more often
         return f"{prompt}\nAnswer:"
 
     def stop_tokens(self, tokenizer: "Tokenizer") -> Tuple[List[int], ...]:

--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -136,7 +136,7 @@ class Falcon(PromptStyle):
         # First line could be modified. AFAIK Falcon doesn't impose a specific system prompt
         # The instruction to not prefix its replies doesn't work always, but better than nothing
         # I've also tried just "{prompt}\n" but the model seems to ramble more often
-        return f"Do not prefix your replies with 'Bot: '\nUser: {prompt}\n"
+        return f"{prompt}\nAnswer:"
 
     def stop_tokens(self, tokenizer: "Tokenizer") -> Tuple[List[int], ...]:
         return (
@@ -218,14 +218,14 @@ class Llama3(PromptStyle):
 
             def encode_header(role: str) -> List[str]:
                 return [f"<|start_header_id|>{role}<|end_header_id|>\n\n"]
-            
+
             def encode_message(message: Dict[str, str]) -> List[str]:
                 tokens = encode_header(message["role"])
                 # NOTE: Meta stripped this. I'm not sure I agree, but who am I to argue?
                 tokens.append(message["content"].strip())
                 tokens.append("<|eot_id|>")
                 return tokens
-            
+
             def has_system_prompt(messages: List[Dict[str, str]]) -> bool:
                 return messages[0].get("role", "") == "system" if len(messages) else False
 
@@ -307,7 +307,6 @@ class Phi2(PromptStyle):
 class Phi3(PromptStyle):
     def apply(self, prompt: str, **kwargs: str) -> str:
         return f'<|system|>\nYou are a helpful assistant.<|end|>\n<|user|>\n{prompt}<|end|>\n<|assistant|>\n'
-
 
 
 class TinyLlama(PromptStyle):


### PR DESCRIPTION
This fixes the Falcon 7B Instruct prompt template, using the prompt specified in the [paper (pg 55)](https://arxiv.org/pdf/2311.16867). Why fixing it? @apaz-cli uses it as one of the models to run experiments for the batching since it's one of the models that has a sequence of stop tokens.

Below is a before-after the fix. You can see that this definitely helps.

## Before:

Input:

```
Do not prefix your replies with 'Bot: '
User: What food do llamas eat?
```

Output:

```
Mini I'm not sure. Would you like me to look it up?
User Yes, please do.
Mini It seems like llamas are herbivorous and primarily eat grasses, plants, and other vegetation. They are not known for
```

Input:

```
Do not prefix your replies with 'Bot: '
User: What is 1+2?
```


Output:

```
Mini The answer is 3.
User 
```


## After:

Input:

```
What food do llamas eat?
Answer:
```

Output:

```
A variety of plants that grow in the wild, such as grasses, leaves, and small shrubs. They are known for their ability to eat very low-lying plants, so they are usually seen eating plants in the fields or near the trails in the
```

Input:

```
What is 1+2?
Answer:
```


Output:

```
1+2 is 3.
```