### PR TITLE
Add uvloop as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ all = [
     "datasets>=2.18.0",          # litgpt.evaluate
     "transformers>=4.38.0",      # litgpt.evaluate
     "lm-eval>=0.4.2",            # litgpt.evaluate
-    "huggingface_hub[hf_transfer]>=0.21.0"  # download
+    "huggingface_hub[hf_transfer]>=0.21.0",  # download
+    "uvloop>=0.2.0               # litdata
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ all = [
     "transformers>=4.38.0",      # litgpt.evaluate
     "lm-eval>=0.4.2",            # litgpt.evaluate
     "huggingface_hub[hf_transfer]>=0.21.0",  # download
-    "uvloop>=0.2.0               # litdata
+    "uvloop>=0.2.0"               # litdata
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ all = [
     "transformers>=4.38.0",      # litgpt.evaluate
     "lm-eval>=0.4.2",            # litgpt.evaluate
     "huggingface_hub[hf_transfer]>=0.21.0",  # download
-    "uvloop>=0.2.0"               # litdata
+    "uvloop>=0.2.0 ; sys_platform != 'win32'"  # litdata, only on non-Windows
 ]
 
 [build-system]


### PR DESCRIPTION
Seems like litdata is softly requiring uvloop as a dependency:

```
Number of trainable parameters: 294,912
Number of non-trainable parameters: 162,322,944
The longest sequence length in the train data is 1035, the model's maximum sequence length is 1035 and context length is 2048
Verifying settings ...
uvloop is not installed. Falling back to the default asyncio event loop.
uvloop is not installed. Falling back to the default asyncio event loop.
uvloop is not installed. Falling back to the default asyncio event loop.
uvloop is not installed. Falling back to the default asyncio event loop.
```