### PR TITLE
Bump PyTorch, PyTorch-Lightning and BnB versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 license = { file = "LICENSE" }
 
 dependencies = [
-    "torch>=2.2.0,<=2.4.1",
+    "torch>=2.5.0,<2.6.0",
     "numpy<2.0",
-    "lightning==2.4.0",
+    "lightning>=2.5.0,<2.6.0",
     "jsonargparse[signatures]>=4.30.1,<=4.32.1",    # 4.33 does not seem to be compatible with Python 3.9
     "huggingface_hub>=0.23.5",          # download models
     "safetensors>=0.4.3",               # download models

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ test = [
     "protobuf>=4.23.4",
 ]
 all = [
-    "bitsandbytes==0.42.0",      # quantization
+    "bitsandbytes >=0.44.0,<0.44.2; sys_platform == 'linux' or sys_platform == 'win32'", # quantization
+    "bitsandbytes >=0.42.0,<0.43.0 ; sys_platform == 'darwin'", # quantization
     "sentencepiece>=0.2.0",      # llama-based models
     "requests>=2.31.0",          # litgpt.data
     "litdata==0.2.17",           # litgpt.data


### PR DESCRIPTION
In #1796 the PyTorch version was restricted to 2.4.1 and in #1765 to PyTorch-Lightning 2.4.
Now the latest version of PTL is 2.5 and it now supports torch 2.5.
This PR bumps both versions.

Additionally, a newer version of PTL required a newer version of Bitsandbytes.