### PR TITLE
Remove hardcoded 32-precision conversion

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -329,7 +329,6 @@ class LLM(torch.nn.Module):
 
         if precision is None:
             precision = get_default_supported_precision(training=False)
-            precision = "32-true"
 
         plugins = None
         if quantize is not None and quantize.startswith("bnb."):


### PR DESCRIPTION
Fixes a bug where the precision was accidentally hardcoded to float 32

Fixes #1814