### PR TITLE
Increase rtol and atol in Gemma 2 for macOS

### DIFF
--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -309,7 +309,7 @@ def test_against_original_gemma_2(model_name):
     assert x.size(1) == T
     ours_y = ours_model(x)
     theirs_y = theirs_model(x)["logits"].to(dtype)  # HF converts logits to float
-    torch.testing.assert_close(ours_y, theirs_y)
+    torch.testing.assert_close(ours_y, theirs_y, rtol=3e-5, atol=3e-5)  # some macOS devices have numerical differences, hence the tol bump
 
 
 @RunIf(min_cuda_gpus=1)


### PR DESCRIPTION
Mac does sometimes have slight numerical discrepancies, e.g., see https://github.com/Lightning-AI/litgpt/actions/runs/11058756360/job/30725503536?pr=1750