### PR TITLE
Make 0.4.13.dev1 version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.4.12"
+version = "0.4.13.dev1"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },


### PR DESCRIPTION
Increases the version after the latest stable release so it will be easier to debug user issues, since it will allow us to distinguish between the latest stable release and the current main branch in user version reports.