### PR TITLE
0.5.2 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.5.2.dev1"
+version = "0.5.2"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },
@@ -35,7 +35,6 @@ test = [
     "transformers>=4.38.0",  # numerical comparisons
     "einops>=0.7.0",
     "protobuf>=4.23.4",
-    "lightning-thunder @ git+https://github.com/Lightning-AI/lightning-thunder/ ; python_version >= '3.10' and sys_platform == 'linux'",
 ]
 all = [
     "bitsandbytes==0.42.0",      # quantization


### PR DESCRIPTION
Bump version so we can make a 0.5.2 release with bug fixes and pinned PyTorch version (until we have PyTorch 2.5 compatibility)