### PR TITLE
Change default precision on macOS

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -299,6 +299,7 @@ class LLM(torch.nn.Module):
                 accelerator = "cuda"
             elif torch.backends.mps.is_available():
                 # accelerator = "mps"
+                accelerator = "cpu"
                 warnings.warn("MPS is currently not supported. Using CPU instead.", UserWarning)
             else:
                 accelerator = "cpu"


### PR DESCRIPTION
Updates the default precision to return "bf16-true" instead of "16-true" on macOS devices that support MPS if CPU is used (since 16-true leads to unstable behaviors and nans and infs in the forward pass).

Fixes #1715 