### PR TITLE
Better clarity on SFT dataset attributes

### DIFF
--- a/tutorials/finetune_adapter.md
+++ b/tutorials/finetune_adapter.md
@@ -120,14 +120,14 @@ If your GPU supports `bfloat16`, the script will automatically use it.
 You can easily train on your own instruction dataset saved in JSON format.
 
 1. Create a JSON file in which each row holds one instruction-response pair.
-   A row has an entry for 'instruction', 'input', and 'output', where 'input' is optional and can be
-   the empty string if the instruction doesn't require a context. Below is an example json file:
+   A row has an entry for 'instruction' and 'output', and optionally 'input'. Note that currently, the 'input' field is only used in the Alpaca chat template. If you are using the Alpaca template, 'input' can be the empty string if the instruction doesn't require a context.
+   Below is an example json file:
 
     ```text
     [
         {
             "instruction": "Arrange the given numbers in ascending order.",
-            "input": "2, 4, 0, 8, 3",
+            "input": "2, 4, 0, 8, 3", // Optional: only used in Alpaca chat template
             "output": "0, 2, 3, 4, 8"
         },
         ...

--- a/tutorials/finetune_full.md
+++ b/tutorials/finetune_full.md
@@ -68,14 +68,14 @@ If your GPU supports `bfloat16`, the script will automatically use it.
 You can easily train on your own instruction dataset saved in JSON format.
 
 1. Create a JSON file in which each row holds one instruction-response pair.
-   A row has an entry for 'instruction', 'input', and 'output', where 'input' is optional and can be
-   the empty string if the instruction doesn't require a context. Below is an example json file:
+   A row has an entry for 'instruction' and 'output', and optionally 'input'. Note that currently, the 'input' field is only used in the Alpaca chat template. If you are using the Alpaca template, 'input' can be the empty string if the instruction doesn't require a context.
+   Below is an example json file:
 
     ```text
     [
         {
             "instruction": "Arrange the given numbers in ascending order.",
-            "input": "2, 4, 0, 8, 3",
+            "input": "2, 4, 0, 8, 3", // Optional: only used in Alpaca chat template
             "output": "0, 2, 3, 4, 8"
         },
         ...

--- a/tutorials/finetune_lora.md
+++ b/tutorials/finetune_lora.md
@@ -95,14 +95,14 @@ If your GPU supports `bfloat16`, you can additionally pass `--precision "bf16-tr
 You can easily train on your own instruction dataset saved in JSON format.
 
 1. Create a JSON file in which each row holds one instruction-response pair.
-   A row has an entry for 'instruction', 'input', and 'output', where 'input' is optional and can be
-   the empty string if the instruction doesn't require a context. Below is an example json file:
+   A row has an entry for 'instruction' and 'output', and optionally 'input'. Note that currently, the 'input' field is only used in the Alpaca chat template. If you are using the Alpaca template, 'input' can be the empty string if the instruction doesn't require a context.
+   Below is an example json file:
 
     ```text
     [
         {
             "instruction": "Arrange the given numbers in ascending order.",
-            "input": "2, 4, 0, 8, 3",
+            "input": "2, 4, 0, 8, 3", // Optional: only used in Alpaca chat template
             "output": "0, 2, 3, 4, 8"
         },
         ...


### PR DESCRIPTION
See #1951

To avoid similar confusions in the future, we should highlight that the "input" attribute is optional and explicitly mention that currently, as far as litgpt chat templates are concerned, it is only ever implemented in the Alpaca chat template.