### PR TITLE
Support for optimizers which don't have "fused" parameter such as grokadamw and 8bit bnb

### DIFF
--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -557,7 +557,7 @@ def instantiate_bnb_optimizer(optimizer, model_parameters):
 
 
 def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
-    # Special care taken where some optimizers do not have parameter "fused" like:
+    # Special care taken where some optimizers do not have some parameters referenced in some of the code, for example "fused" in the pretrain.py script:
     #   bnb.optim.AdamW8bit
     #   grokadamw.GrokAdamW
     #   torch.optim.RMSprop

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -560,6 +560,7 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
     # Special care taken where some optimizers do not have parameter "fused" like:
     #   bnb.optim.AdamW8bit
     #   grokadamw.GrokAdamW
+    #   torch.optim.RMSprop
     
     if isinstance(optimizer, str):
         if "." in optimizer:

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import subprocess
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
 import warnings
-import inspect
 
 import lightning as L
 import torch
@@ -572,9 +571,7 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
         optimizer_cls = getattr(module, class_name)
 
         valid_params = set(inspect.signature(optimizer_cls).parameters)
-        kwargs = {key: value for key, value in kwargs.items() if key in valid_params}
-        optimizer = optimizer_cls(model_parameters, **kwargs)
-
+        kwargs = {key: value for key, value in dict(kwargs).items() if key in valid_params}
         optimizer = optimizer_cls(model_parameters, **kwargs)
     elif isinstance(optimizer, dict):
         optimizer = dict(optimizer)
@@ -583,7 +580,7 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
         optimizer_cls = getattr(module, class_name)
 
         valid_params = set(inspect.signature(optimizer_cls).parameters)
-        kwargs = {key: value for key, value in kwargs.items() if key in valid_params}
+        kwargs = {key: value for key, value in dict(kwargs).items() if key in valid_params}
         
         optimizer["init_args"].update(kwargs)
         optimizer = instantiate_class(model_parameters, optimizer)

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -577,15 +577,13 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
 
         optimizer = optimizer_cls(model_parameters, **kwargs)
     elif isinstance(optimizer, dict):
-        optimizer = dict(optimizer)  # copy
-
+        optimizer = dict(optimizer)
         class_module, class_name = optimizer["class_path"].rsplit(".", 1)
         module = __import__(class_module, fromlist=[class_name])
         optimizer_cls = getattr(module, class_name)
 
-        if "fused" in kwargs and "fused" not in inspect.signature(optimizer_cls).parameters:
-            kwargs = dict(kwargs)   # copy
-            del kwargs["fused"]
+        valid_params = set(inspect.signature(optimizer_cls).parameters)
+        kwargs = {key: value for key, value in kwargs.items() if key in valid_params}
         
         optimizer["init_args"].update(kwargs)
         optimizer = instantiate_class(model_parameters, optimizer)

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -571,9 +571,9 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
         module = __import__(class_module, fromlist=[class_name])
         optimizer_cls = getattr(module, class_name)
 
-        if "fused" in kwargs and "fused" not in inspect.signature(optimizer_cls).parameters:
-            kwargs = dict(kwargs)   # copy
-            del kwargs["fused"]
+        valid_params = set(inspect.signature(optimizer_cls).parameters)
+        kwargs = {key: value for key, value in kwargs.items() if key in valid_params}
+        optimizer = optimizer_cls(model_parameters, **kwargs)
 
         optimizer = optimizer_cls(model_parameters, **kwargs)
     elif isinstance(optimizer, dict):

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -18,9 +18,10 @@ from litgpt.pretrain import initialize_weights
 from tests.conftest import RunIf
 
 
+@RunIf(min_cuda_gpus=1, standalone=True)
 @mock.patch("litgpt.pretrain.save_hyperparameters")
 def test_optimizer_args(_, tmp_path):
-    model_config = Config(block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
+    model_config = Config(block_size=2, n_layer=2, n_embd=4, n_head=2, padded_vocab_size=8)
 
     dataset = torch.tensor([[0, 1, 2], [3, 4, 5], [0, 1, 2]])
     dataloader = DataLoader(dataset)

--- a/tests/test_pretrain.py
+++ b/tests/test_pretrain.py
@@ -18,6 +18,26 @@ from litgpt.pretrain import initialize_weights
 from tests.conftest import RunIf
 
 
+@mock.patch("litgpt.pretrain.save_hyperparameters")
+def test_optimizer_args(_, tmp_path):
+    model_config = Config(block_size=2, n_layer=2, n_embd=8, n_head=4, padded_vocab_size=8)
+
+    dataset = torch.tensor([[0, 1, 2], [3, 4, 5], [0, 1, 2]])
+    dataloader = DataLoader(dataset)
+    pretrain.get_dataloaders = Mock(return_value=(dataloader, dataloader))
+
+    for i in ("AdamW", "SGD", "RMSprop"):
+        pretrain.setup(
+            "pythia-14m",
+            devices=1,
+            optimizer="RMSprop",
+            model_config=model_config,
+            out_dir=tmp_path,
+            train=TrainArgs(global_batch_size=2, max_tokens=16, save_interval=1, micro_batch_size=1, max_norm=1.0),
+            eval=EvalArgs(interval=1, max_iters=1, final_validation=False),
+        )
+
+
 @RunIf(min_cuda_gpus=2, standalone=True)
 # Set CUDA_VISIBLE_DEVICES for FSDP hybrid-shard, if fewer GPUs are used than are available
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1"})


### PR DESCRIPTION
This fixes #1743 

1. This changes bring support for optimizers which do not have "fused" parameter. Examples:

```yaml
optimizer: grokadamw.GrokAdamW
optimizer: bitsandbytes.optim.AdamW8bit
optimizer: bitsandbytes.optim.PagedAdamW8bit
```

2. Additionally, pytorch optimizers can be written in following format:
```yaml
optimizer: torch.optim.AdamW
optimizer: AdamW
```

3. In case of yaml config file, if value for `optimizer:` isn't `str` nor `dict`, error is thrown.