### PR TITLE
Fix jsonarparse version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "torch>=2.2.0",
     "numpy<2.0",
     "lightning==2.4.0.dev20240728",
-    "jsonargparse[signatures]>=4.27.6",
+    jsonargparse = ">=4.27.6,<=4.32.1"  # 4.33 does not seem to be compatible with Python 3.9
     "huggingface_hub>=0.23.5",          # download models
     "safetensors>=0.4.3",               # download models
     "tokenizers>=0.15.2",               # tokenization in most models


### PR DESCRIPTION
Fixes the jsonargparse version to a upper range because the recent release broke Python 3.9 support