### PR TITLE
Temporarily remove MPS device support

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -226,7 +226,7 @@ class LLM(torch.nn.Module):
             fabric = L.Fabric(
                 accelerator=accelerator,
                 devices=1,
-                precision="32-true",
+                precision=get_default_supported_precision(training=False),
             )
 
             with fabric.init_module(empty_init=False):

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -124,14 +124,27 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(
-        devices=devices,
-        num_nodes=num_nodes,
-        strategy=strategy,
-        precision=precision,
-        loggers=logger,
-        plugins=plugins,
-    )
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(
+            accelerator=accelerator,
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
+    else:
+        fabric = L.Fabric(
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
 
     if torch.cuda.is_available() and devices > 1:
         check_nvlink_connectivity(fabric)

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -124,14 +124,27 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(
-        devices=devices,
-        num_nodes=num_nodes,
-        strategy=strategy,
-        precision=precision,
-        loggers=logger,
-        plugins=plugins,
-    )
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(
+            accelerator=accelerator,
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
+    else:
+        fabric = L.Fabric(
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
 
     if torch.cuda.is_available() and devices > 1:
         check_nvlink_connectivity(fabric)

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -154,14 +154,27 @@ def setup(
     else:
         strategy = "auto"
 
-    fabric = L.Fabric(
-        devices=devices,
-        num_nodes=num_nodes,
-        strategy=strategy,
-        precision=precision,
-        loggers=logger,
-        plugins=plugins,
-    )
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(
+            accelerator=accelerator,
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
+    else:
+        fabric = L.Fabric(
+            devices=devices,
+            num_nodes=num_nodes,
+            strategy=strategy,
+            precision=precision,
+            loggers=logger,
+            plugins=plugins,
+        )
 
     if torch.cuda.is_available() and devices > 1:
         check_nvlink_connectivity(fabric)

--- a/litgpt/generate/adapter.py
+++ b/litgpt/generate/adapter.py
@@ -90,7 +90,12 @@ def main(
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
 
-    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(devices=1, accelerator=accelerator, precision=precision, plugins=plugins)
+    else:
+        fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)

--- a/litgpt/generate/adapter_v2.py
+++ b/litgpt/generate/adapter_v2.py
@@ -90,7 +90,12 @@ def main(
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
 
-    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(devices=1, accelerator=accelerator, precision=precision, plugins=plugins)
+    else:
+        fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)

--- a/litgpt/generate/full.py
+++ b/litgpt/generate/full.py
@@ -89,7 +89,12 @@ def main(
         plugins = BitsandbytesPrecision(quantize[4:], dtype)
         precision = None
 
-    fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
+    if torch.backends.mps.is_available():
+        accelerator = "cpu"
+        warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
+        fabric = L.Fabric(devices=1, accelerator=accelerator, precision=precision, plugins=plugins)
+    else:
+        fabric = L.Fabric(devices=1, precision=precision, plugins=plugins)
     fabric.launch()
 
     check_valid_checkpoint_dir(checkpoint_dir)


### PR DESCRIPTION
LitGPT currently doesn't support MPS devices due to the `index_copy_` operation. I tried to come up with an alternative code but after a few hours, I couldn't figure out how to cover all the edge cases (the problem are some weird shapes in the new KV cache). 

So, I am currently disabling the support for MPS until we have support for that. Until then, MacBooks will run LitGPT code on CPU.

Fixes #1714 