### PR TITLE
Fix device Error in Decode Stream

### DIFF
--- a/litgpt/chat/base.py
+++ b/litgpt/chat/base.py
@@ -91,7 +91,7 @@ def process_prompt(prompt, model, tokenizer, prompt_style, fabric, temperature, 
     y: Iterator[torch.Tensor] = generate(
         model, encoded_prompt, max_returned_tokens, temperature=temperature, top_k=top_k, top_p=top_p, stop_tokens=stop_tokens
     )
-    token_generator: Iterator[str] = tokenizer.decode_stream(y)
+    token_generator: Iterator[str] = tokenizer.decode_stream(y, device=fabric.device)
 
     fabric.print(">> Reply: ", end="")
 

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -137,7 +137,7 @@ class Tokenizer:
             return self.processor.decode([dummy_token_id] + tokens)[len(dummy_token) :]
         return self.processor.decode(tokens)
 
-    def decode_stream(self, token_stream: Iterable[torch.Tensor]) -> Iterator[str]:
+    def decode_stream(self, token_stream: Iterable[torch.Tensor], device: Optional[torch.device] = None) -> Iterator[str]:
         if self.backend == "huggingface":
             try:
                 for token in token_stream:
@@ -150,7 +150,7 @@ class Tokenizer:
 
             # sentencepiece does not support decoding token-by-token because it adds spaces based on the surrounding tokens
             # meaning that we need to decode everything each time
-            so_far = torch.tensor([], dtype=torch.long, device=fabric.device)
+            so_far = torch.tensor([], dtype=torch.long, device=device)
             decoded_so_far = ""
             try:
                 for token in token_stream:


### PR DESCRIPTION
This PR fixes the NameError: 'fabric' is not defined in decode_stream. The error occurs because device is not defined in the function:

so_far = torch.tensor([], dtype=torch.long, **device=fabric.device**)

The variable fabric is not initialized, leading to the NameError.