### PR TITLE
Set torch.load(..., `weights_only=False`) in litgpt/api.py

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -386,7 +386,7 @@ class LLM(torch.nn.Module):
             model.eval()
 
             if generate_strategy == "sequential":
-                state_dict = torch.load(str(self.checkpoint_dir / "lit_model.pth"), mmap=True, map_location="cpu")
+                state_dict = torch.load(str(self.checkpoint_dir / "lit_model.pth"), mmap=True, map_location="cpu", weights_only=False)
                 model.load_state_dict(state_dict, assign=True)
                 model = fabric.setup_module(model, move_to_device=False)
 
@@ -405,7 +405,7 @@ class LLM(torch.nn.Module):
                     pbar = tqdm(total=fabric.world_size, desc="Loading model weights")
                 for rank in range(fabric.world_size):
                     if fabric.global_rank == rank:
-                        state_dict = torch.load(str(self.checkpoint_dir / "lit_model.pth"), mmap=True, map_location="cpu")
+                        state_dict = torch.load(str(self.checkpoint_dir / "lit_model.pth"), mmap=True, map_location="cpu", weights_only=False)
                         model.load_state_dict(state_dict, assign=True)
 
                         # cannot use `.setup_module` because it will wrap with DDP


### PR DESCRIPTION
Fixes an [error](https://dev.azure.com/Lightning-AI/lit%20Models/_build/results?buildId=221553&view=logs&j=8f314803-5dd0-5dfc-f80d-9e97f23b827e&t=bc8d09c9-6e7d-5a58-973b-84e67a1cfd78) in Thunder workflow.

Thunder CI workflow uses the latest dev version of PyTorch, where `weights_only=True` will be by default. 
(Now it's `weights_only=False`.)

> FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`

Since LitGPT loads weights from `.pth`, the content of which is controlled by the repo, it's safe to set `weights_only=True`.