### PR TITLE
Fixed the issue that precision is always "32-true".

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -330,7 +330,6 @@ class LLM(torch.nn.Module):
         if precision is None:
             precision = get_default_supported_precision(training=False)
             precision = "32-true"
-        precision = "32-true"
 
         plugins = None
         if quantize is not None and quantize.startswith("bnb."):


### PR DESCRIPTION
The precision is always "32-true" regardless of the value passed from the parameter, which is incorrect. This PR removes the erroneous extra line:

```
precision = "32-true"
```
