### PR TITLE
Pin version of mistune in check links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install "mistune<3.1"  # a newer version is incompatible with nbconvert
         pip install pytest pytest-check-links
 
     - name: Check links


### PR DESCRIPTION
A new version of mistune, that is used in check links workflow, has just been updated.
Sadly, it's incompatible with the version of nbconvert used in `pytest-check-links`, which results in this [error](https://github.com/Lightning-AI/litgpt/actions/runs/12549175840/job/34989788262?pr=1894).

This PR restricts from installing the latest version of mistune in the workflow.