### PR TITLE
Make json parsing more robust

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Optional, Union, Iterable, Iterator
 
+from litgpt.utils import fix_and_load_json
 import torch
 
 
@@ -37,8 +38,13 @@ class Tokenizer:
                 self.bos_id = self.token_to_id(bos_token) if bos_token is not None else None
                 self.eos_id = self.token_to_id(eos_token) if eos_token is not None else None
             if (special_tokens_path := checkpoint_dir / "generation_config.json").is_file():
-                with open(special_tokens_path, encoding="utf-8") as fp:
-                    config = json.load(fp)
+                try:
+                    with open(special_tokens_path, encoding="utf-8") as fp:
+                        config = json.load(fp)
+                except json.JSONDecodeError:  # Some files like the Llama 3.2 one have bugs
+                    with open(special_tokens_path, encoding="utf-8") as fp:
+                        json_string = fp.read()
+                        config = fix_and_load_json(json_string)
                 if self.bos_id is None:
                     self.bos_id = config.get("bos_token_id")
                 if self.eos_id is None:

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -2,6 +2,7 @@
 
 """Utility functions for training and inference."""
 import inspect
+import json
 import math
 import os
 import pickle
@@ -653,3 +654,9 @@ def check_nvlink_connectivity(fabric=None):
 
         except Exception as e:
             custom_print(f"An error occurred: {e}")
+
+
+def fix_and_load_json(json_string):
+    """ Remove trailing comma before closing curly brace """
+    fixed_json_string = re.sub(r',\s*}', "}", json_string)
+    return json.loads(fixed_json_string)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,6 +34,7 @@ from litgpt.utils import (
     extend_checkpoint_dir,
     find_multiple,
     find_resume_path,
+    fix_and_load_json,
     incremental_save,
     init_out_dir,
     instantiate_bnb_optimizer,
@@ -590,3 +591,33 @@ def test_nvlink_all_gpu_connected_but_other_connected_output(mock_run, nvlink_al
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
         mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+
+
+def test_fix_and_load_json():
+    # Invalid JSON string with a trailing comma
+    invalid_json = '''
+    {
+      "_from_model_config": true,
+      "bos_token_id": 128000,
+      "eos_token_id": 128001,
+      "transformers_version": "4.45.0.dev0",
+      "do_sample": true,
+      "temperature": 0.6,
+      "top_p": 0.9,
+    }
+    '''
+
+    # Expected valid Python dictionary after fixing the JSON
+    expected_output = {
+        "_from_model_config": True,
+        "bos_token_id": 128000,
+        "eos_token_id": 128001,
+        "transformers_version": "4.45.0.dev0",
+        "do_sample": True,
+        "temperature": 0.6,
+        "top_p": 0.9
+    }
+
+    # Run the function and compare the result
+    result = fix_and_load_json(invalid_json)
+    assert result == expected_output


### PR DESCRIPTION
Some files like the Llama 3.2 `generation_config.json` are not compatible with Python's json parser. This fixes it. Right now, it's not necessary to do it with other config files, but we can extend it later when necessary.