### PR TITLE
Add `batched_generate_fn()`

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -26,11 +26,6 @@ from litgpt.utils import (
     load_checkpoint
 )
 
-class SampleArgs(TypedDict):
-    temperature: float
-    top_k: Optional[int]
-    top_p: float
-
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
     if torch._dynamo.is_compiling():
@@ -215,7 +210,7 @@ def batched_generate_fn(
 
     if isinstance(sample_args, dict):
         sample_args = [sample_args] * len(prompts)
-    
+
     if prompts.ndim == 1:
         prompts = prompts.unsqueeze(0)
 

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -84,9 +84,9 @@ def batched_sample(logits: list[torch.Tensor], kwargs: list[dict]) -> list[torch
     return [sample(l, **sample_args).to(dtype=torch.int64) for sample_args, l in zip(kwargs, logits)]
 
 
-def batched_next_token(model: GPT, input_pos: torch.Tensor, x: list[torch.Tensor], kwargs: dict | list[dict]) -> list[torch.Tensor]:
+def batched_next_token(model: GPT, input_pos: torch.Tensor, x: list[torch.Tensor], kwargs: Union[dict, list[dict]]) -> list[torch.Tensor]:
     # TODO: Take input_pos as a list of tensors.
-    # The desired API is input_pos: torch.Tensor | list[torch.Tensor]
+    # The desired API is input_pos: Union[torch.Tensor, list[torch.Tensor]].
     # This means making the rope cache and kvcache forward() work with batches. Currently, they do not.
     # This is relatively complicated, given the current implementation. It will require some rewriting.
     # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -4,7 +4,7 @@ import sys
 import time
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Literal, Optional, Tuple, List, TypedDict, Union, Iterator
+from typing import Any, Literal, Optional, Tuple, List, Union, Iterator
 import warnings
 
 import lightning as L

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -308,6 +308,7 @@ def batched_generate_fn(
 
     # print("Yielding remaining tokens.")
 
+    # TODO: Prove that this is unreachable.
     # Yield any remaining tokens
     if yielded_idx < len(tokens):
         yield from tokens[yielded_idx:]

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -301,7 +301,7 @@ def batched_generate_fn(
     max_token_lists = max(len(l) for l in token_lists)
     if yielded_idx < max_token_lists:
         for idx in range(yielded_idx, max_token_lists):
-            y_tokens = [token_lists[i][idx] for i in range(batch_size)]
+            y_tokens = [token_lists[i][idx] if (stop_idxes[i] == -1 or idx < stop_idxes[i]) else None for i in range(batch_size)]
             if all(y is None for y in y_tokens):
                 return
             yield y_tokens

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -309,10 +309,13 @@ def batched_generate_fn(
 
     # print("Yielding remaining tokens.")
 
-    # TODO: Prove that this is unreachable, remove from this function.
     # Yield any remaining tokens
-    if yielded_idx < len(tokens):
-        yield from tokens[yielded_idx:]
+    if yielded_idx < len(token_lists[0]):
+        for idx in range(yielded_idx, max(len(tokens) for tokens in token_lists)):
+            y_tokens = [token_lists[i][idx] for i in range(batch_size)]
+            if all(y is None for y in y_tokens):
+                return
+            yield y_tokens
 
 
 @torch.inference_mode()

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -75,9 +75,8 @@ def sample(
 
 def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
     logits = model(x, input_pos)
-    next = sample(logits, **kwargs)
-    return next.to(dtype=x.dtype)
-
+    _next = sample(logits, **kwargs)
+    return _next.to(dtype=x.dtype)
 
 
 def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[dict]) -> list[torch.Tensor]:
@@ -86,7 +85,8 @@ def batched_sample(logits: list[torch.Tensor], dtype: torch.dtype, kwargs: list[
 
 
 def batched_next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor | list[torch.Tensor], kwargs: dict | list[dict]) -> list[torch.Tensor]:
-    # TODO: Take input_pos as a 2d tensor or list of tensors.
+    # TODO: Take input_pos as a list of tensors.
+    # The desired API is input_pos: torch.Tensor | list[torch.Tensor]
     # This means making the rope cache and kvcache forward() work with batches. Currently, they do not.
     # This is relatively complicated, given the current implementation. It will require some rewriting.
     # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -4,7 +4,7 @@ import sys
 import time
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Literal, Optional, Tuple, List, Union, Iterator
+from typing import Any, Literal, Optional, Tuple, List, TypedDict, Union, Iterator
 import warnings
 
 import lightning as L
@@ -25,6 +25,11 @@ from litgpt.utils import (
     get_default_supported_precision,
     load_checkpoint
 )
+
+class SampleArgs(TypedDict):
+    temperature: float
+    top_k: Optional[int]
+    top_p: float
 
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
@@ -77,51 +82,6 @@ def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: A
     logits = model(x, input_pos)
     _next = sample(logits, **kwargs)
     return _next.to(dtype=torch.int64)
-
-
-def batched_sample(logits: list[torch.Tensor], kwargs: list[dict]) -> list[torch.Tensor]:
-    assert len(logits) == len(kwargs), "logits and kwargs must have the same length."
-    return [sample(l, **sample_args).to(dtype=torch.int64) for sample_args, l in zip(kwargs, logits)]
-
-
-def batched_next_token(model: GPT, input_pos: torch.Tensor, x: list[torch.Tensor], kwargs: Union[dict, list[dict]]) -> list[torch.Tensor]:
-    # TODO: Take input_pos as a list of tensors.
-    # The desired API is input_pos: Union[torch.Tensor, list[torch.Tensor]].
-    # This means making the rope cache and kvcache forward() work with batches. Currently, they do not.
-    # This is relatively complicated, given the current implementation. It will require some rewriting.
-    # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115
-    # We will also need the same with tensor.index_copy_(). These do not work for batches, and the replacement
-    # is somewhat nontrivial. Until then, we can only accept prompts that are all the same length.
-    assert input_pos.ndim == 1, "Passing input_pos as a tensor is not yet supported."
-    assert all(t.size(0) == input_pos.size(0) for t in x), "For now, all input sequences must have the same length as input_pos."
-
-    # After this problem is resolved, there will be another problem. That being, continuous batched prefill.
-    # If you have any ideas on this, let me know. I don't think that padding input_pos is viable.
-
-    # Pad the contexts into a batch.
-    if isinstance(x, list):
-        assert all(isinstance(t, torch.Tensor) for t in x), "x must be a list of tensors."
-        x = [t.squeeze() for t in x]
-        assert all(t.ndim == 1 for t in x), "x must be a list of tensors that can be squeezed to 1D."
-        x = torch.nn.utils.rnn.pad_sequence([t.squeeze()[::-1] for t in x], batch_first=True).flip(dims=[1])
-
-    # Make sure we converted all the arguments correctly.
-    assert x.ndim == 2, "Could not create a 2D tensor from x."
-    assert input_pos.dtype == torch.int64, "input_pos must be a tensor with dtype int64."
-    assert x.dtype == torch.int64, "x must be a tensor with dtype int64."
-
-    _kwargs = kwargs if isinstance(kwargs, list) else [kwargs] * x.size(0)
-    assert all(isinstance(k, dict) for k in _kwargs), "kwargs must be a dictionary or list of dictionaries."
-
-    # Run the model on the batch.
-    logits_stack = model(x, input_pos)
-
-    # Unbind the logits stack into a list of logits.
-    logits_list = [logits_stack] if logits_stack.ndim == 1 else logits_stack.unbind(0)
-    logits_list = [l.unsqueeze(0) for l in logits_list]
-
-    # Return the next token for each sample in the batch.
-    return batched_sample(logits_list, kwargs=_kwargs)
 
 
 @torch.inference_mode()
@@ -195,6 +155,143 @@ def generate_fn(
         # Update input_pos for the next iteration.
         if prefill_token:
             prefill_token = False
+            input_pos = torch.tensor([prompt_size], device=device, dtype=torch.int64)
+        else:
+            input_pos.add_(1)
+
+    # Yield any remaining tokens
+    if yielded_idx < len(tokens):
+        yield from tokens[yielded_idx:]
+
+
+def batched_sample(logits: list[torch.Tensor], kwargs: list[dict]) -> list[torch.Tensor]:
+    assert len(logits) == len(kwargs), "logits and kwargs must have the same length."
+    return [sample(l, **sample_args).to(dtype=torch.int64) for sample_args, l in zip(kwargs, logits)]
+
+
+def batched_next_token(model: GPT, input_pos: torch.Tensor, x: list[torch.Tensor], kwargs: Union[dict, list[dict]]) -> list[torch.Tensor]:
+    # TODO: Take input_pos as a list of tensors.
+    # The desired API is input_pos: Union[torch.Tensor, list[torch.Tensor]].
+    # This means making the rope cache and kvcache forward() work with batches. Currently, they do not.
+    # This is relatively complicated, given the current implementation. It will require some rewriting.
+    # Relevant thread: https://discuss.pytorch.org/t/batched-index-select/9115
+    # We will also need the same with tensor.index_copy_(). These do not work for batches, and the replacement
+    # is somewhat nontrivial. Until then, we can only accept prompts that are all the same length.
+    assert input_pos.ndim == 1, "Passing input_pos as a tensor is not yet supported."
+    assert all(t.size(0) == input_pos.size(0) for t in x), "For now, all input sequences must have the same length as input_pos."
+
+    # After this problem is resolved, there will be another problem. That being, continuous batched prefill.
+    # If you have any ideas on this, let me know. I don't think that padding input_pos is viable.
+
+    # Pad the contexts into a batch.
+    if isinstance(x, list):
+        assert all(isinstance(t, torch.Tensor) for t in x), "x must be a list of tensors."
+        x = [t.squeeze() for t in x] # [::-1]
+        assert all(t.ndim == 1 for t in x), "x must be a list of tensors that can be squeezed to 1D."
+        x = torch.nn.utils.rnn.pad_sequence([t.squeeze() for t in x], batch_first=True)
+
+    # Make sure we converted all the arguments correctly.
+    assert x.ndim == 2, "Could not create a 2D tensor from x."
+    assert input_pos.dtype == torch.int64, "input_pos must be a tensor with dtype int64."
+    assert x.dtype == torch.int64, "x must be a tensor with dtype int64."
+
+    _kwargs = kwargs if isinstance(kwargs, list) else [kwargs] * x.size(0)
+    assert all(isinstance(k, dict) for k in _kwargs), "kwargs must be a dictionary or list of dictionaries."
+
+    # Run the model on the batch.
+    logits_stack = model(x, input_pos)
+
+    # Unbind the logits stack into a list of logits.
+    logits_list = [logits_stack] if logits_stack.ndim == 1 else logits_stack.unbind(0)
+    logits_list = [l.unsqueeze(0) for l in logits_list]
+
+    # Return the next token for each sample in the batch.
+    return batched_sample(logits_list, kwargs=_kwargs)
+
+@torch.inference_mode()
+def batched_generate_fn(
+    model: GPT,
+    prompts: list[Union[torch.Tensor, None]],
+    max_returned_tokens: int,
+    *,
+    sample_args: Union[list[dict], dict],
+    stop_tokens: Tuple[List[int], ...] = (),
+    include_prompt: bool,
+    include_eos: bool,
+) -> Iterator[list[Union[torch.Tensor, None]]]:
+
+    if isinstance(sample_args, dict):
+        sample_args = [sample_args] * len(prompts)
+        
+    n_prompts = len(prompts)
+    max_prompt_size = max(prompt.size(0) for prompt in prompts)
+    prompt_size = prompts[0].size(0)
+    device = prompts[0].device
+
+    assert all(prompt.size(0) == max_prompt_size for prompt in prompts), "For now, prompts must have the same length."
+    assert all(prompt.device == prompts[0].device for prompt in prompts), "Prompts must be on the same device."
+
+    assert max_returned_tokens > max_prompt_size, f"Not enough space for {prompt_size} prompt tokens in a context length of {max_returned_tokens}."
+    if model.max_seq_length < max_returned_tokens - 1:
+        raise NotImplementedError(f"max_seq_length {model.max_seq_length} needs to be >= {max_returned_tokens - 1}")
+
+    # Yield the prompts if include_prompt is True
+    if include_prompt:
+        yield prompts
+
+    stop_progresses = [([0] * len(stop_tokens)) for _ in range(n_prompts)]
+    yielded_idxes = [0] * n_prompts
+
+    # Generate output tokens.
+    # The first token generated is the prefill token.
+    # The input_pos for this token is the width of the entire prompt.
+    # For subsequent iterations, it's the index in the context for the token that we're generating.
+    token_lists = [[] for _ in range(n_prompts)]
+    tokens = prompts
+    prefill_token = True
+    input_pos = torch.arange(0, prompt_size, device=device, dtype=torch.int64)
+    for current_idx in range(max_returned_tokens - prompt_size):
+
+        # Generate the token
+        tokens = batched_next_token(model, input_pos, [token.view(1, -1) for token in tokens], sample_args)
+        for i, token in enumerate(tokens):
+            token_lists[i].append(token)
+        int_tokens = [token.item() for token in tokens]
+
+        # Check for stop sequences
+        # For each stop sequence, we keep a running total of how many are matched in stop_progress.
+        # If the current token matches the next token in the stop sequence, we increment the
+        # running total and hold off on yielding the token.
+        for batch_idx, int_token in enumerate(int_tokens):
+            for i, seq in enumerate(stop_tokens):
+                if int_token == seq[stop_progresses[batch_idx][i]]:
+                    stop_progresses[batch_idx][i] += 1
+                    if stop_progresses[batch_idx][i] == len(seq):
+                        if include_eos:
+                            yield from token_lists[batch_idx][yielded_idxes[batch_idx]:]
+                        return
+                else:
+                    stop_progresses[batch_idx][i] = 0
+                    
+        # ==============================================================================================================
+
+        # Yield tokens that are not part of a stop sequence in progress.
+        # If there are no stop sequences, then that's all of them.
+        if stop_tokens:
+            safe_idx = len(tokens) - max(stop_progress)
+        else:
+            safe_idx = current_idx + 1 # include the token just generated
+
+        if yielded_idx < safe_idx:
+            y_tokens = tokens[yielded_idx : safe_idx]
+            yield from y_tokens
+            yielded_idx = safe_idx
+
+        # Update input_pos for the next iteration.
+        if prefill_token:
+            prefill_token = False
+
+            # TODO: Add batch dim (fix kvcache and rope cache)
             input_pos = torch.tensor([prompt_size], device=device, dtype=torch.int64)
         else:
             input_pos.add_(1)

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -310,12 +310,14 @@ def batched_generate_fn(
     # print("Yielding remaining tokens.")
 
     # Yield any remaining tokens
-    if yielded_idx < len(token_lists[0]):
-        for idx in range(yielded_idx, max(len(tokens) for tokens in token_lists)):
+    max_token_lists = max(len(l) for l in token_lists)
+    if yielded_idx < max_token_lists:
+        for idx in range(yielded_idx, max_token_lists):
             y_tokens = [token_lists[i][idx] for i in range(batch_size)]
             if all(y is None for y in y_tokens):
                 return
             yield y_tokens
+    return
 
 
 @torch.inference_mode()

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -103,7 +103,7 @@ def batched_next_token(model: GPT, input_pos: torch.Tensor, x: list[torch.Tensor
         assert all(isinstance(t, torch.Tensor) for t in x), "x must be a list of tensors."
         x = [t.squeeze() for t in x]
         assert all(t.ndim == 1 for t in x), "x must be a list of tensors that can be squeezed to 1D."
-        x = torch.nn.utils.rnn.pad_sequence([t.squeeze() for t in x], batch_first=True)
+        x = torch.nn.utils.rnn.pad_sequence([t.squeeze()[::-1] for t in x], batch_first=True).flip(dims=[1])
 
     # Make sure we converted all the arguments correctly.
     assert x.ndim == 2, "Could not create a 2D tensor from x."

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -234,8 +234,8 @@ def batched_generate_fn(
     # Yield the prompts if include_prompt is True
     if include_prompt:
         # TODO: Prompt length is padded, but they shouldn't all be the same length.
-        for s in range(max_prompt_size):
-            yield [prompt[s] for prompt in prompts]
+        for i in range(max_prompt_size):
+            yield [prompt[i].view(-1) for prompt in prompts]
 
     stop_progresses = [[0] * len(stop_tokens) for _ in range(batch_size)] # [batch_size, ~len(stop_tokens)]
     stop_idxes = [-1] * batch_size
@@ -302,7 +302,8 @@ def batched_generate_fn(
         if prefill_token:
             prefill_token = False
 
-            # TODO: Add batch dim
+            # TODO: Make the model support a batched input_pos of shape [batch_size, 1].
+            # The kvcache has been fixed, but the rope cache is still broken.
             input_pos = torch.tensor([max_prompt_size], device=device, dtype=torch.int64)
         else:
             input_pos.add_(1)

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -200,6 +200,7 @@ def generate_fn(
 
 
 # TODO: Make include_eos work.
+# TODO: Rewrite unbatched generate_fn to use batched_generate_fn.
 @torch.inference_mode()
 def batched_generate_fn(
     model: GPT,
@@ -308,7 +309,7 @@ def batched_generate_fn(
 
     # print("Yielding remaining tokens.")
 
-    # TODO: Prove that this is unreachable.
+    # TODO: Prove that this is unreachable, remove from this function.
     # Yield any remaining tokens
     if yielded_idx < len(tokens):
         yield from tokens[yielded_idx:]

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -252,7 +252,6 @@ def batched_generate_fn(
         for i in range(batch_size):
             token_lists[i].append(tokens[i])
         int_tokens = [token.item() for token in tokens]
-        # print("Generated tokens:", int_tokens)
 
         # Check for stop sequences
         # For each stop sequence, we keep a running total of how many are matched in stop_progress.
@@ -272,20 +271,15 @@ def batched_generate_fn(
                 else:
                     stop_progresses[batch_idx][seq_idx] = 0
 
-        # print("Stop progress:", stop_progresses)
-
         # Yield tokens that are not part of a stop sequence in progress.
         # If there are no stop sequences, then that's all of them.
         if len(stop_tokens) != 0:
             safe_idxes = [len(token_lists[i]) - max(stop_progresses[i]) for i in range(batch_size)]
-            # print("safe_idxes:", safe_idxes)
         else:
             safe_idxes = [current_idx + 1] # include the token just generated
         safe_idx = min(safe_idxes)
-        # print("safe_idx:", safe_idx)
 
         if yielded_idx < safe_idx:
-            # print(yielded_idx, ":", safe_idx)
             for idx in range(yielded_idx, safe_idx):
                 y_tokens = [token_lists[i][idx] if (stop_idxes[i] == -1 or idx < stop_idxes[i]) else None for i in range(batch_size)]
                 if all(y is None for y in y_tokens):
@@ -302,8 +296,6 @@ def batched_generate_fn(
             input_pos = torch.tensor([max_prompt_size], device=device, dtype=torch.int64)
         else:
             input_pos.add_(1)
-
-    # print("Yielding remaining tokens.")
 
     # Yield any remaining tokens
     max_token_lists = max(len(l) for l in token_lists)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ license = { file = "LICENSE" }
 
 dependencies = [
     "torch>=2.2.0",
+    "numpy<2.0",
     "lightning==2.4.0.dev20240728",
     "jsonargparse[signatures]>=4.27.6",
     "huggingface_hub>=0.23.5",          # download models

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -141,6 +141,8 @@ def test_simple_batch():
 @RunIf(min_cuda_gpus=1)
 def test_batch_generate(tmp_path):
 
+    torch.use_deterministic_algorithms(True)
+
     device = "cuda:0"
     batch_size = 3
     sample_kwargs = {"top_k": 1}
@@ -184,6 +186,8 @@ def test_batch_generate(tmp_path):
     assert len(third_stream) == 41
     assert third_stream[-1] == 42358
 
+    torch.use_deterministic_algorithms(False)
+
     # for t in llm.tokenizer.decode_stream([torch.tensor(i) for i in first_stream]):
     #    print(t, end="", flush=True)
     # print()
@@ -191,6 +195,8 @@ def test_batch_generate(tmp_path):
 
 @RunIf(min_cuda_gpus=1)
 def test_batch_generate_equivalence(tmp_path):
+
+    torch.use_deterministic_algorithms(True)
 
     device = "cuda:0"
     batch_size = 3
@@ -238,6 +244,8 @@ def test_batch_generate_equivalence(tmp_path):
             tokens.append(t.item())
         else:
             tokens.extend(t.tolist())
+
+    torch.use_deterministic_algorithms(False)
 
     # TODO: (apaz-cli) This consistency test doesn't actually work at the moment. It's inconsistent.
     # The output is really close... Something is going on here. For the moment, maybe this is close enough?

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -158,36 +158,103 @@ def test_batch_generate(tmp_path):
         dtype=torch.int64,
     )
 
+    # Generate tokens
     tokens = []
     for l in batched_generate_fn(
         model,
         prompts=batch_x,
         max_returned_tokens=50,
-        stop_tokens=[
-            (42789,),
-            (23029,),
-            (7992,),
-        ],  # llm.prompt_style.stop_tokens(llm.tokenizer),
         sample_args=sample_kwargs,
         include_prompt=True,
         include_eos=False,
     ):
         tokens.append([t.item() if t is not None else None for t in l])
 
+    def find_unique_stop(triplets):
+        # Initialize a dictionary to count all number occurrences
+        number_count = {}
+
+        # Count occurrences of each number across all positions
+        for triplet in triplets:
+            for num in triplet:
+                number_count[num] = number_count.get(num, 0) + 1
+
+        # Initialize lists to store unique numbers for each position
+        unique_first = []
+        unique_second = []
+        unique_third = []
+
+        # Check each triplet
+        for a, b, c in triplets:
+            if number_count[a] == 1:
+                unique_first.append(a)
+            if number_count[b] == 1:
+                unique_second.append(b)
+            if number_count[c] == 1:
+                unique_third.append(c)
+
+        import random  # Seeded earlier
+
+        random.shuffle(unique_first)
+        random.shuffle(unique_second)
+        random.shuffle(unique_third)
+        return [unique_first[0], unique_second[0], unique_third[0]]
+
+    # Now that we know the randomly generated tokens, sample some tokens to stop each stream at.
+    stops = find_unique_stop(tokens[batch_x.size(1) :])
+    first_stream = [t[0] for t in tokens if t[0] is not None]
+    second_stream = [t[1] for t in tokens if t[1] is not None]
+    third_stream = [t[2] for t in tokens if t[2] is not None]
+
+    # Let's slice the streams at the stop tokens.
+    stop_idxes = [
+        first_stream.index(stops[0]),
+        second_stream.index(stops[1]),
+        third_stream.index(stops[2]),
+    ]
+
+    # While we're at it, grab the last token that would be generated before stopping.
+    last_tokens = [
+        first_stream[stop_idxes[0] - 1],
+        second_stream[stop_idxes[1] - 1],
+        third_stream[stop_idxes[2] - 1],
+    ]
+
+    for t in tokens:
+        print(t)
+
+    # Now we generate again, stopping early at the stop tokens.
+    tokens = []
+    for l in batched_generate_fn(
+        model,
+        prompts=batch_x,
+        max_returned_tokens=50,
+        stop_tokens=[(s,) for s in stops],
+        sample_args=sample_kwargs,
+        include_prompt=True,
+        include_eos=False,
+    ):
+        tokens.append([t.item() if t is not None else None for t in l])
+
+    # Finally, assert that the streams are correct.
+
     first_stream = [t[0] for t in tokens if t[0] is not None]
     print(first_stream)
-    assert len(first_stream) == 46
-    assert first_stream[-1] == 7596
+    print(len(first_stream), stop_idxes[0])
+    assert len(first_stream) == stop_idxes[0]
+    assert first_stream[-1] == last_tokens[0]
 
     second_stream = [t[1] for t in tokens if t[1] is not None]
     print(second_stream)
-    assert len(second_stream) == 39
-    assert second_stream[-1] == 46964
+    print(len(second_stream), stop_idxes[1])
+    assert len(second_stream) == stop_idxes[1]
+    assert second_stream[-1] == last_tokens[1]
 
     third_stream = [t[2] for t in tokens if t[2] is not None]
     print(third_stream)
-    assert len(third_stream) == 41
-    assert third_stream[-1] == 42358
+    print(len(third_stream), stop_idxes[2])
+    assert len(third_stream) == stop_idxes[2]
+    assert third_stream[-1] == last_tokens[2]
 
     torch.use_deterministic_algorithms(False)
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -175,14 +175,17 @@ def test_batch_generate(tmp_path):
         tokens.append([t.item() if t is not None else None for t in l])
 
     first_stream = [t[0] for t in tokens if t[0] is not None]
+    print(first_stream)
     assert len(first_stream) == 46
     assert first_stream[-1] == 7596
 
     second_stream = [t[1] for t in tokens if t[1] is not None]
+    print(second_stream)
     assert len(second_stream) == 39
     assert second_stream[-1] == 46964
 
     third_stream = [t[2] for t in tokens if t[2] is not None]
+    print(third_stream)
     assert len(third_stream) == 41
     assert third_stream[-1] == 42358
 

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -283,14 +283,15 @@ def test_batch_generate_equivalence(tmp_path):
         dtype=torch.int64,
     )
 
+    # The other test tests the stop_tokens functionality much more exhaustively, we'll just generate and compare 50 tokens here.
+
     batch_tokens = []
     for l in batched_generate_fn(
         model,
         prompts=batch_x,
         max_returned_tokens=50,
-        stop_tokens=[(33814,)],
         sample_args=sample_kwargs,
-        include_prompt=True,
+        include_prompt=False,
         include_eos=False,
     ):
         batch_tokens.append([t.item() if t is not None else None for t in l])
@@ -305,8 +306,7 @@ def test_batch_generate_equivalence(tmp_path):
         model,
         prompt=batch_x[0],
         max_returned_tokens=50,
-        stop_tokens=[(33814,)],
-        include_prompt=True,
+        include_prompt=False,
         include_eos=False,
         **sample_kwargs,
     ):
@@ -321,4 +321,6 @@ def test_batch_generate_equivalence(tmp_path):
     # The output is really close... Something is going on here. For the moment, maybe this is close enough?
     # Enough at least that we can start prototyping.
 
+    print(first_stream)
+    print(tokens)
     # assert first_stream == tokens

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -4,13 +4,39 @@ import warnings
 from pathlib import Path
 import lightning as L
 import litgpt
-from litgpt.generate.base import next_token, batched_next_token, batched_generate_fn
+from litgpt.generate.base import (
+    next_token,
+    batched_next_token,
+    batched_generate_fn,
+    generate_fn,
+)
 from litgpt.api import LLM, GPT
 from litgpt.scripts.download import download_from_hub
 from tests.conftest import RunIf
 
 
 warnings.filterwarnings("ignore")
+
+
+def create_llm(tmp_path, batch_size, max_seq_length, device) -> tuple[LLM, GPT]:
+
+    L.seed_everything(42)
+
+    model_name = "microsoft/phi-2"
+    download_from_hub(repo_id=model_name, tokenizer_only=True, checkpoint_dir=tmp_path)
+
+    llm: LLM = LLM.load(
+        model_name,
+        tokenizer_dir=Path(tmp_path / model_name),
+        init="random",
+    )
+    model: GPT = llm.model
+    model.set_kv_cache(
+        batch_size=batch_size, max_seq_length=max_seq_length, device=device
+    )
+
+    return llm, model
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires a GPU.")
 def test_batched_equivalence(tmp_path):
@@ -56,7 +82,9 @@ def test_batched_equivalence(tmp_path):
     model.clear_kv_cache()
     model.set_kv_cache(batch_size=batch_size, max_seq_length=50, device="cuda:0")
 
-    toks_1: torch.Tensor = batched_next_token(model, input_pos_1, batch_x1, sample_kwargs)
+    toks_1: torch.Tensor = batched_next_token(
+        model, input_pos_1, batch_x1, sample_kwargs
+    )
     toks_2: torch.Tensor = batched_next_token(model, input_pos_2, toks_1, sample_kwargs)
 
     assert toks_1.ndim == 2
@@ -109,42 +137,110 @@ def test_simple_batch():
     torch.testing.assert_close(outs1, outs1_ref)
     torch.backends.cuda.matmul.allow_tf32 = old_allow_tf32
 
+
 @RunIf(min_cuda_gpus=1)
-def test_batch_generate():
-
-    L.seed_everything(42)
-
-    tmp_path = Path("/tmp/temp_folder")
-    model_name = "microsoft/phi-2"
-    download_from_hub(repo_id=model_name, tokenizer_only=True, checkpoint_dir=tmp_path)
+def test_batch_generate(tmp_path):
 
     device = "cuda:0"
     batch_size = 3
     sample_kwargs = {"top_k": 1}
+    llm, model = create_llm(tmp_path, batch_size, 50, device)
 
-    llm: LLM = LLM.load(
-        model_name,
-        tokenizer_dir=Path(tmp_path / model_name),
-        init="random",
-    )
-    model: GPT = llm.model
-    model.set_kv_cache(batch_size=batch_size, max_seq_length=50, device=device)
-
-    x = torch.tensor(
-        [43993, 25, 1867, 466, 32660, 17485, 4483, 30, 198, 26410],
+    batch_x = torch.tensor(
+        [
+            [43993, 25, 1867, 466, 32660, 17485, 4483, 30, 198, 26410],
+            [25, 1867, 466, 32660, 17485, 4483, 30, 198, 26410, 7596],
+            [1867, 466, 32660, 17485, 4483, 30, 198, 26410, 7596, 7596],
+        ],
         device=device,
         dtype=torch.int64,
     )
 
-    batch_x = torch.stack([x] * batch_size, dim=0)
-
+    tokens = []
     for l in batched_generate_fn(
         model,
         prompts=batch_x,
         max_returned_tokens=50,
-        stop_tokens=[(42789,),], # llm.prompt_style.stop_tokens(llm.tokenizer),
+        stop_tokens=[
+            (42789,),
+            (23029,),
+            (7992,),
+        ],  # llm.prompt_style.stop_tokens(llm.tokenizer),
         sample_args=sample_kwargs,
         include_prompt=True,
         include_eos=False,
     ):
-        print("Outputed token:", l, "\n")
+        tokens.append([t.item() if t is not None else None for t in l])
+
+    first_stream = [t[0] for t in tokens if t[0] is not None]
+    assert len(first_stream) == 46
+    assert first_stream[-1] == 7596
+
+    second_stream = [t[1] for t in tokens if t[1] is not None]
+    assert len(second_stream) == 39
+    assert second_stream[-1] == 46964
+
+    third_stream = [t[2] for t in tokens if t[2] is not None]
+    assert len(third_stream) == 41
+    assert third_stream[-1] == 42358
+
+    # for t in llm.tokenizer.decode_stream([torch.tensor(i) for i in first_stream]):
+    #    print(t, end="", flush=True)
+    # print()
+
+
+@RunIf(min_cuda_gpus=1)
+def test_batch_generate_equivalence(tmp_path):
+
+    device = "cuda:0"
+    batch_size = 3
+    sample_kwargs = {"top_k": 1}
+    llm, model = create_llm(tmp_path, batch_size, 50, device)
+
+    batch_x = torch.tensor(
+        [
+            [43993, 25, 1867, 466, 32660, 17485, 4483, 30, 198, 26410],
+            [25, 1867, 466, 32660, 17485, 4483, 30, 198, 26410, 7596],
+            [1867, 466, 32660, 17485, 4483, 30, 198, 26410, 7596, 7596],
+        ],
+        device=device,
+        dtype=torch.int64,
+    )
+
+    batch_tokens = []
+    for l in batched_generate_fn(
+        model,
+        prompts=batch_x,
+        max_returned_tokens=50,
+        stop_tokens=[(33814,)],
+        sample_args=sample_kwargs,
+        include_prompt=True,
+        include_eos=False,
+    ):
+        batch_tokens.append([t.item() if t is not None else None for t in l])
+
+    first_stream = [t[0] for t in batch_tokens if t[0] is not None]
+
+    batch_size = 1
+    llm, model = create_llm(tmp_path, batch_size, 50, device)
+
+    tokens = []
+    for t in generate_fn(
+        model,
+        prompt=batch_x[0],
+        max_returned_tokens=50,
+        stop_tokens=[(33814,)],
+        include_prompt=True,
+        include_eos=False,
+        **sample_kwargs,
+    ):
+        if t.size(0) == 1:
+            tokens.append(t.item())
+        else:
+            tokens.extend(t.tolist())
+
+    # TODO: (apaz-cli) This consistency test doesn't actually work at the moment. It's inconsistent.
+    # The output is really close... Something is going on here. For the moment, maybe this is close enough?
+    # Enough at least that we can start prototyping.
+
+    # assert first_stream == tokens


### PR DESCRIPTION
Still a bit rough around the edges. Debug prints are commented out. But it does the thing, so putting it up for review and feedback. Writing tests and cleaning it up.

* Does handle:
  * Stop sequences (supports all litgpt models)
* Does not yet handle:
  * Batched `input_pos`
  * Padding to the left
  * `include_eos`

Once `include_eos` works, I'd like to rewrite `generate_fn()` in terms of `batched_generate_fn()`.

Also we're going to have to re-benchmark everything of course.