### PR TITLE
Several improvements related to KVCache

### DIFF
--- a/litgpt/adapter.py
+++ b/litgpt/adapter.py
@@ -9,7 +9,7 @@ Port for LitGPT
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
@@ -28,56 +28,9 @@ class Config(BaseConfig):
 
 
 class GPT(BaseModel):
-    """The implementation is identical to `litgpt.model.GPT` with the exception that
-    the `Block` saves the layer index and passes it down to the attention layer."""
-
-    def __init__(self, config: Config) -> None:
-        nn.Module.__init__(self)
-        assert config.padded_vocab_size is not None
-        self.config = config
-
-        self.lm_head = nn.Linear(config.n_embd, config.padded_vocab_size, bias=config.lm_head_bias)
-        self.transformer = nn.ModuleDict(
-            dict(
-                wte=nn.Embedding(config.padded_vocab_size, config.n_embd),
-                h=nn.ModuleList(Block(config, i) for i in range(config.n_layer)),
-                ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
-            )
-        )
-        self.max_seq_length = self.config.block_size
-        self.mask_cache: Optional[torch.Tensor] = None
-
-    def forward(
-        self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None, lm_head_chunk_size: int = 0
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        T = idx.size(1)
-        if self.max_seq_length < T:
-            raise ValueError(f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}.")
-
-        if input_pos is not None:  # use the kv cache
-            cos = self.cos.index_select(0, input_pos)
-            sin = self.sin.index_select(0, input_pos)
-            if self.mask_cache is None:
-                raise TypeError("You need to call `gpt.set_kv_cache()`")
-            mask = self.mask_cache.index_select(2, input_pos)
-        else:
-            cos = self.cos[:T]
-            sin = self.sin[:T]
-            mask = None
-
-        x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
-        if self.config.scale_embeddings:
-            x = x * (self.config.n_embd**0.5)
-        for block in self.transformer.h:
-            x = block(x, cos, sin, mask, input_pos)
-        x = self.transformer.ln_f(x)
-        if lm_head_chunk_size > 0:
-            # chunk the lm head logits to reduce the peak memory used by autograd
-            return [self.lm_head(x_i) for x_i in x.split(lm_head_chunk_size, dim=1)]
-        x = self.lm_head(x)  # (b, t, vocab_size)
-        if self.config.final_logit_softcapping is not None:
-            x = torch.tanh(x / self.config.final_logit_softcapping) * self.config.final_logit_softcapping
-        return x
+    @staticmethod
+    def create_block(config: BaseConfig, block_idx: int) -> BaseBlock:
+        return Block(config, block_idx)
 
     @classmethod
     def from_name(cls, name: str, **kwargs: Any) -> Self:
@@ -91,30 +44,9 @@ class GPT(BaseModel):
 
 
 class Block(BaseBlock):
-    """The implementation is identical to `litgpt.model.Block` with the exception that
-    we replace the attention layer where adaption is implemented."""
-
-    def __init__(self, config: Config, block_idx: int) -> None:
-        # Skip the parent class __init__ altogether and replace it to avoid useless allocations
-        nn.Module.__init__(self)
-        if not config.parallel_residual and config.shared_attention_norm:
-            raise NotImplementedError(
-                "No checkpoint amongst the ones we support uses this configuration:"
-
-                " non-parallel residual and shared attention norm."
-            )
-        self.norm_1 = config.norm_class(config.n_embd, eps=config.norm_eps)
-        self.attn = CausalSelfAttention(config, block_idx)
-        self.post_attention_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_attention_norm else nn.Identity()
-        )
-        self.norm_2 = None if config.shared_attention_norm else config.norm_class(config.n_embd, eps=config.norm_eps)
-        self.mlp = config.mlp_class(config)
-        self.post_mlp_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_mlp_norm else nn.Identity()
-        )
-
-        self.config = config
+    @staticmethod
+    def create_self_attention(config: BaseConfig, block_idx: int) -> BaseCausalSelfAttention:
+        return CausalSelfAttention(config, block_idx)
 
 
 class CausalSelfAttention(BaseCausalSelfAttention):
@@ -130,11 +62,6 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             self.gating_factor = torch.nn.Parameter(torch.zeros(1, 1, config.n_head, 1))
             # kv cache for inference
             self.adapter_kv_cache: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
