### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "torch>=2.5.0,<2.6.0",
     "numpy<2.0",
     "lightning>=2.5.0,<2.6.0",
-    "jsonargparse[signatures]>=4.30.1,<=4.32.1",    # 4.33 does not seem to be compatible with Python 3.9
+    "jsonargparse[signatures]>=4.30.1,<=4.32.1; python_version<='3.9'",    # 4.33 does not seem to be compatible with Python 3.9
+    "jsonargparse[signatures]>=4.37.0; python_version>'3.9'",    # required to work with python3.12+
     "huggingface_hub>=0.23.5",          # download models
     "safetensors>=0.4.3",               # download models
     "tokenizers>=0.15.2",               # tokenization in most models


### PR DESCRIPTION
Add conditional install for jsonargparse for different python version.

Hopefully this is helpful, but I could only test with python 3.10+; if someone has python3.9 handy and can make sure that the proper jsonargparse version is installed, I'd recommend that before accepting the PR.

I ran the pytests in the tests folder, they failed, but they also failed for me on the main branch; maybe there is some config I'm unaware of.