### PR TITLE
Pin to PyTorch 2.4.1

### DIFF
--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -44,8 +44,8 @@ jobs:
 
     - script: |
         pip install --upgrade pip
+        pip uninstall torch  # uninstall so that the latest supported torch version is installed from the .toml file in the next line
         pip install '.[all,test]'
-        pip install -U torch torchvision torchaudio
       displayName: 'Install dependencies'
 
     - bash: |

--- a/.github/azure-gpu-test.yml
+++ b/.github/azure-gpu-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - script: |
         pip install --upgrade pip
-        pip uninstall torch  # uninstall so that the latest supported torch version is installed from the .toml file in the next line
+        pip uninstall torch -y  # uninstall so that the latest supported torch version is installed from the .toml file in the next line
         pip install '.[all,test]'
       displayName: 'Install dependencies'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 dependencies = [
-    "torch>=2.2.0",
+    "torch>=2.2.0,<=2.4.1",
     "numpy<2.0",
     "lightning==2.4.0",
     "jsonargparse[signatures]>=4.30.1,<=4.32.1",    # 4.33 does not seem to be compatible with Python 3.9


### PR DESCRIPTION
Temporarily pin PyTorch to <= 2.4.1 until the Lightning package is updated to support 2.5.0 (used for Bitsandbytes plugin and some others).