### PR TITLE
Use correct Llama 3.1 and 3.2 context lengths

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -881,7 +881,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-8B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-8B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=32,
@@ -900,7 +900,7 @@ llama_3 = [
     dict(
         name="Llama-3-70B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3-70B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=80,
@@ -919,7 +919,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-70B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-70B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=80,
@@ -959,7 +959,7 @@ llama_3 = [
     dict(
         name="Llama-3.2-1B{}",
         hf_config=dict(org="meta-llama", name="Llama-3.2-1B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=16,
@@ -979,7 +979,7 @@ llama_3 = [
     dict(
         name="Llama-3.2-3B{}",
         hf_config=dict(org="meta-llama", name="Llama-3.2-3B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=28,

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -900,7 +900,7 @@ llama_3 = [
     dict(
         name="Llama-3-70B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3-70B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=80,

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -881,7 +881,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-8B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-8B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=32,
@@ -919,7 +919,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-70B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-70B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=80,
@@ -939,7 +939,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-405B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-405B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=126,
@@ -959,7 +959,7 @@ llama_3 = [
     dict(
         name="Llama-3.2-1B{}",
         hf_config=dict(org="meta-llama", name="Llama-3.2-1B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=16,
@@ -979,7 +979,7 @@ llama_3 = [
     dict(
         name="Llama-3.2-3B{}",
         hf_config=dict(org="meta-llama", name="Llama-3.2-3B{}"),
-        block_size=131072,
+        block_size=8192,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=28,


### PR DESCRIPTION
Before, Llama 3.1 and 3.2 used a shorter max supported context length that would actually be supported by the new rope settings.