### PR TITLE
Post-release setup for 0.5.5.dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litgpt"
-version = "0.5.4"
+version = "0.5.5.dev1"
 description = "Hackable implementation of state-of-the-art open-source LLMs"
 authors = [
     { name = "Lightning AI", email = "contact@lightning.ai" },
@@ -17,6 +17,7 @@ dependencies = [
     "safetensors>=0.4.3",               # download models
     "tokenizers>=0.15.2",               # tokenization in most models
     "tqdm>=4.66.0",                     # convert_hf_checkpoint
+    "lightning-thunder @ git+https://github.com/Lightning-AI/lightning-thunder/ ; python_version >= '3.10' and sys_platform == 'linux'",
 ]
 
 [project.urls]


### PR DESCRIPTION
1. Increases version for the new development cycle
2. Restores back Thunder in the list of dependencies after it was removed in #1884 