### PR TITLE
AMD (MI250X) support

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -492,7 +492,7 @@ def build_rope_cache(
     # Create position indices `[0, 1, ..., seq_len - 1]`
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio
 
-    # Calculate the product of position index and θ_i
+    # Calculate the product of position index and $\theta_i$
     idx_theta = torch.outer(seq_idx, theta).repeat(1, 2)
 
     return torch.cos(idx_theta), torch.sin(idx_theta)

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -8,31 +8,43 @@ import os
 import pickle
 import re
 import shutil
-import sys
-from dataclasses import asdict, is_dataclass
-from io import BytesIO
-from packaging import version
-from pathlib import Path
 import subprocess
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
+import sys
 import warnings
+from dataclasses import asdict
+from dataclasses import is_dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Literal
+from typing import Mapping
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import Union
 
 import lightning as L
 import torch
 import torch.nn as nn
 import torch.utils._device
 import yaml
-from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
+from lightning.fabric.loggers import CSVLogger
+from lightning.fabric.loggers import TensorBoardLogger
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.load import _lazy_load as lazy_load
-from lightning.pytorch.loggers import WandbLogger
 from lightning.pytorch.cli import instantiate_class
+from lightning.pytorch.loggers import WandbLogger
+from packaging import version
 from torch.serialization import normalize_storage_type
 from typing_extensions import Self
 
 
 if TYPE_CHECKING:
-    from litgpt import GPT, Config
+    from litgpt import Config
+    from litgpt import GPT
 
 
 def init_out_dir(out_dir: Path) -> Path:
@@ -84,23 +96,25 @@ def reset_parameters(module: nn.Module) -> None:
 
 
 def check_valid_checkpoint_dir(
-        checkpoint_dir: Path,
-        model_filename: str = "lit_model.pth",
-        verbose: bool = True,
-        raise_error: bool = False,
-        ignore_tokenizer_files: bool = False
-    ) -> None:
+    checkpoint_dir: Path,
+    model_filename: str = "lit_model.pth",
+    verbose: bool = True,
+    raise_error: bool = False,
+    ignore_tokenizer_files: bool = False,
+) -> None:
 
     files = {
         model_filename: (checkpoint_dir / model_filename).is_file(),
         "model_config.yaml": (checkpoint_dir / "model_config.yaml").is_file(),
     }
     if not ignore_tokenizer_files:
-        files.update({
-            "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file() or
-                                                (checkpoint_dir / "tokenizer.model").is_file(),
-            "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
-        })
+        files.update(
+            {
+                "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file()
+                or (checkpoint_dir / "tokenizer.model").is_file(),
+                "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
+            }
+        )
 
     if checkpoint_dir.is_dir():
         if all(files.values()):
@@ -458,7 +472,9 @@ def copy_config_files(source_dir: Path, out_dir: Path) -> None:
 
 
 def CLI(*args: Any, **kwargs: Any) -> Any:
-    from jsonargparse import CLI, set_config_read_mode, set_docstring_parse_options
+    from jsonargparse import CLI
+    from jsonargparse import set_config_read_mode
+    from jsonargparse import set_docstring_parse_options
 
     set_docstring_parse_options(attribute_docstrings=True)
     set_config_read_mode(urls_enabled=True)
@@ -539,15 +555,21 @@ def choose_logger(
 
 def get_argument_names(cls):
     sig = inspect.signature(cls.__init__)
-    return {name for name, param in sig.parameters.items()
-            if param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]}
+    return {
+        name
+        for name, param in sig.parameters.items()
+        if param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]
+    }
 
 
 def instantiate_bnb_optimizer(optimizer, model_parameters):
-    if (isinstance(optimizer, str) and "AdamW" not in optimizer) or (isinstance(optimizer, dict) and "AdamW" not in optimizer.get("class_path", "")):
+    if (isinstance(optimizer, str) and "AdamW" not in optimizer) or (
+        isinstance(optimizer, dict) and "AdamW" not in optimizer.get("class_path", "")
+    ):
         raise ValueError("The chosen quantization format only supports the AdamW optimizer.")
 
     import bitsandbytes as bnb
+
     if isinstance(optimizer, str):
         optimizer = bnb.optim.PagedAdamW(model_parameters)
     else:
@@ -594,10 +616,12 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
 
 def extend_checkpoint_dir(checkpoint_dir: Path) -> Path:
     new_checkpoint_dir = "checkpoints" / checkpoint_dir
-    should_return_new_dir = (not checkpoint_dir.is_dir() and
-                             checkpoint_dir.parts[0] != "checkpoints" and
-                             not checkpoint_dir.is_absolute() and
-                             new_checkpoint_dir.exists())
+    should_return_new_dir = (
+        not checkpoint_dir.is_dir()
+        and checkpoint_dir.parts[0] != "checkpoints"
+        and not checkpoint_dir.is_absolute()
+        and new_checkpoint_dir.exists()
+    )
     return new_checkpoint_dir if should_return_new_dir else checkpoint_dir
 
 
