### PR TITLE
handle wrapped thundermodules in generate

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -174,7 +174,9 @@ def generate_fn(
     token = prompt
     prefill_token = True
     input_pos = torch.arange(0, prompt_size, device=device, dtype=torch.int64)
-    if model.__class__.__name__ != 'ThunderModule':
+    # input_pos_maxp1 introduces data-dependent shapes and control flow.
+    # We want to skip if ThunderModules are involved, either directly or wrapped in LightningModule etc.
+    if any(m.__class__.__name__ != 'ThunderModule' for m in model.modules()):
         input_pos_maxp1 = torch.tensor(prompt_size, device=device)
     else:
         input_pos_maxp1 = None


### PR DESCRIPTION
The passing of maxp1 in generate introduces data dependent shapes/control flow which we want to avoid with Thunder.
Currently, we check for ThunderModule, but Fabric wraps a thundermodule.