### PR TITLE
Temporary remove Thunder to make a release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "safetensors>=0.4.3",               # download models
     "tokenizers>=0.15.2",               # tokenization in most models
     "tqdm>=4.66.0",                     # convert_hf_checkpoint
-    "lightning-thunder @ git+https://github.com/Lightning-AI/lightning-thunder/ ; python_version >= '3.10' and sys_platform == 'linux'",
 ]
 
 [project.urls]


### PR DESCRIPTION
One thing that I didn't notice while looking how Sebastian [usually makes releases](https://github.com/Lightning-AI/litgpt/pull/1815/files), is that we have to temporarily remove Thunder from the list of dependencies.
The last release of Thunder was done in March, but we need the latest version, so the code installs the version from main branch.
That causes an error during building a package: [link](https://github.com/Lightning-AI/litgpt/actions/runs/12466677354/job/34794646118#step:5:192).
This error occurs because PyPI does not allow uploading distributions with direct dependencies specified via URLs (e.g., git+https://...) in `pyproject.toml` or `setup.py`.