@@ -622,7 +646,9 @@ def auto_download_checkpoint(model_name, access_token=None, ignore_tokenizer_fil
 
     checkpoint_dir = extend_checkpoint_dir(Path(model_name))
     try:
-        check_valid_checkpoint_dir(checkpoint_dir, verbose=False, raise_error=True, ignore_tokenizer_files=ignore_tokenizer_files)
+        check_valid_checkpoint_dir(
+            checkpoint_dir, verbose=False, raise_error=True, ignore_tokenizer_files=ignore_tokenizer_files
+        )
     except FileNotFoundError as e:
         if access_token is None:
             access_token = os.getenv("HF_TOKEN")
@@ -637,52 +663,120 @@ def auto_download_checkpoint(model_name, access_token=None, ignore_tokenizer_fil
 
 
 def check_nvlink_connectivity(fabric=None):
+    """Checks GPU connectivity for both NVIDIA and AMD GPUs.
+
+    This function delegates to vendor-specific implementations based on
+    the detected GPU vendor.
+    """
     if fabric is not None:
         custom_print = fabric.print
     else:
         custom_print = print
+
+    # Only execute on the primary process
     if os.getenv("RANK", "0") == "0":
         try:
-            result = subprocess.run(["nvidia-smi", "topo", "-m"], stdout=subprocess.PIPE, text=True)
-
-            if result.returncode != 0:
-                custom_print("Failed to run nvidia-smi")
-                return
-
-            lines = result.stdout.split('\n')
-            gpu_matrix = []
-
-            start_index = next((i for i, line in enumerate(lines) if "GPU0" in line), None) + 1
-            headers_line = lines[start_index - 1]
-            headers = headers_line.split()
-            # The regex is to avoid counting the "GPU NUMA ID" header as a GPU
-            # in headers like ['\x1b[4mGPU0', 'GPU1', 'GPU2', 'GPU3', 'GPU4', 'GPU5', 'GPU6', 'GPU7', 'NIC0', 'NIC1', 'NIC2', 'NIC3', 'NIC4', 'NIC5', 'NIC6', 'NIC7', 'NIC8', 'NIC9', 'CPU', 'Affinity', 'NUMA', 'Affinity', 'GPU', 'NUMA', 'ID\x1b[0m']
-            gpu_regex = re.compile(r'^GPU\d+$')
-            gpu_count = len([header for header in headers if gpu_regex.match(header)])
-
-            all_nvlink = True
-            for line in lines[start_index:start_index + gpu_count]:
-                gpu_matrix.append(line.strip())
-                connections = line.split()[1:1 + gpu_count]
-                if not all("NV" in conn for conn in connections if conn != "X"):
-                    all_nvlink = False
-                    break
-
-            if all_nvlink:
-                custom_print("All GPUs are fully connected via NVLink.")
+            if torch.cuda.is_available():
+                device_properties = torch.cuda.get_device_properties(0)
+                gpu_name = device_properties.name.lower()
+                if "nvidia" in gpu_name:
+                    _check_nvidia_connectivity(custom_print)
+                elif "advanced micro devices" in gpu_name or "amd" in gpu_name:
+                    _check_amd_connectivity(custom_print)
+                else:
+                    custom_print(f"Unrecognized GPU vendor: {device_properties.name}")
             else:
-                custom_print(
-                    "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
-                    "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
-                )
-
+                custom_print("No GPUs available")
         except Exception as e:
-            custom_print(f"An error occurred: {e}")
+            custom_print(f"An error occurred while checking GPU connectivity: {e}")
+
+
+def _check_nvidia_connectivity(custom_print):
+    """Checks NVLink connectivity on NVIDIA GPUs."""
+    result = subprocess.run(["nvidia-smi", "topo", "-m"], stdout=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        custom_print("Failed to run nvidia-smi")
+        return
+
+    lines = result.stdout.strip().split("\n")
+    start_index = next((i for i, line in enumerate(lines) if "GPU0" in line), None)
+    if start_index is None:
+        custom_print("Failed to parse nvidia-smi output")
+        return
+
+    headers_line = lines[start_index]
+    headers = headers_line.split()
+    gpu_regex = re.compile(r"^GPU\d+$")
+    gpu_count = len([header for header in headers if gpu_regex.match(header)])
+
+    all_nvlink = True
+    for line in lines[start_index + 1 : start_index + 1 + gpu_count]:
+        columns = line.split()
+        connections = columns[1 : 1 + gpu_count]
+        if not all("NV" in conn for conn in connections if conn != "X"):
+            all_nvlink = False
+            break
+
+    if all_nvlink:
+        custom_print("All GPUs are fully connected via NVLink.")
+    else:
+        custom_print(
+            "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
+            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+        )
+
+
+def _check_amd_connectivity(custom_print):
+    """Checks XGMI connectivity on AMD GPUs."""
+    result = subprocess.run(["rocm-smi", "--showtopotype"], stdout=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        custom_print("Failed to run rocm-smi")
+        return
+
+    lines = result.stdout.strip().split("\n")
+    # Find the line that starts with "GPU0"
+    gpu_header_index = next((i for i, line in enumerate(lines) if re.match(r"^\s*GPU0", line)), None)
+    if gpu_header_index is None or gpu_header_index == 0:
+        custom_print("Failed to parse rocm-smi output (no GPU headers found)")
+        return
+
+    header_line = lines[gpu_header_index - 1]
+    headers = header_line.strip().split()
+    gpu_regex = re.compile(r"^GPU\d+$")
+    gpu_count = len([header for header in headers if gpu_regex.match(header)])
+
+    # Collect GPU connection lines
+    gpu_lines = []
+    for line in lines[gpu_header_index : gpu_header_index + gpu_count]:
+        if re.match(r"^\s*GPU\d+", line):
+            gpu_lines.append(line.strip())
+    if len(gpu_lines) != gpu_count:
+        custom_print("Mismatch in GPU count when parsing rocm-smi output")
+        return
+
+    all_xgmi = True
+    for line in gpu_lines:
+        columns = line.split()
+        connections = columns[1 : 1 + gpu_count]
+        for conn in connections:
+            if conn not in ("XGMI", "0"):
+                all_xgmi = False
+                break
+        if not all_xgmi:
+            break
+
+    if all_xgmi:
+        custom_print("All GPUs are fully connected via XGMI.")
+    else:
+        custom_print(
+            "Warning: Not all GPUs are fully connected via XGMI. Some GPUs are connected via slower interfaces. "
+            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+        )
 
 
 def fix_and_load_json(s):
     # Remove trailing commas before } or ]
-    s = re.sub(r',(\s*[}\]])', r'\1', s)
+    s = re.sub(r",(\s*[}\]])", r"\1", s)
 
     # Insert missing commas between properties
     # Match positions where a value is followed by a newline and then a quote without a comma

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -8,13 +8,14 @@ import os
 import pickle
 import re
 import shutil
-import subprocess
 import sys
-import warnings
 from dataclasses import asdict, is_dataclass
 from io import BytesIO
+from packaging import version
 from pathlib import Path
+import subprocess
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
+import warnings
 
 import lightning as L
 import torch
@@ -24,9 +25,8 @@ import yaml
 from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.load import _lazy_load as lazy_load
-from lightning.pytorch.cli import instantiate_class
 from lightning.pytorch.loggers import WandbLogger
-from packaging import version
+from lightning.pytorch.cli import instantiate_class
 from torch.serialization import normalize_storage_type
 from typing_extensions import Self
 
@@ -84,25 +84,23 @@ def reset_parameters(module: nn.Module) -> None:
 
 
 def check_valid_checkpoint_dir(
-    checkpoint_dir: Path,
-    model_filename: str = "lit_model.pth",
-    verbose: bool = True,
-    raise_error: bool = False,
-    ignore_tokenizer_files: bool = False,
-) -> None:
+        checkpoint_dir: Path,
+        model_filename: str = "lit_model.pth",
+        verbose: bool = True,
+        raise_error: bool = False,
+        ignore_tokenizer_files: bool = False
+    ) -> None:
 
     files = {
         model_filename: (checkpoint_dir / model_filename).is_file(),
         "model_config.yaml": (checkpoint_dir / "model_config.yaml").is_file(),
     }
     if not ignore_tokenizer_files:
-        files.update(
-            {
-                "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file()
-                or (checkpoint_dir / "tokenizer.model").is_file(),
-                "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
-            }
-        )
+        files.update({
+            "tokenizer.json OR tokenizer.model": (checkpoint_dir / "tokenizer.json").is_file() or
+                                                (checkpoint_dir / "tokenizer.model").is_file(),
+            "tokenizer_config.json": (checkpoint_dir / "tokenizer_config.json").is_file(),
+        })
 
     if checkpoint_dir.is_dir():
         if all(files.values()):
@@ -541,21 +539,15 @@ def choose_logger(
 
 def get_argument_names(cls):
     sig = inspect.signature(cls.__init__)
-    return {
-        name
-        for name, param in sig.parameters.items()
-        if param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]
-    }
+    return {name for name, param in sig.parameters.items()
+            if param.kind in [inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY]}
 
 
 def instantiate_bnb_optimizer(optimizer, model_parameters):
-    if (isinstance(optimizer, str) and "AdamW" not in optimizer) or (
-        isinstance(optimizer, dict) and "AdamW" not in optimizer.get("class_path", "")
-    ):
+    if (isinstance(optimizer, str) and "AdamW" not in optimizer) or (isinstance(optimizer, dict) and "AdamW" not in optimizer.get("class_path", "")):
         raise ValueError("The chosen quantization format only supports the AdamW optimizer.")
 
     import bitsandbytes as bnb
-
     if isinstance(optimizer, str):
         optimizer = bnb.optim.PagedAdamW(model_parameters)
     else:
@@ -602,12 +594,10 @@ def instantiate_torch_optimizer(optimizer, model_parameters, **kwargs):
 
 def extend_checkpoint_dir(checkpoint_dir: Path) -> Path:
     new_checkpoint_dir = "checkpoints" / checkpoint_dir
-    should_return_new_dir = (
-        not checkpoint_dir.is_dir()
-        and checkpoint_dir.parts[0] != "checkpoints"
-        and not checkpoint_dir.is_absolute()
-        and new_checkpoint_dir.exists()
-    )
+    should_return_new_dir = (not checkpoint_dir.is_dir() and
+                             checkpoint_dir.parts[0] != "checkpoints" and
+                             not checkpoint_dir.is_absolute() and
+                             new_checkpoint_dir.exists())
     return new_checkpoint_dir if should_return_new_dir else checkpoint_dir
 
 
@@ -632,9 +622,7 @@ def auto_download_checkpoint(model_name, access_token=None, ignore_tokenizer_fil
 
     checkpoint_dir = extend_checkpoint_dir(Path(model_name))
     try:
-        check_valid_checkpoint_dir(
-            checkpoint_dir, verbose=False, raise_error=True, ignore_tokenizer_files=ignore_tokenizer_files
-        )
+        check_valid_checkpoint_dir(checkpoint_dir, verbose=False, raise_error=True, ignore_tokenizer_files=ignore_tokenizer_files)
     except FileNotFoundError as e:
         if access_token is None:
             access_token = os.getenv("HF_TOKEN")
@@ -759,7 +747,7 @@ def _check_amd_connectivity(custom_print):
 
 def fix_and_load_json(s):
     # Remove trailing commas before } or ]
-    s = re.sub(r",(\s*[}\]])", r"\1", s)
+    s = re.sub(r',(\s*[}\]])', r'\1', s)
 
     # Insert missing commas between properties
     # Match positions where a value is followed by a newline and then a quote without a comma

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -11,28 +11,17 @@ import shutil
 import subprocess
 import sys
 import warnings
-from dataclasses import asdict
-from dataclasses import is_dataclass
+from dataclasses import asdict, is_dataclass
 from io import BytesIO
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Literal
-from typing import Mapping
-from typing import Optional
-from typing import TYPE_CHECKING
-from typing import TypeVar
-from typing import Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Literal, Mapping, Optional, TypeVar, Union
 
 import lightning as L
 import torch
 import torch.nn as nn
 import torch.utils._device
 import yaml
-from lightning.fabric.loggers import CSVLogger
-from lightning.fabric.loggers import TensorBoardLogger
+from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.strategies import FSDPStrategy
 from lightning.fabric.utilities.load import _lazy_load as lazy_load
 from lightning.pytorch.cli import instantiate_class
@@ -43,8 +32,7 @@ from typing_extensions import Self
 
 
 if TYPE_CHECKING:
-    from litgpt import Config
-    from litgpt import GPT
+    from litgpt import GPT, Config
 
 
 def init_out_dir(out_dir: Path) -> Path:
@@ -472,9 +460,7 @@ def copy_config_files(source_dir: Path, out_dir: Path) -> None:
 
 
 def CLI(*args: Any, **kwargs: Any) -> Any:
-    from jsonargparse import CLI
-    from jsonargparse import set_config_read_mode
-    from jsonargparse import set_docstring_parse_options
+    from jsonargparse import CLI, set_config_read_mode, set_docstring_parse_options
 
     set_docstring_parse_options(attribute_docstrings=True)
     set_config_read_mode(urls_enabled=True)
@@ -673,7 +659,6 @@ def check_nvlink_connectivity(fabric=None):
     else:
         custom_print = print
 
-    # Only execute on the primary process
     if os.getenv("RANK", "0") == "0":
         try:
             if torch.cuda.is_available():
@@ -734,7 +719,6 @@ def _check_amd_connectivity(custom_print):
         return
 
     lines = result.stdout.strip().split("\n")
-    # Find the line that starts with "GPU0"
     gpu_header_index = next((i for i, line in enumerate(lines) if re.match(r"^\s*GPU0", line)), None)
     if gpu_header_index is None or gpu_header_index == 0:
         custom_print("Failed to parse rocm-smi output (no GPU headers found)")
@@ -745,7 +729,6 @@ def _check_amd_connectivity(custom_print):
     gpu_regex = re.compile(r"^GPU\d+$")
     gpu_count = len([header for header in headers if gpu_regex.match(header)])
 
-    # Collect GPU connection lines
     gpu_lines = []
     for line in lines[gpu_header_index : gpu_header_index + gpu_count]:
         if re.match(r"^\s*GPU\d+", line):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -498,7 +498,7 @@ GPU3	NV12	NV12	NV12	X""", returncode=0)
 
 
 @mock.patch("subprocess.run")
-def test_all_nvlink_connected(mock_run, all_nvlink_connected_output):
+def test_all_nvlink_connected(mock_run, all_nvlink_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties):
     mock_run.return_value = all_nvlink_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
@@ -520,7 +520,7 @@ Legend:
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_partially_connected_output(mock_run, nvlink_partially_connected_output):
+def test_nvlink_partially_connected_output(mock_run, nvlink_partially_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties):
     mock_run.return_value = nvlink_partially_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
@@ -550,7 +550,7 @@ Legend:
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_not_connected_output(mock_run, nvlink_not_connected_output):
+def test_nvlink_not_connected_output(mock_run, nvlink_not_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties):
     mock_run.return_value = nvlink_not_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,7 @@ from contextlib import redirect_stderr
 from dataclasses import asdict
 from io import StringIO
 from pathlib import Path
-from tempfile import NamedTemporaryFile
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, NamedTemporaryFile
 from unittest import mock
 
 import pytest
@@ -13,36 +12,36 @@ import torch
 import torch.nn.functional as F
 import yaml
 from lightning import Fabric
-from lightning.fabric.loggers import CSVLogger
-from lightning.fabric.loggers import TensorBoardLogger
+from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.pytorch.loggers import WandbLogger
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT
 from litgpt.args import TrainArgs
-from litgpt.utils import capture_hparams
-from litgpt.utils import check_file_size_on_cpu_and_warn
-from litgpt.utils import check_nvlink_connectivity
-from litgpt.utils import check_valid_checkpoint_dir
-from litgpt.utils import choose_logger
-from litgpt.utils import chunked_cross_entropy
-from litgpt.utils import CLI
-from litgpt.utils import copy_config_files
-from litgpt.utils import CycleIterator
-from litgpt.utils import extend_checkpoint_dir
-from litgpt.utils import find_multiple
-from litgpt.utils import find_resume_path
-from litgpt.utils import fix_and_load_json
-from litgpt.utils import incremental_save
-from litgpt.utils import init_out_dir
-from litgpt.utils import instantiate_bnb_optimizer
-from litgpt.utils import instantiate_torch_optimizer
-from litgpt.utils import num_parameters
-from litgpt.utils import parse_devices
-from litgpt.utils import save_hyperparameters
+from litgpt.utils import (
+    CLI,
+    CycleIterator,
+    capture_hparams,
+    check_file_size_on_cpu_and_warn,
+    check_nvlink_connectivity,
+    check_valid_checkpoint_dir,
+    choose_logger,
+    chunked_cross_entropy,
+    copy_config_files,
+    extend_checkpoint_dir,
+    find_multiple,
+    find_resume_path,
+    fix_and_load_json,
+    incremental_save,
+    init_out_dir,
+    instantiate_bnb_optimizer,
+    instantiate_torch_optimizer,
+    num_parameters,
+    parse_devices,
+    save_hyperparameters,
+)
 from tests.conftest import RunIf
-
 
 def test_find_multiple():
     assert find_multiple(17, 5) == 20
@@ -485,6 +484,28 @@ def test_file_size_above_limit_on_gpu():
 
 
 @pytest.fixture
+def mock_cuda_is_available_true(monkeypatch):
+    """Fixture to mock torch.cuda.is_available() to return True."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+
+@pytest.fixture
+def mock_nvidia_device_properties(monkeypatch):
+    """Fixture to mock torch.cuda.get_device_properties() for NVIDIA GPUs."""
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "NVIDIA RTX A6000"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+
+
+@pytest.fixture
+def mock_amd_device_properties(monkeypatch):
+    """Fixture to mock torch.cuda.get_device_properties() for AMD GPUs."""
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "AMD Instinct MI250X"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+
+
+@pytest.fixture
 def all_nvlink_connected_output():
     return mock.MagicMock(
         stdout="""        GPU0	GPU1	GPU2	GPU3
@@ -497,11 +518,13 @@ GPU3	NV12	NV12	NV12	X""",
 
 
 @mock.patch("subprocess.run")
-def test_all_nvlink_connected(mock_run, all_nvlink_connected_output):
+def test_all_nvlink_connected(
+    mock_run, all_nvlink_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
+):
     mock_run.return_value = all_nvlink_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-        mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+    mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
 
 
 @pytest.fixture
@@ -522,14 +545,16 @@ Legend:
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_partially_connected_output(mock_run, nvlink_partially_connected_output):
+def test_nvlink_partially_connected_output(
+    mock_run, nvlink_partially_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
+):
     mock_run.return_value = nvlink_partially_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-        mock_print.assert_any_call(
-            "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
-            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
-        )
+    mock_print.assert_any_call(
+        "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
+        "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+    )
 
 
 @pytest.fixture
@@ -555,14 +580,16 @@ Legend:
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_not_connected_output(mock_run, nvlink_not_connected_output):
+def test_nvlink_not_connected_output(
+    mock_run, nvlink_not_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
+):
     mock_run.return_value = nvlink_not_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-        mock_print.assert_any_call(
-            "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
-            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
-        )
+    mock_print.assert_any_call(
+        "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
+        "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+    )
 
 
 @pytest.fixture
@@ -618,12 +645,99 @@ NIC Legend:
 
 @mock.patch("subprocess.run")
 def test_nvlink_all_gpu_connected_but_other_connected_output(
-    mock_run, nvlink_all_gpu_connected_but_other_connected_output
+    mock_run,
+    nvlink_all_gpu_connected_but_other_connected_output,
+    mock_cuda_is_available_true,
+    mock_nvidia_device_properties,
 ):
     mock_run.return_value = nvlink_all_gpu_connected_but_other_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
+    mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+
+
+@pytest.fixture
+def nvidia_smi_nvlink_output_dual_gpu_no_numa():
+    return mock.MagicMock(
+        stdout="""
+        GPU0    GPU1    CPU Affinity    NUMA Affinity   GPU NUMA ID
+GPU0     X      NV1     0-15    0               N/A
+GPU1    NV1      X      0-15    0               N/A
+
+Legend:
+
+  X    = Self
+  SYS  = Connection traversing PCIe as well as the SMP interconnect between NUMA nodes (e.g., QPI/UPI)
+  NODE = Connection traversing PCIe as well as the interconnect between PCIe Host Bridges within a NUMA node
+  PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
+  PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
+  PIX  = Connection traversing at most a single PCIe bridge
+  NV#  = Connection traversing a bonded set of # NVLinks
+    """,
+        returncode=0,
+    )
+
+
+@mock.patch("subprocess.run")
+def test_check_nvlink_connectivity__returns_fully_connected_when_nvidia_all_nvlink_two_gpus(
+    mock_run, all_nvlink_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
+):
+    mock_run.return_value = all_nvlink_connected_output
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
         mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+
+
+@pytest.fixture
+def rocm_smi_xgmi_output_multi_gpu():
+    """
+    rocm-smi --showtopotype on ROCm 6.0.3+
+    """
+    return mock.MagicMock(
+        stdout="""
+=============================== ROCm System Management Interface ============================
+=============================== Link Type between two GPUs ===============================
+       GPU0         GPU1         GPU2         GPU3         GPU4         GPU5         GPU6         GPU7
+GPU0   0            XGMI         XGMI         XGMI         XGMI         XGMI         XGMI         XGMI
+GPU1   XGMI         0            XGMI         XGMI         XGMI         XGMI         XGMI         XGMI
+GPU2   XGMI         XGMI         0            XGMI         XGMI         XGMI         XGMI         XGMI
+GPU3   XGMI         XGMI         XGMI         0            XGMI         XGMI         XGMI         XGMI
+GPU4   XGMI         XGMI         XGMI         XGMI         0            XGMI         XGMI         XGMI
+GPU5   XGMI         XGMI         XGMI         XGMI         XGMI         0            XGMI         XGMI
+GPU6   XGMI         XGMI         XGMI         XGMI         XGMI         XGMI         0            XGMI
+GPU7   XGMI         XGMI         XGMI         XGMI         XGMI         XGMI         XGMI         0
+================================== End of ROCm SMI Log ===================================
+    """,
+        returncode=0,
+    )
+
+
+@mock.patch("subprocess.run")
+def test_check_nvlink_connectivity__returns_fully_connected_when_amd_all_xgmi_8_gpus(
+    mock_run, rocm_smi_xgmi_output_multi_gpu, mock_cuda_is_available_true, mock_amd_device_properties
+):
+    mock_run.return_value = rocm_smi_xgmi_output_multi_gpu
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
+        mock_print.assert_any_call("All GPUs are fully connected via XGMI.")
+
+
+@mock.patch("subprocess.run")
+def test_check_nvlink_connectivity__returns_no_gpus_when_no_gpus(mock_run, monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
+        mock_print.assert_any_call("No GPUs available")
+
+
+@mock.patch("subprocess.run")
+def test_check_nvlink_connectivity__returns_unrecognized_vendor_when_unrecognized_vendor(mock_run, monkeypatch, mock_cuda_is_available_true):
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "GARAGE DIY HYPERSCALER GPU"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
+        mock_print.assert_any_call("Unrecognized GPU vendor: GARAGE DIY HYPERSCALER GPU")
 
 
 def test_fix_and_load_json():
@@ -678,63 +792,3 @@ def test_fix_and_load_json():
 
     result_missing_commas = fix_and_load_json(invalid_json_missing_commas)
     assert result_missing_commas == expected_output_missing_commas
-
-
-def test_check_nvlink_connectivity__returns_fully_connected_when_nvidia_all_nvlink(monkeypatch):
-    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
-    mock_device_properties.name = "NVIDIA GeForce RTX 3090"
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-
-    nvidia_smi_output = """
-    GPU0    GPU1
-    GPU0    X      NV1
-    GPU1    NV1    X
-    """
-    mock_run = mock.MagicMock(return_value=mock.Mock(stdout=nvidia_smi_output, returncode=0))
-    with mock.patch("subprocess.run", mock_run):
-        with mock.patch("builtins.print") as mock_print:
-            check_nvlink_connectivity()
-            mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
-
-
-def test_check_nvlink_connectivity_returns_fully_connected_when_amd_all_xgmi(monkeypatch):
-    # Mock the GPU device properties to simulate AMD GPUs
-    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
-    mock_device_properties.name = "Advanced Micro Devices [AMD/ATI] MI250X"
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-
-    rocm_smi_output = """
-    =============================== Link Type between two GPUs ===============================
-        GPU0         GPU1
-    GPU0   0            XGMI
-    GPU1   XGMI         0
-    ==========================================================================================
-    """
-    mock_run = mock.MagicMock(return_value=mock.Mock(stdout=rocm_smi_output, returncode=0))
-    with mock.patch("subprocess.run", mock_run):
-        with mock.patch("builtins.print") as mock_print:
-            check_nvlink_connectivity()
-            mock_print.assert_any_call("All GPUs are fully connected via XGMI.")
-
-
-def test_check_nvlink_connectivity_returns_no_gpus_when_no_gpus(monkeypatch):
-    # Mock torch.cuda.is_available to return False
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
-
-    with mock.patch("builtins.print") as mock_print:
-        check_nvlink_connectivity()
-        mock_print.assert_any_call("No GPUs available")
-
-
-def test_check_nvlink_connectivity_returns_unrecognized_vendor_when_unrecognized_vendor(monkeypatch):
-    # Mock the GPU device properties to simulate an unrecognized GPU vendor
-    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
-    mock_device_properties.name = "Unknown GPU Vendor"
-    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-
-    with mock.patch("builtins.print") as mock_print:
-        check_nvlink_connectivity()
-        mock_print.assert_any_call("Unrecognized GPU vendor: Unknown GPU Vendor")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,48 +1,47 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
-from dataclasses import asdict
-
 import os
 from contextlib import redirect_stderr
+from dataclasses import asdict
 from io import StringIO
 from pathlib import Path
-from tempfile import TemporaryDirectory, NamedTemporaryFile
+from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
 import torch
 import torch.nn.functional as F
 import yaml
-from tests.conftest import RunIf
 from lightning import Fabric
-from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
+from lightning.fabric.loggers import CSVLogger
+from lightning.fabric.loggers import TensorBoardLogger
 from lightning.fabric.plugins import BitsandbytesPrecision
 from lightning.pytorch.loggers import WandbLogger
 from lightning_utilities.core.imports import RequirementCache
 
 from litgpt import GPT
 from litgpt.args import TrainArgs
-from litgpt.utils import (
-    CLI,
-    CycleIterator,
-    capture_hparams,
-    check_file_size_on_cpu_and_warn,
-    check_nvlink_connectivity,
-    check_valid_checkpoint_dir,
-    choose_logger,
-    chunked_cross_entropy,
-    copy_config_files,
-    extend_checkpoint_dir,
-    find_multiple,
-    find_resume_path,
-    fix_and_load_json,
-    incremental_save,
-    init_out_dir,
-    instantiate_bnb_optimizer,
-    instantiate_torch_optimizer,
-    num_parameters,
-    parse_devices,
-    save_hyperparameters,
-)
+from litgpt.utils import capture_hparams
+from litgpt.utils import check_file_size_on_cpu_and_warn
+from litgpt.utils import check_nvlink_connectivity
+from litgpt.utils import check_valid_checkpoint_dir
+from litgpt.utils import choose_logger
+from litgpt.utils import chunked_cross_entropy
+from litgpt.utils import CLI
+from litgpt.utils import copy_config_files
+from litgpt.utils import CycleIterator
+from litgpt.utils import extend_checkpoint_dir
+from litgpt.utils import find_multiple
+from litgpt.utils import find_resume_path
+from litgpt.utils import fix_and_load_json
+from litgpt.utils import incremental_save
+from litgpt.utils import init_out_dir
+from litgpt.utils import instantiate_bnb_optimizer
+from litgpt.utils import instantiate_torch_optimizer
+from litgpt.utils import num_parameters
+from litgpt.utils import parse_devices
+from litgpt.utils import save_hyperparameters
+from tests.conftest import RunIf
 
 
 def test_find_multiple():
@@ -306,12 +305,15 @@ def test_choose_logger(tmp_path):
         choose_logger("foo", out_dir=tmp_path, name="foo")
 
 
-@pytest.mark.parametrize("path_type, input_path, expected", [
-    ("relative", "some/relative/path", "some/relative/path"),
-    ("absolute", "/usr/absolute/path", "/usr/absolute/path"),
-    ("env_relative", "some/relative/path", "prefix/some/relative/path"),
-    ("env_absolute", "/usr/absolute/path", "/usr/absolute/path")
-])
+@pytest.mark.parametrize(
+    "path_type, input_path, expected",
+    [
+        ("relative", "some/relative/path", "some/relative/path"),
+        ("absolute", "/usr/absolute/path", "/usr/absolute/path"),
+        ("env_relative", "some/relative/path", "prefix/some/relative/path"),
+        ("env_absolute", "/usr/absolute/path", "/usr/absolute/path"),
+    ],
+)
 def test_init_out_dir(path_type, input_path, expected):
     if path_type.startswith("env_"):
         with mock.patch.dict(os.environ, {"LIGHTNING_ARTIFACTS_DIR": "prefix"}):
@@ -322,13 +324,17 @@ def test_init_out_dir(path_type, input_path, expected):
         if "LIGHTNING_ARTIFACTS_DIR" not in os.environ:
             assert result == Path(expected), f"Failed for {path_type} with input {input_path} (result {result})"
         else:
-            assert result == Path(os.getenv("LIGHTNING_ARTIFACTS_DIR")) / expected, f"Failed for {path_type} with input {input_path} (result {result})"
+            assert (
+                result == Path(os.getenv("LIGHTNING_ARTIFACTS_DIR")) / expected
+            ), f"Failed for {path_type} with input {input_path} (result {result})"
 
 
 def test_find_resume_path(tmp_path):
     assert find_resume_path(resume=None, out_dir=Path("does/not/exist")) is None
     assert find_resume_path(resume=Path("does/not/exist"), out_dir=Path("does/not/matter")) == Path("does/not/exist")
-    assert find_resume_path(resume=(tmp_path / "checkpoint.pt"), out_dir=Path("does/not/matter")) == (tmp_path / "checkpoint.pt")
+    assert find_resume_path(resume=(tmp_path / "checkpoint.pt"), out_dir=Path("does/not/matter")) == (
+        tmp_path / "checkpoint.pt"
+    )
 
     # `resume='auto'` does not enforce the checkpoint to exist
     assert find_resume_path(resume="auto", out_dir=Path("does/not/exist")) is None
@@ -357,6 +363,7 @@ def model_parameters():
 
 def test_instantiate_bnb_optimizer_with_str(model_parameters):
     import bitsandbytes as bnb
+
     with mock.patch("litgpt.utils.get_argument_names", return_value={"lr", "eps", "weight_decay"}):
         optimizer = instantiate_bnb_optimizer("AdamW", model_parameters)
         assert isinstance(optimizer, bnb.optim.adamw.PagedAdamW)
@@ -364,6 +371,7 @@ def test_instantiate_bnb_optimizer_with_str(model_parameters):
 
 def test_instantiate_bnb_optimizer_with_dict(model_parameters):
     import bitsandbytes as bnb
+
     optimizer_dict = {"class_path": "AdamW", "init_args": {"lr": 0.01}}
     with mock.patch("litgpt.utils.get_argument_names", return_value={"lr", "eps", "weight_decay"}):
         optimizer = instantiate_bnb_optimizer(optimizer_dict, model_parameters)
@@ -383,16 +391,21 @@ def test_instantiate_torch_optimizer_with_str(model_parameters):
 
 
 def test_instantiate_torch_optimizer_with_class(model_parameters):
-    optimizer = instantiate_torch_optimizer({"class_path": "torch.optim.Adam", "init_args": {"lr": 123}}, model_parameters, lr=0.02)
+    optimizer = instantiate_torch_optimizer(
+        {"class_path": "torch.optim.Adam", "init_args": {"lr": 123}}, model_parameters, lr=0.02
+    )
     assert isinstance(optimizer, torch.optim.Adam)
     # init args gets overridden
     assert optimizer.param_groups[0]["lr"] == 0.02
 
 
-@pytest.mark.parametrize("input_path, expected", [
-    (Path("checkpoints/my_model"), Path("checkpoints/my_model")),
-    (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
-])
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        (Path("checkpoints/my_model"), Path("checkpoints/my_model")),
+        (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
+    ],
+)
 def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
     original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
@@ -410,10 +423,13 @@ def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
             os.chdir(original_dir)  # Reset the current directory
 
 
-@pytest.mark.parametrize("input_path, expected", [
-    (Path("my_model"), Path("checkpoints/my_model")),
-    (Path("my_model"), Path("./checkpoints/my_model")),
-])
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        (Path("my_model"), Path("checkpoints/my_model")),
+        (Path("my_model"), Path("./checkpoints/my_model")),
+    ],
+)
 def test_extend_checkpoint_dir(input_path, expected):
     original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
@@ -431,10 +447,13 @@ def test_extend_checkpoint_dir(input_path, expected):
             os.chdir(original_dir)  # Reset the current directory
 
 
-@pytest.mark.parametrize("input_path, expected", [
-    (Path("my_model"), Path("my_model")),
-    (Path("/my_model"), Path("/my_model")),
-])
+@pytest.mark.parametrize(
+    "input_path, expected",
+    [
+        (Path("my_model"), Path("my_model")),
+        (Path("/my_model"), Path("/my_model")),
+    ],
+)
 def test_extend_checkpoint_dir_dont_exist(input_path, expected):
     assert extend_checkpoint_dir(input_path) == expected
 
@@ -467,11 +486,14 @@ def test_file_size_above_limit_on_gpu():
 
 @pytest.fixture
 def all_nvlink_connected_output():
-    return mock.MagicMock(stdout="""        GPU0	GPU1	GPU2	GPU3
+    return mock.MagicMock(
+        stdout="""        GPU0	GPU1	GPU2	GPU3
 GPU0	X	NV12	NV12	NV12
 GPU1	NV12	X	NV12	NV12
 GPU2	NV12	NV12	X	NV12
-GPU3	NV12	NV12	NV12	X""", returncode=0)
+GPU3	NV12	NV12	NV12	X""",
+        returncode=0,
+    )
 
 
 @mock.patch("subprocess.run")
@@ -484,7 +506,8 @@ def test_all_nvlink_connected(mock_run, all_nvlink_connected_output):
 
 @pytest.fixture
 def nvlink_partially_connected_output():
-    return mock.MagicMock(stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity
+    return mock.MagicMock(
+        stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity
 GPU0     X      NV1     SYS     SYS     0-7
 GPU1    NV1      X      SYS     SYS     0-7
 GPU2    SYS     SYS      X      NV1     8-15
@@ -493,7 +516,9 @@ GPU3    SYS     SYS     NV1      X      8-15
 Legend:
   X   = Self
   NV1 = Connected via NVLink with 1 hop
-  SYS = Connected via the PCIe or CPU subsystem""", returncode=0)
+  SYS = Connected via the PCIe or CPU subsystem""",
+        returncode=0,
+    )
 
 
 @mock.patch("subprocess.run")
@@ -509,7 +534,8 @@ def test_nvlink_partially_connected_output(mock_run, nvlink_partially_connected_
 
 @pytest.fixture
 def nvlink_not_connected_output():
-    return mock.MagicMock(stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity    NUMA Affinity   GPU NUMA ID
+    return mock.MagicMock(
+        stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity    NUMA Affinity   GPU NUMA ID
 GPU0     X      PHB     PHB     PHB     0-47    0               N/A
 GPU1    PHB      X      PHB     PHB     0-47    0               N/A
 GPU2    PHB     PHB      X      PHB     0-47    0               N/A
@@ -523,7 +549,9 @@ Legend:
   PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
   PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
   PIX  = Connection traversing at most a single PCIe bridge
-  NV#  = Connection traversing a bonded set of # NVLinks""", returncode=0)
+  NV#  = Connection traversing a bonded set of # NVLinks""",
+        returncode=0,
+    )
 
 
 @mock.patch("subprocess.run")
@@ -539,7 +567,8 @@ def test_nvlink_not_connected_output(mock_run, nvlink_not_connected_output):
 
 @pytest.fixture
 def nvlink_all_gpu_connected_but_other_connected_output():
-    return mock.MagicMock(stdout="""	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	NIC2	NIC3	NIC4	NIC5	NIC6	NIC7	NIC8	NIC9	CPU Affinity	NUMA Affinity	GPU NUMA ID
+    return mock.MagicMock(
+        stdout="""	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	NIC2	NIC3	NIC4	NIC5	NIC6	NIC7	NIC8	NIC9	CPU Affinity	NUMA Affinity	GPU NUMA ID
 GPU0	X 	NV12	NV12	NV12	NV12	NV12	NV12	NV12	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
 GPU1	NV12	X 	NV12	NV12	NV12	NV12	NV12	NV12	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
 GPU2	NV12	NV12	X 	NV12	NV12	NV12	NV12	NV12	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
@@ -548,16 +577,16 @@ GPU4	NV12	NV12	NV12	NV12	X 	NV12	NV12	NV12	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	P
 GPU5	NV12	NV12	NV12	NV12	NV12	X 	NV12	NV12	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	64-127,192-254	1		N/A
 GPU6	NV12	NV12	NV12	NV12	NV12	NV12	X 	NV12	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	64-127,192-254	1		N/A
 GPU7	NV12	NV12	NV12	NV12	NV12	NV12	NV12	X 	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	64-127,192-254	1		N/A
-NIC0	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS				
-NIC1	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS				
-NIC2	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS	SYS	SYS				
-NIC3	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS	SYS	SYS				
-NIC4	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS				
-NIC5	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS				
-NIC6	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS				
-NIC7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS				
-NIC8	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB				
-NIC9	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 				
+NIC0	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS
+NIC1	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS
+NIC2	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS	SYS	SYS
+NIC3	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS	SYS	SYS
+NIC4	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS
+NIC5	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS
+NIC6	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS
+NIC7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS
+NIC8	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB
+NIC9	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X
 
 Legend:
 
@@ -582,11 +611,15 @@ NIC Legend:
   NIC8: mlx5_8
   NIC9: mlx5_9
 
-""", returncode=0)
+""",
+        returncode=0,
+    )
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_all_gpu_connected_but_other_connected_output(mock_run, nvlink_all_gpu_connected_but_other_connected_output):
+def test_nvlink_all_gpu_connected_but_other_connected_output(
+    mock_run, nvlink_all_gpu_connected_but_other_connected_output
+):
     mock_run.return_value = nvlink_all_gpu_connected_but_other_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
@@ -595,7 +628,7 @@ def test_nvlink_all_gpu_connected_but_other_connected_output(mock_run, nvlink_al
 
 def test_fix_and_load_json():
     # Test 1: Invalid JSON string with a trailing comma
-    invalid_json_trailing_comma = '''
+    invalid_json_trailing_comma = """
     {
       "_from_model_config": true,
       "bos_token_id": 128000,
@@ -605,7 +638,7 @@ def test_fix_and_load_json():
       "temperature": 0.6,
       "top_p": 0.9,
     }
-    '''
+    """
 
     expected_output_trailing_comma = {
         "_from_model_config": True,
@@ -614,14 +647,14 @@ def test_fix_and_load_json():
         "transformers_version": "4.45.0.dev0",
         "do_sample": True,
         "temperature": 0.6,
-        "top_p": 0.9
+        "top_p": 0.9,
     }
 
     result_trailing_comma = fix_and_load_json(invalid_json_trailing_comma)
     assert result_trailing_comma == expected_output_trailing_comma
 
     # Test 2: Invalid JSON string with missing commas between properties
-    invalid_json_missing_commas = '''
+    invalid_json_missing_commas = """
     {
       "_from_model_config": true,
       "bos_token_id": 128000,
@@ -631,7 +664,7 @@ def test_fix_and_load_json():
       "temperature": 0.6,
       "top_p": 0.9,
     }
-    '''
+    """
 
     expected_output_missing_commas = {
         "_from_model_config": True,
@@ -640,8 +673,68 @@ def test_fix_and_load_json():
         "transformers_version": "4.45.0.dev0",
         "do_sample": True,
         "temperature": 0.6,
-        "top_p": 0.9
+        "top_p": 0.9,
     }
 
     result_missing_commas = fix_and_load_json(invalid_json_missing_commas)
     assert result_missing_commas == expected_output_missing_commas
+
+
+def test_check_nvlink_connectivity__returns_fully_connected_when_nvidia_all_nvlink(monkeypatch):
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "NVIDIA GeForce RTX 3090"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    nvidia_smi_output = """
+    GPU0    GPU1
+    GPU0    X      NV1
+    GPU1    NV1    X
+    """
+    mock_run = mock.MagicMock(return_value=mock.Mock(stdout=nvidia_smi_output, returncode=0))
+    with mock.patch("subprocess.run", mock_run):
+        with mock.patch("builtins.print") as mock_print:
+            check_nvlink_connectivity()
+            mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+
+
+def test_check_nvlink_connectivity_returns_fully_connected_when_amd_all_xgmi(monkeypatch):
+    # Mock the GPU device properties to simulate AMD GPUs
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "Advanced Micro Devices [AMD/ATI] MI250X"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    rocm_smi_output = """
+    =============================== Link Type between two GPUs ===============================
+        GPU0         GPU1
+    GPU0   0            XGMI
+    GPU1   XGMI         0
+    ==========================================================================================
+    """
+    mock_run = mock.MagicMock(return_value=mock.Mock(stdout=rocm_smi_output, returncode=0))
+    with mock.patch("subprocess.run", mock_run):
+        with mock.patch("builtins.print") as mock_print:
+            check_nvlink_connectivity()
+            mock_print.assert_any_call("All GPUs are fully connected via XGMI.")
+
+
+def test_check_nvlink_connectivity_returns_no_gpus_when_no_gpus(monkeypatch):
+    # Mock torch.cuda.is_available to return False
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
+        mock_print.assert_any_call("No GPUs available")
+
+
+def test_check_nvlink_connectivity_returns_unrecognized_vendor_when_unrecognized_vendor(monkeypatch):
+    # Mock the GPU device properties to simulate an unrecognized GPU vendor
+    mock_device_properties = mock.MagicMock(name="GPU Device", spec=["name"])
+    mock_device_properties.name = "Unknown GPU Vendor"
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+
+    with mock.patch("builtins.print") as mock_print:
+        check_nvlink_connectivity()
+        mock_print.assert_any_call("Unrecognized GPU vendor: Unknown GPU Vendor")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -645,9 +645,9 @@ Legend:
 
 @mock.patch("subprocess.run")
 def test_check_nvlink_connectivity__returns_fully_connected_when_nvidia_all_nvlink_two_gpus(
-    mock_run, all_nvlink_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
+    mock_run, nvidia_smi_nvlink_output_dual_gpu_no_numa, mock_cuda_is_available_true, mock_nvidia_device_properties
 ):
-    mock_run.return_value = all_nvlink_connected_output
+    mock_run.return_value = nvidia_smi_nvlink_output_dual_gpu_no_numa
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
         mock_print.assert_any_call("All GPUs are fully connected via NVLink.")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,8 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+from dataclasses import asdict
+
 import os
 from contextlib import redirect_stderr
-from dataclasses import asdict
 from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory, NamedTemporaryFile
@@ -11,6 +12,7 @@ import pytest
 import torch
 import torch.nn.functional as F
 import yaml
+from tests.conftest import RunIf
 from lightning import Fabric
 from lightning.fabric.loggers import CSVLogger, TensorBoardLogger
 from lightning.fabric.plugins import BitsandbytesPrecision
@@ -41,7 +43,7 @@ from litgpt.utils import (
     parse_devices,
     save_hyperparameters,
 )
-from tests.conftest import RunIf
+
 
 def test_find_multiple():
     assert find_multiple(17, 5) == 20
@@ -304,15 +306,12 @@ def test_choose_logger(tmp_path):
         choose_logger("foo", out_dir=tmp_path, name="foo")
 
 
-@pytest.mark.parametrize(
-    "path_type, input_path, expected",
-    [
-        ("relative", "some/relative/path", "some/relative/path"),
-        ("absolute", "/usr/absolute/path", "/usr/absolute/path"),
-        ("env_relative", "some/relative/path", "prefix/some/relative/path"),
-        ("env_absolute", "/usr/absolute/path", "/usr/absolute/path"),
-    ],
-)
+@pytest.mark.parametrize("path_type, input_path, expected", [
+    ("relative", "some/relative/path", "some/relative/path"),
+    ("absolute", "/usr/absolute/path", "/usr/absolute/path"),
+    ("env_relative", "some/relative/path", "prefix/some/relative/path"),
+    ("env_absolute", "/usr/absolute/path", "/usr/absolute/path")
+])
 def test_init_out_dir(path_type, input_path, expected):
     if path_type.startswith("env_"):
         with mock.patch.dict(os.environ, {"LIGHTNING_ARTIFACTS_DIR": "prefix"}):
@@ -323,17 +322,13 @@ def test_init_out_dir(path_type, input_path, expected):
         if "LIGHTNING_ARTIFACTS_DIR" not in os.environ:
             assert result == Path(expected), f"Failed for {path_type} with input {input_path} (result {result})"
         else:
-            assert (
-                result == Path(os.getenv("LIGHTNING_ARTIFACTS_DIR")) / expected
-            ), f"Failed for {path_type} with input {input_path} (result {result})"
+            assert result == Path(os.getenv("LIGHTNING_ARTIFACTS_DIR")) / expected, f"Failed for {path_type} with input {input_path} (result {result})"
 
 
 def test_find_resume_path(tmp_path):
     assert find_resume_path(resume=None, out_dir=Path("does/not/exist")) is None
     assert find_resume_path(resume=Path("does/not/exist"), out_dir=Path("does/not/matter")) == Path("does/not/exist")
-    assert find_resume_path(resume=(tmp_path / "checkpoint.pt"), out_dir=Path("does/not/matter")) == (
-        tmp_path / "checkpoint.pt"
-    )
+    assert find_resume_path(resume=(tmp_path / "checkpoint.pt"), out_dir=Path("does/not/matter")) == (tmp_path / "checkpoint.pt")
 
     # `resume='auto'` does not enforce the checkpoint to exist
     assert find_resume_path(resume="auto", out_dir=Path("does/not/exist")) is None
@@ -362,7 +357,6 @@ def model_parameters():
 
 def test_instantiate_bnb_optimizer_with_str(model_parameters):
     import bitsandbytes as bnb
-
     with mock.patch("litgpt.utils.get_argument_names", return_value={"lr", "eps", "weight_decay"}):
         optimizer = instantiate_bnb_optimizer("AdamW", model_parameters)
         assert isinstance(optimizer, bnb.optim.adamw.PagedAdamW)
@@ -370,7 +364,6 @@ def test_instantiate_bnb_optimizer_with_str(model_parameters):
 
 def test_instantiate_bnb_optimizer_with_dict(model_parameters):
     import bitsandbytes as bnb
-
     optimizer_dict = {"class_path": "AdamW", "init_args": {"lr": 0.01}}
     with mock.patch("litgpt.utils.get_argument_names", return_value={"lr", "eps", "weight_decay"}):
         optimizer = instantiate_bnb_optimizer(optimizer_dict, model_parameters)
@@ -390,21 +383,16 @@ def test_instantiate_torch_optimizer_with_str(model_parameters):
 
 
 def test_instantiate_torch_optimizer_with_class(model_parameters):
-    optimizer = instantiate_torch_optimizer(
-        {"class_path": "torch.optim.Adam", "init_args": {"lr": 123}}, model_parameters, lr=0.02
-    )
+    optimizer = instantiate_torch_optimizer({"class_path": "torch.optim.Adam", "init_args": {"lr": 123}}, model_parameters, lr=0.02)
     assert isinstance(optimizer, torch.optim.Adam)
     # init args gets overridden
     assert optimizer.param_groups[0]["lr"] == 0.02
 
 
-@pytest.mark.parametrize(
-    "input_path, expected",
-    [
-        (Path("checkpoints/my_model"), Path("checkpoints/my_model")),
-        (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
-    ],
-)
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("checkpoints/my_model"), Path("checkpoints/my_model")),
+    (Path("checkpoints/my_model"), Path("./checkpoints/my_model")),
+])
 def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
     original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
@@ -422,13 +410,10 @@ def test_extend_checkpoint_dir_is_prefixed(input_path, expected):
             os.chdir(original_dir)  # Reset the current directory
 
 
-@pytest.mark.parametrize(
-    "input_path, expected",
-    [
-        (Path("my_model"), Path("checkpoints/my_model")),
-        (Path("my_model"), Path("./checkpoints/my_model")),
-    ],
-)
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("my_model"), Path("checkpoints/my_model")),
+    (Path("my_model"), Path("./checkpoints/my_model")),
+])
 def test_extend_checkpoint_dir(input_path, expected):
     original_dir = Path.cwd()  # Save the current directory
     with TemporaryDirectory() as tmp_dir:
@@ -446,13 +431,10 @@ def test_extend_checkpoint_dir(input_path, expected):
             os.chdir(original_dir)  # Reset the current directory
 
 
-@pytest.mark.parametrize(
-    "input_path, expected",
-    [
-        (Path("my_model"), Path("my_model")),
-        (Path("/my_model"), Path("/my_model")),
-    ],
-)
+@pytest.mark.parametrize("input_path, expected", [
+    (Path("my_model"), Path("my_model")),
+    (Path("/my_model"), Path("/my_model")),
+])
 def test_extend_checkpoint_dir_dont_exist(input_path, expected):
     assert extend_checkpoint_dir(input_path) == expected
 
@@ -505,32 +487,27 @@ def mock_amd_device_properties(monkeypatch):
     monkeypatch.setattr(torch.cuda, "get_device_properties", lambda idx: mock_device_properties)
 
 
+
 @pytest.fixture
 def all_nvlink_connected_output():
-    return mock.MagicMock(
-        stdout="""        GPU0	GPU1	GPU2	GPU3
+    return mock.MagicMock(stdout="""        GPU0	GPU1	GPU2	GPU3
 GPU0	X	NV12	NV12	NV12
 GPU1	NV12	X	NV12	NV12
 GPU2	NV12	NV12	X	NV12
-GPU3	NV12	NV12	NV12	X""",
-        returncode=0,
-    )
+GPU3	NV12	NV12	NV12	X""", returncode=0)
 
 
 @mock.patch("subprocess.run")
-def test_all_nvlink_connected(
-    mock_run, all_nvlink_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
-):
+def test_all_nvlink_connected(mock_run, all_nvlink_connected_output):
     mock_run.return_value = all_nvlink_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-    mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
+        mock_print.assert_any_call("All GPUs are fully connected via NVLink.")
 
 
 @pytest.fixture
 def nvlink_partially_connected_output():
-    return mock.MagicMock(
-        stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity
+    return mock.MagicMock(stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity
 GPU0     X      NV1     SYS     SYS     0-7
 GPU1    NV1      X      SYS     SYS     0-7
 GPU2    SYS     SYS      X      NV1     8-15
@@ -539,28 +516,23 @@ GPU3    SYS     SYS     NV1      X      8-15
 Legend:
   X   = Self
   NV1 = Connected via NVLink with 1 hop
-  SYS = Connected via the PCIe or CPU subsystem""",
-        returncode=0,
-    )
+  SYS = Connected via the PCIe or CPU subsystem""", returncode=0)
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_partially_connected_output(
-    mock_run, nvlink_partially_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
-):
+def test_nvlink_partially_connected_output(mock_run, nvlink_partially_connected_output):
     mock_run.return_value = nvlink_partially_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-    mock_print.assert_any_call(
-        "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
-        "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
-    )
+        mock_print.assert_any_call(
+            "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
+            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+        )
 
 
 @pytest.fixture
 def nvlink_not_connected_output():
-    return mock.MagicMock(
-        stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity    NUMA Affinity   GPU NUMA ID
+    return mock.MagicMock(stdout="""        GPU0    GPU1    GPU2    GPU3    CPU Affinity    NUMA Affinity   GPU NUMA ID
 GPU0     X      PHB     PHB     PHB     0-47    0               N/A
 GPU1    PHB      X      PHB     PHB     0-47    0               N/A
 GPU2    PHB     PHB      X      PHB     0-47    0               N/A
@@ -574,28 +546,23 @@ Legend:
   PHB  = Connection traversing PCIe as well as a PCIe Host Bridge (typically the CPU)
   PXB  = Connection traversing multiple PCIe bridges (without traversing the PCIe Host Bridge)
   PIX  = Connection traversing at most a single PCIe bridge
-  NV#  = Connection traversing a bonded set of # NVLinks""",
-        returncode=0,
-    )
+  NV#  = Connection traversing a bonded set of # NVLinks""", returncode=0)
 
 
 @mock.patch("subprocess.run")
-def test_nvlink_not_connected_output(
-    mock_run, nvlink_not_connected_output, mock_cuda_is_available_true, mock_nvidia_device_properties
-):
+def test_nvlink_not_connected_output(mock_run, nvlink_not_connected_output):
     mock_run.return_value = nvlink_not_connected_output
     with mock.patch("builtins.print") as mock_print:
         check_nvlink_connectivity()
-    mock_print.assert_any_call(
-        "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
-        "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
-    )
+        mock_print.assert_any_call(
+            "Warning: Not all GPUs are fully connected via NVLink. Some GPUs are connected via slower interfaces. "
+            "It is recommended to switch to a different machine with faster GPU connections for optimal multi-GPU training performance."
+        )
 
 
 @pytest.fixture
 def nvlink_all_gpu_connected_but_other_connected_output():
-    return mock.MagicMock(
-        stdout="""	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	NIC2	NIC3	NIC4	NIC5	NIC6	NIC7	NIC8	NIC9	CPU Affinity	NUMA Affinity	GPU NUMA ID
+    return mock.MagicMock(stdout="""	GPU0	GPU1	GPU2	GPU3	GPU4	GPU5	GPU6	GPU7	NIC0	NIC1	NIC2	NIC3	NIC4	NIC5	NIC6	NIC7	NIC8	NIC9	CPU Affinity	NUMA Affinity	GPU NUMA ID
 GPU0	X 	NV12	NV12	NV12	NV12	NV12	NV12	NV12	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
 GPU1	NV12	X 	NV12	NV12	NV12	NV12	NV12	NV12	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
 GPU2	NV12	NV12	X 	NV12	NV12	NV12	NV12	NV12	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	0-63,128-191	0		N/A
@@ -604,16 +571,16 @@ GPU4	NV12	NV12	NV12	NV12	X 	NV12	NV12	NV12	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	P
 GPU5	NV12	NV12	NV12	NV12	NV12	X 	NV12	NV12	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	64-127,192-254	1		N/A
 GPU6	NV12	NV12	NV12	NV12	NV12	NV12	X 	NV12	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	64-127,192-254	1		N/A
 GPU7	NV12	NV12	NV12	NV12	NV12	NV12	NV12	X 	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	64-127,192-254	1		N/A
-NIC0	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS
-NIC1	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS
-NIC2	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS	SYS	SYS
-NIC3	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS	SYS	SYS
-NIC4	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS
-NIC5	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS
-NIC6	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS
-NIC7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS
-NIC8	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB
-NIC9	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X
+NIC0	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS				
+NIC1	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS				
+NIC2	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS	SYS	SYS				
+NIC3	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS	SYS	SYS				
+NIC4	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	X 	PXB	SYS	SYS	SYS	SYS				
+NIC5	SYS	SYS	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	PXB	X 	SYS	SYS	SYS	SYS				
+NIC6	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PIX	SYS	SYS				
+NIC7	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PIX	X 	SYS	SYS				
+NIC8	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	X 	PXB				
+NIC9	SYS	SYS	SYS	SYS	PXB	PXB	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	SYS	PXB	X 				
 
 Legend:
 
@@ -638,9 +605,7 @@ NIC Legend:
   NIC8: mlx5_8
   NIC9: mlx5_9
 
-""",
-        returncode=0,
-    )
+""", returncode=0)
 
 
 @mock.patch("subprocess.run")
@@ -742,7 +707,7 @@ def test_check_nvlink_connectivity__returns_unrecognized_vendor_when_unrecognize
 
 def test_fix_and_load_json():
     # Test 1: Invalid JSON string with a trailing comma
-    invalid_json_trailing_comma = """
+    invalid_json_trailing_comma = '''
     {
       "_from_model_config": true,
       "bos_token_id": 128000,
@@ -752,7 +717,7 @@ def test_fix_and_load_json():
       "temperature": 0.6,
       "top_p": 0.9,
     }
-    """
+    '''
 
     expected_output_trailing_comma = {
         "_from_model_config": True,
@@ -761,14 +726,14 @@ def test_fix_and_load_json():
         "transformers_version": "4.45.0.dev0",
         "do_sample": True,
         "temperature": 0.6,
-        "top_p": 0.9,
+        "top_p": 0.9
     }
 
     result_trailing_comma = fix_and_load_json(invalid_json_trailing_comma)
     assert result_trailing_comma == expected_output_trailing_comma
 
     # Test 2: Invalid JSON string with missing commas between properties
-    invalid_json_missing_commas = """
+    invalid_json_missing_commas = '''
     {
       "_from_model_config": true,
       "bos_token_id": 128000,
@@ -778,7 +743,7 @@ def test_fix_and_load_json():
       "temperature": 0.6,
       "top_p": 0.9,
     }
-    """
+    '''
 
     expected_output_missing_commas = {
         "_from_model_config": True,
@@ -787,7 +752,7 @@ def test_fix_and_load_json():
         "transformers_version": "4.45.0.dev0",
         "do_sample": True,
         "temperature": 0.6,
-        "top_p": 0.9,
+        "top_p": 0.9
     }
 
     result_missing_commas = fix_and_load_json(invalid_json_missing_commas)


### PR DESCRIPTION
PR adds AMD support via the following:
- split nvlink check logic to branch on device name, as reported by torch - it looks for amd in the device name and uses `rocm-smi --showtopotype` instead of the nvidia-smi one, for AMD.
- rewrite the `build_rope_cache` to use a vectorized approach instead of indexing into the nonzero mask - ~I did not bench performance vs. main, but~ should be quicker as well as a bonus. The previous code did not work on my hardware, probably due to device detection issues, and resulted in `build_rope_cache` receiving `device=None` which then tries the nonzero indexing on the `meta` device and fails because of missing custom kernels :man_shrugging: 
- ~added debug prints in `build_rope_cache`, since there was no logger (will remove once reviewed, if you have preferences on how to log, let me know)~
- ~reformatted the edited files via isort and black - let me know if you prefer the unlinted versions. Alternatively we could add the optional pre-commit in a separate PR~

tests results on my machine (linux with a 4090):
```
1337 passed, 40 skipped, 70 xfailed, 2 xpassed, 381 warnings in 430.23s (0:07:10) ========================================================
```

Testing `finetune_lora` with llama 3.1 8B  on a 8xMI250X node and seems to run so far with ~65-75% utilization. I am frankly quite shocked this runs quicker than our accelerate FSDP out of the box :)
![Screenshot from 2024-10-05 18-08-42](https://github.com/user-attachments/assets/0ba370bf-503b-446e-b157-cadf94542a20)



