### PR TITLE
Add bnb.nn.StableEmbedding for quantized training

### DIFF
--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -172,7 +172,6 @@ def main(
     fabric.print(f"Number of non-trainable parameters: {num_parameters(model, requires_grad=False):,}")
 
     model = fabric.setup_module(model)
-
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
 
@@ -180,7 +179,8 @@ def main(
         old_embedding = model.transformer.wte
         model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
         with torch.no_grad():
-            model.wte.weight.copy_(old_embedding.weight)
+            model.transformer.wte.weight.copy_(old_embedding.weight)
+        model.transformer.wte = model.transformer.wte.to(device=old_embedding.weight.device, dtype=old_embedding.weight.dtype)
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -175,6 +175,12 @@ def main(
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
+
+        from bitsandbytes.nn import StableEmbedding
+        old_embedding = model.transformer.wte
+        model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
+        with torch.no_grad():
+            model.wte.weight.copy_(old_embedding.weight)
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -172,7 +172,6 @@ def main(
     fabric.print(f"Number of non-trainable parameters: {num_parameters(model, requires_grad=False):,}")
 
     model = fabric.setup_module(model)
-
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
 
@@ -180,7 +179,8 @@ def main(
         old_embedding = model.transformer.wte
         model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
         with torch.no_grad():
-            model.wte.weight.copy_(old_embedding.weight)
+            model.transformer.wte.weight.copy_(old_embedding.weight)
+        model.transformer.wte = model.transformer.wte.to(device=old_embedding.weight.device, dtype=old_embedding.weight.dtype)
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -175,6 +175,12 @@ def main(
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
+
+        from bitsandbytes.nn import StableEmbedding
+        old_embedding = model.transformer.wte
+        model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
+        with torch.no_grad():
+            model.wte.weight.copy_(old_embedding.weight)
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -202,7 +202,6 @@ def main(
     fabric.print(f"Number of non-trainable parameters: {num_parameters(model, requires_grad=False):,}")
 
     model = fabric.setup_module(model)
-
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
 
@@ -210,8 +209,8 @@ def main(
         old_embedding = model.transformer.wte
         model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
         with torch.no_grad():
-            model.wte.weight.copy_(old_embedding.weight)
-
+            model.transformer.wte.weight.copy_(old_embedding.weight)
+        model.transformer.wte = model.transformer.wte.to(device=old_embedding.weight.device, dtype=old_embedding.weight.dtype)
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -205,6 +205,13 @@ def main(
 
     if isinstance(fabric.strategy.precision, BitsandbytesPrecision):
         optimizer = instantiate_bnb_optimizer(optimizer, model.parameters())
+
+        from bitsandbytes.nn import StableEmbedding
+        old_embedding = model.transformer.wte
+        model.transformer.wte = StableEmbedding(old_embedding.num_embeddings, old_embedding.embedding_dim)
+        with torch.no_grad():
+            model.wte.weight.copy_(old_embedding.weight)
+
     else:
         optimizer = instantiate_torch_optimizer(optimizer, model.parameters())
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -182,6 +182,8 @@ def test_adapter_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca
     assert dtype_to_name == {
         "torch.float16": {
             "transformer.wte.weight",
+            "transformer.wte.norm.weight",
+            "transformer.wte.norm.bias",
             "transformer.h.0.norm_1.weight",
             "transformer.h.0.norm_1.bias",
             "transformer.h.0.attn.gating_factor",

--- a/tests/test_adapter_v2.py
+++ b/tests/test_adapter_v2.py
@@ -405,6 +405,8 @@ def test_adapter_v2_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alp
             "transformer.h.1.mlp.fc.adapter_scale",
             "transformer.h.1.attn.attn.linear.bias",
             "transformer.wte.weight",
+            "transformer.wte.norm.weight",
+            "transformer.wte.norm.bias",
             "transformer.h.0.norm_2.weight",
             "transformer.h.1.mlp.proj.linear.bias",
             "transformer.h.0.attn.gating_factor",

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -724,6 +724,7 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
 
     args, kwargs = train_mock.call_args
     fabric, model, optimizer, *_ = args
+    model.transformer.wte = model.transformer.wte.half()
     assert isinstance(fabric.strategy.precision, BitsandbytesPrecision)
     assert isinstance(optimizer, _FabricOptimizer)
     assert isinstance(optimizer._optimizer, PagedAdamW)
@@ -748,6 +749,8 @@ def test_lora_bitsandbytes(monkeypatch, tmp_path, fake_checkpoint_dir, alpaca_pa
             "transformer.h.0.attn.attn.lora_B",
             "transformer.h.0.norm_2.weight",
             "transformer.wte.weight",
+            "transformer.wte.norm.weight",
+            "transformer.wte.norm.bias",
             "transformer.h.1.mlp.fc.linear.bias",
             "transformer.ln_f.bias",
             "transformer.h.1.attn.attn.lora_B",


### PR DESCRIPTION
The bnb.nn.StableEmbedding is used during finetuning to replace the standard Embedding layer. As discussed #1769

Fixes #1769