### PR TITLE
Be more specific about missign RoPE parameters

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -129,8 +129,9 @@ class GPT(nn.Module):
                 }
             else:
                 # Some but not all parameters are specified; raise an error
+                missing_params = [param for param, present in zip(adjusted_params_required, params_present) if not present]
                 raise ValueError(
-                    "The following adjusted RoPE parameters are missing in rope_adjustments."
+                    f"The following adjusted RoPE parameters are missing in rope_adjustments: {', '.join(missing_params)}. "
                     "All adjusted RoPE parameters must be specified together."
                 )
 


### PR DESCRIPTION
Suggests which parameters are missing if some of the new extra RoPE parameters are used (as suggested by @Andrei-Aksionov )