### PR TITLE
Qwen2.5: fix block size for Coder series

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -1905,7 +1905,7 @@ qwen_2_5_coder = [
     dict(
         name="Qwen2.5-Coder-1.5B{}",
         hf_config=dict(org="Qwen", name="Qwen2.5-Coder-1.5B{}"),
-        block_size=131072,
+        block_size=32768,
         vocab_size=151643,
         padded_vocab_size=151936,
         n_layer=28,
@@ -1947,7 +1947,7 @@ qwen_2_5_coder = [
     dict(
         name="Qwen2.5-Coder-7B{}",
         hf_config=dict(org="Qwen", name="Qwen2.5-Coder-7B{}"),
-        block_size=131072,
+        block_size=32768,
         vocab_size=151643,
         padded_vocab_size=152064,
         n_layer=28,
@@ -1968,7 +1968,7 @@ qwen_2_5_coder = [
     dict(
         name="Qwen2.5-Coder-14B{}",
         hf_config=dict(org="Qwen", name="Qwen2.5-Coder-14B{}"),
-        block_size=131072,
+        block_size=32768,
         vocab_size=151643,
         padded_vocab_size=152064,
         n_layer=48,
@@ -1989,7 +1989,7 @@ qwen_2_5_coder = [
     dict(
         name="Qwen2.5-Coder-32B{}",
         hf_config=dict(org="Qwen", name="Qwen2.5-Coder-32B{}"),
-        block_size=131072,
+        block_size=32768,
         vocab_size=151643,
         padded_vocab_size=152064,
         n_layer=64,


### PR DESCRIPTION
Block size for Qwen2.5 Coder series is wrongly specified.

Correct block size is 32768 across all model sizes.