-        self.block_idx = block_idx
-        self.apply_sliding_window_attention = (
-            config.sliding_window_size is not None and
-            block_idx % config.sliding_window_layer_placing == 0
-        )
         self.config = config
 
     def scaled_dot_product_attention(

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -4,7 +4,7 @@ import sys
 import time
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Literal, Optional, Tuple, List, Union, Iterator
+from typing import Any, Literal, Optional, Tuple, List, Union, Iterator, Dict
 import warnings
 
 import lightning as L
@@ -73,14 +73,22 @@ def sample(
     return torch.argmax(logits, dim=-1, keepdim=True)
 
 
-def next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, **kwargs: Any) -> torch.Tensor:
-    logits = model(x, input_pos)
-    _next = sample(logits, **kwargs).to(dtype=torch.int64)
+def next_token(
+    model: GPT,
+    input_pos: torch.Tensor,
+    x: torch.Tensor,
+    input_pos_maxp1: Optional[int] = None,
+    **sample_kwargs: Dict[str, Any],
+) -> torch.Tensor:
+    logits = model(x, input_pos, input_pos_maxp1=input_pos_maxp1)
+    _next = sample(logits, **sample_kwargs).to(dtype=torch.int64)
     return _next
+
 
 def batched_sample(logits: list[torch.Tensor], kwargs: list[dict]) -> torch.Tensor:
     assert len(logits) == len(kwargs), "logits and kwargs must have the same length."
     return torch.stack([sample(l, **sample_args).to(dtype=torch.int64) for sample_args, l in zip(kwargs, logits)], dim=0)
+
 
 def batched_next_token(model: GPT, input_pos: torch.Tensor, x: torch.Tensor, kwargs: Union[dict, list[dict]]) -> torch.Tensor:
     # Where:
@@ -166,10 +174,19 @@ def generate_fn(
     token = prompt
     prefill_token = True
     input_pos = torch.arange(0, prompt_size, device=device, dtype=torch.int64)
+    input_pos_maxp1 = prompt_size
     for current_idx in range(max_returned_tokens - prompt_size):
 
         # Generate the token
-        token = next_token(model, input_pos, token.view(1, -1), temperature=temperature, top_k=top_k, top_p=top_p)
+        token = next_token(
+            model,
+            input_pos,
+            token.view(1, -1),
+            input_pos_maxp1=input_pos_maxp1,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
         tokens.append(token)
         int_token = token.item()
 
@@ -205,6 +222,7 @@ def generate_fn(
             input_pos = torch.tensor([prompt_size], device=device, dtype=torch.int64)
         else:
             input_pos.add_(1)
+        input_pos_maxp1 += 1
 
     # Yield any remaining tokens
     if yielded_idx < len(tokens):

--- a/litgpt/lora.py
+++ b/litgpt/lora.py
@@ -45,7 +45,7 @@ two matrices of a lower rank.
 
 import math
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Tuple, Type, Union, Optional
 
 import torch
 import torch.nn as nn
@@ -57,7 +57,6 @@ from litgpt.config import Config as BaseConfig
 from litgpt.model import GPT as BaseModel
 from litgpt.model import Block as BaseBlock
 from litgpt.model import CausalSelfAttention as BaseCausalSelfAttention
-from litgpt.model import KVCache
 from litgpt.utils import map_old_state_dict_weights
 
 
@@ -501,60 +500,15 @@ class Config(BaseConfig):
 
 
 class GPT(BaseModel):
-    def __init__(self, config: Config) -> None:
-        nn.Module.__init__(self)
-        assert config.padded_vocab_size is not None
-        self.config = config
+    @staticmethod
+    def create_block(config: Config, block_idx: int) -> "Block":
+        return Block(config, block_idx)
 
-        self.lm_head = LoRALinear(
-            config.n_embd,
-            config.padded_vocab_size,
-            bias=config.lm_head_bias,
-            r=(config.lora_r if config.lora_head else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
+    @staticmethod
+    def create_lm_head(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config.n_embd, config.padded_vocab_size, bias=config.lm_head_bias
         )
-        self.transformer = nn.ModuleDict(
-            dict(
-                wte=nn.Embedding(config.padded_vocab_size, config.n_embd),
-                h=nn.ModuleList(Block(config, block_idx) for block_idx in range(config.n_layer)),
-                ln_f=config.norm_class(config.n_embd, eps=config.norm_eps),
-            )
-        )
-        self.max_seq_length = self.config.block_size
-        self.mask_cache: Optional[torch.Tensor] = None
-
-    def forward(
-        self, idx: torch.Tensor, input_pos: Optional[torch.Tensor] = None, lm_head_chunk_size: int = 0
-    ) -> Union[torch.Tensor, List[torch.Tensor]]:
-        T = idx.size(1)
-        if self.max_seq_length < T:
-            raise ValueError(f"Cannot forward sequence of length {T}, max seq length is only {self.max_seq_length}.")
-
-        if input_pos is not None:  # use the kv cache
-            cos = self.cos.index_select(0, input_pos)
-            sin = self.sin.index_select(0, input_pos)
-            if self.mask_cache is None:
-                raise TypeError("You need to call `gpt.set_kv_cache()`")
-            mask = self.mask_cache.index_select(2, input_pos)
-        else:
-            cos = self.cos[:T]
-            sin = self.sin[:T]
-            mask = None
-
-        x = self.transformer.wte(idx)  # token embeddings of shape (b, t, n_embd)
-        if self.config.scale_embeddings:
-            x = x * (self.config.n_embd**0.5)
-        for block in self.transformer.h:
-            x = block(x, cos, sin, mask, input_pos)
-        x = self.transformer.ln_f(x)
-        if lm_head_chunk_size > 0:
-            # chunk the lm head logits to reduce the peak memory used by autograd
-            return [self.lm_head(x_i) for x_i in x.split(lm_head_chunk_size, dim=1)]
-        x = self.lm_head(x)  # (b, t, vocab_size)
-        if self.config.final_logit_softcapping is not None:
-            x = torch.tanh(x / self.config.final_logit_softcapping) * self.config.final_logit_softcapping
-        return x
 
     @classmethod
     def from_name(cls, name: str, **kwargs: Any) -> Self:
@@ -574,35 +528,16 @@ class GPT(BaseModel):
 
 
 class Block(BaseBlock):
-    def __init__(self, config: Config, block_idx: int) -> None:
-        nn.Module.__init__(self)
-        if not config.parallel_residual and config.shared_attention_norm:
-            raise NotImplementedError(
-                "No checkpoint amongst the ones we support uses this configuration:"
-                " non-parallel residual and shared attention norm."
-            )
-        self.norm_1 = config.norm_class(config.n_embd, eps=config.norm_eps)
-        self.attn = CausalSelfAttention(config, block_idx)
-        self.post_attention_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_attention_norm else nn.Identity()
-        )
-        self.norm_2 = None if config.shared_attention_norm else config.norm_class(config.n_embd, eps=config.norm_eps)
-        self.mlp = config.mlp_class(config)
-        self.post_mlp_norm = (
-            config.norm_class(config.n_embd, eps=config.norm_eps) if config.post_mlp_norm else nn.Identity()
-        )
-
-        self.config = config
+    @staticmethod
+    def create_self_attention(config: Config, block_idx: int) -> "CausalSelfAttention":
+        return CausalSelfAttention(config, block_idx)
 
 
 class CausalSelfAttention(BaseCausalSelfAttention):
-    def __init__(self, config: Config, block_idx: int) -> None:
-        # Skip the parent class __init__ altogether and replace it to avoid
-        # useless allocations
-        nn.Module.__init__(self)
+    @staticmethod
+    def create_qkv_linear(config: Config) -> nn.Module:
         shape = (config.n_head + 2 * config.n_query_groups) * config.head_size
-        # key, query, value projections for all heads, but in a batch
-        self.attn = LoRAQKVLinear(
+        return LoRAQKVLinear(
             in_features=config.n_embd,
             out_features=shape,
             r=config.lora_r,
@@ -615,24 +550,14 @@ class CausalSelfAttention(BaseCausalSelfAttention):
             n_head=config.n_head,
             n_query_groups=config.n_query_groups,
         )
-        # output projection
-        # if `head_size` is explicitly specified in the config, `n_emd` might not be equal to `head_size * n_head`
-        self.proj = LoRALinear(
-            config.head_size * config.n_head,
-            config.n_embd,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_projection else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
-        )
-        # disabled by default
-        self.kv_cache: Optional[KVCache] = None
-        self.apply_sliding_window_attention = (
-            config.sliding_window_size is not None and
-            block_idx % config.sliding_window_layer_placing == 0
-        )
 
-        self.config = config
+    @staticmethod
+    def create_output_projection(config: Config) -> nn.Module:
+        # if `head_size` is explicitly specified in the config, `n_emd` might
+        # not be equal to `head_size * n_head`
+        return create_lora_linear(
+            config.head_size * config.n_head, config.n_embd,
+        )
 
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""
@@ -646,27 +571,36 @@ class CausalSelfAttention(BaseCausalSelfAttention):
         super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
 
+def create_lora_linear(
+    config: Config,
+    in_size: int,
+    out_size: int,
+    bias: Optional[Union[float, bool]] = None,
+) -> LoRALinear:
+    if bias is None:
+        bias = config.bias
+    return LoRALinear(
+        in_size,
+        out_size,
+        bias=bias,
+        r=(config.lora_r if config.lora_mlp else 0),
+        lora_alpha=config.lora_alpha,
+        lora_dropout=config.lora_dropout,
+    )
+
+
 class GptNeoxMLP(litgpt.model.GptNeoxMLP):
-    def __init__(self, config: Config) -> None:
-        nn.Module.__init__(self)
-        self.fc = LoRALinear(
-            config.n_embd,
-            config.intermediate_size,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
-        )
-        self.proj = LoRALinear(
-            config.intermediate_size,
-            config.n_embd,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
+    @staticmethod
+    def create_fc(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config, config.n_embd, config.intermediate_size
         )
 
-        self.config = config
+    @staticmethod
+    def create_proj(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config, config.intermediate_size, config.n_embd
+        )
 
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""
@@ -681,34 +615,17 @@ class GptNeoxMLP(litgpt.model.GptNeoxMLP):
 
 
 class LLaMAMLP(litgpt.model.LLaMAMLP):
-    def __init__(self, config: Config) -> None:
-        nn.Module.__init__(self)
-        self.fc_1 = LoRALinear(
-            config.n_embd,
-            config.intermediate_size,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
-        )
-        self.fc_2 = LoRALinear(
-            config.n_embd,
-            config.intermediate_size,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
-        )
-        self.proj = LoRALinear(
-            config.intermediate_size,
-            config.n_embd,
-            bias=config.bias,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
+    @staticmethod
+    def create_fc(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config, config.n_embd, config.intermediate_size
         )
 
-        self.config = config
+    @staticmethod
+    def create_proj(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config, config.intermediate_size, config.n_embd
+        )
 
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""
@@ -733,19 +650,15 @@ class GemmaMLP(LLaMAMLP):
 
 
 class LLaMAMoE(litgpt.model.LLaMAMoE):
-    def __init__(self, config: Config) -> None:
-        nn.Module.__init__(self)
-        self.gate = LoRALinear(
-            config.n_embd,
-            config.n_expert,
-            bias=False,
-            r=(config.lora_r if config.lora_mlp else 0),
-            lora_alpha=config.lora_alpha,
-            lora_dropout=config.lora_dropout,
+    @staticmethod
+    def create_gate(config: Config) -> nn.Module:
+        return create_lora_linear(
+            config, config.n_embd, config.n_expert, bias=False
         )
-        self.experts = nn.ModuleList(LLaMAMLP(config) for _ in range(config.n_expert))
 
-        self.config = config
+    @staticmethod
+    def create_experts(config: Config) -> nn.ModuleList:
+        return nn.ModuleList(LLaMAMLP(config) for _ in range(config.n_expert))
 
     def _load_from_state_dict(self, state_dict: Dict, prefix: str, *args: Any, **kwargs: Any) -> None:
         """For compatibility with base checkpoints."""

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -358,7 +358,6 @@ def get_default_supported_precision(training: bool) -> str:
 
     Args:
         training: If True, returns '-mixed' version of the precision; if False, returns '-true' version.
-        use_mps: Flag to determine if MPS should be used when available.
 
     Returns:
         The default precision that is suitable for the task and is supported by the hardware.

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -13,7 +13,7 @@ from litgpt.model import apply_rope, build_rope_cache
 @torch.inference_mode()
 def test_rope_gptneox():
     bs, seq_len, n_head, n_embed = 1, 6, 2, 8
-    head_size = n_embed // n_head
+    head_size = n_embed // n_head  # 4
     x = torch.randint(0, 10000, size=(bs, n_head, seq_len, head_size)).float()
     position_ids = torch.arange(seq_len).unsqueeze(0)
 
@@ -21,9 +21,10 @@ def test_rope_gptneox():
     theirs_cos, theirs_sin = theirs_rot_emb(x, position_ids)
 
     ours_cos_cached, ours_sin_cached = build_rope_cache(seq_len, head_size, device=x.device)
-    # their rope cache has 2 added dimensions and the cos/sin is duplicated
-    torch.testing.assert_close(ours_cos_cached, theirs_cos.squeeze())
-    torch.testing.assert_close(ours_sin_cached, theirs_sin.squeeze())
+    ours_cos_cached = ours_cos_cached.unsqueeze(0)
+    ours_sin_cached = ours_sin_cached.unsqueeze(0)
+    torch.testing.assert_close(ours_cos_cached, theirs_cos)
+    torch.testing.assert_close(ours_sin_cached, theirs_sin)
 
     ours_x_rope = apply_rope(x, ours_cos_cached, ours_sin_cached)
     theirs_x_rope, _ = apply_rotary_pos_emb_gptneo(x, x, theirs_cos, theirs_sin, position_ids)
@@ -47,8 +48,10 @@ def test_rope_llama_2():
 
     # our rope
     ours_cos, ours_sin = build_rope_cache(seq_len, n_elem=head_dim, base=rope_theta)
-    torch.testing.assert_close(theirs_cos.squeeze(0), ours_cos)
-    torch.testing.assert_close(theirs_sin.squeeze(0), ours_sin)
+    ours_cos = ours_cos.unsqueeze(0)
+    ours_sin = ours_sin.unsqueeze(0)
+    torch.testing.assert_close(theirs_cos, ours_cos)
+    torch.testing.assert_close(theirs_sin, ours_sin)
 
     ##################################
     # Compare rotated tensors
@@ -86,8 +89,10 @@ def test_rope_llama_3():
 
     # our rope
     ours_cos, ours_sin = build_rope_cache(seq_len, n_elem=head_dim, base=rope_theta)
-    torch.testing.assert_close(theirs_cos.squeeze(0), ours_cos)
-    torch.testing.assert_close(theirs_sin.squeeze(0), ours_sin)
+    ours_cos = ours_cos.unsqueeze(0)
+    ours_sin = ours_sin.unsqueeze(0)
+    torch.testing.assert_close(theirs_cos, ours_cos)
+    torch.testing.assert_close(theirs_sin, ours_sin)
 
     ##################################
     # Compare rotated tensors
@@ -146,8 +151,10 @@ def test_rope_llama_3_1():
 
     # our rope
     ours_cos, ours_sin = build_rope_cache(seq_len, n_elem=head_dim, base=rope_theta, extra_config=our_rope_config)
-    torch.testing.assert_close(theirs_cos.squeeze(0), ours_cos)
-    torch.testing.assert_close(theirs_sin.squeeze(0), ours_sin)
+    ours_cos = ours_cos.unsqueeze(0)
+    ours_sin = ours_sin.unsqueeze(0)
+    torch.testing.assert_close(theirs_cos, ours_cos)
+    torch.testing.assert_close(theirs_sin, ours_sin)
 
     ##################################
     # Compare rotated tensors
@@ -206,8 +213,10 @@ def test_rope_llama_3_2():
 
     # our rope
     ours_cos, ours_sin = build_rope_cache(seq_len, n_elem=head_dim, base=rope_theta, extra_config=our_rope_config)
-    torch.testing.assert_close(theirs_cos.squeeze(0), ours_cos)
-    torch.testing.assert_close(theirs_sin.squeeze(0), ours_sin)
+    ours_cos = ours_cos.unsqueeze(0)
+    ours_sin = ours_sin.unsqueeze(0)
+    torch.testing.assert_close(theirs_cos, ours_cos)
+    torch.testing.assert_close(theirs_sin, ours_sin)
 
     ##################################
     # Compare rotated tensors
@@ -225,4 +234,24 @@ def test_rope_llama_3_2():
     theirs_q_rot, theirs_k_rot = apply_rotary_pos_emb_llama(queries, keys, theirs_cos, theirs_sin)
     torch.testing.assert_close(theirs_q_rot, ours_q_rot)
     torch.testing.assert_close(theirs_k_rot, ours_k_rot)
-    
+
+@torch.inference_mode()
+def test_rope_cos_sin_shapes_if_rope_n_elem_is_odd():
+    bs, seq_len, n_head, n_embed = 1, 6, 2, 8
+    head_size = n_embed // n_head  # 4
+    rotary_percentage = 0.75
+    rope_n_elem = int(head_size * rotary_percentage)  # 3
+    ours_cos, ours_sin = build_rope_cache(seq_len, rope_n_elem)
+    required_shape = (seq_len, rope_n_elem)
+    assert ours_cos.shape == required_shape
+    assert ours_sin.shape == required_shape
+    # Special case: If `rope_n_elem == 1`, the shape is extended. This is to
+    # accommodate a current bug in Hugging Face, ensuring that other unit tests
+    # pass.
+    # https://github.com/huggingface/transformers/issues/35233
+    rotary_percentage = 0.25
+    rope_n_elem = int(head_size * rotary_percentage)  # 1
+    ours_cos, ours_sin = build_rope_cache(seq_len, rope_n_elem)
+    required_shape = (seq_len, rope_n_elem + 1)
+    assert ours_cos.shape == required_shape
+    assert ours_sin.shape == required_shape


### PR DESCRIPTION
Implements what is asked for in #1867.

- Ensure that `KVCache` buffers are only as large as `config.n_query_groups`
- Shrink buffers returned by `KVCache` to just cover `input_pos` entries
- Refactor child classes of `model.py` classes to avoid copy and paste

Also adding comments, docstrings here and there.