### PR TITLE
Fixing Llama 3.1 and 3.2 Maximum Context Length

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -881,7 +881,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-8B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-8B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=32,
@@ -919,7 +919,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-70B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-70B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=80,
@@ -939,7 +939,7 @@ llama_3 = [
     dict(
         name="Llama-3.1-405B{}",
         hf_config=dict(org="meta-llama", name="Meta-Llama-3.1-405B{}"),
-        block_size=8192,
+        block_size=131072,
         vocab_size=128000,
         padded_vocab_size=128256,
         n_layer=126,


### PR DESCRIPTION
This bumps the maximum context length for the Llama 3.1 and 3.2 models. (There was an accident with a leftover automerge setting the other day.)