### PR TITLE
Temporarily take out thunder dependency for deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ test = [
     "transformers>=4.38.0",  # numerical comparisons
     "einops>=0.7.0",
     "protobuf>=4.23.4",
-    "lightning-thunder @ git+https://github.com/Lightning-AI/lightning-thunder/ ; python_version >= '3.10' and sys_platform == 'linux'",
 ]
 all = [
     "bitsandbytes==0.42.0",      # quantization


### PR DESCRIPTION
We can't have direct dependencies for new package releases to PyPI (see https://github.com/Lightning-AI/litgpt/actions/runs/10818557393/job/30014436744), so I am temporarily taking it out here.