### PR TITLE
feat: add linear rope type

### DIFF
--- a/litgpt/data/alpaca_2k.py
+++ b/litgpt/data/alpaca_2k.py
@@ -4,8 +4,8 @@
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from litgpt.data.base import SFTDataset
 from litgpt.data.alpaca import Alpaca
+from litgpt.data.base import SFTDataset
 
 
 @dataclass

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -610,7 +610,6 @@ def build_rope_cache(
             else:
                 raise NotImplementedError(f"Not implemented for rope_type={rope_type}")
 
-
     # Create position indices `[0, 1, ..., seq_len - 1]`
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio
 

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -587,19 +587,29 @@ def build_rope_cache(
     theta = 1.0 / (base ** (torch.arange(0, n_elem, 2, device=device).float() / n_elem))
 
     if extra_config is not None:
-        orig_context_len = extra_config["original_max_seq_len"]
-        factor = extra_config["factor"]
-        low_freq_factor = extra_config["low_freq_factor"]
-        high_freq_factor = extra_config["high_freq_factor"]
+        if "rope_type" in extra_config:
+            rope_type = extra_config["rope_type"]
 
-        wavelen = 2 * torch.pi / theta
-        ratio = orig_context_len / wavelen
-        smooth_factor = (ratio - low_freq_factor) / (high_freq_factor - low_freq_factor)
-        smooth_factor = torch.clamp(smooth_factor, min=0.0, max=1.0)
+            if rope_type is None or rope_type == "llama3":
+                orig_context_len = extra_config["original_max_seq_len"]
+                factor = extra_config["factor"]
+                low_freq_factor = extra_config["low_freq_factor"]
+                high_freq_factor = extra_config["high_freq_factor"]
 
-        # Compute adjusted_theta without masked indexing
-        adjusted_theta = (1 - smooth_factor) * (theta / factor) + smooth_factor * theta
-        theta = adjusted_theta
+                wavelen = 2 * torch.pi / theta
+                ratio = orig_context_len / wavelen
+                smooth_factor = (ratio - low_freq_factor) / (high_freq_factor - low_freq_factor)
+                smooth_factor = torch.clamp(smooth_factor, min=0.0, max=1.0)
+
+                # Compute adjusted_theta without masked indexing
+                adjusted_theta = (1 - smooth_factor) * (theta / factor) + smooth_factor * theta
+                theta = adjusted_theta
+            elif rope_type == "linear":
+                factor = extra_config["factor"]
+                theta = theta / factor
+            else:
+                raise NotImplementedError(f"Not implemented for rope_type={rope_type}")
+
 
     # Create position indices `[0, 1, ..., seq_len - 1]`
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -587,10 +587,9 @@ def build_rope_cache(
     theta = 1.0 / (base ** (torch.arange(0, n_elem, 2, device=device).float() / n_elem))
 
     if extra_config is not None:
-        rope_type = extra_config.get("rope_type", "llama3")
-        if rope_type == "llama3":
+        factor = extra_config["factor"]
+        if "original_max_seq_len" in extra_config:
             orig_context_len = extra_config["original_max_seq_len"]
-            factor = extra_config["factor"]
             low_freq_factor = extra_config["low_freq_factor"]
             high_freq_factor = extra_config["high_freq_factor"]
 
@@ -602,11 +601,8 @@ def build_rope_cache(
             # Compute adjusted_theta without masked indexing
             adjusted_theta = (1 - smooth_factor) * (theta / factor) + smooth_factor * theta
             theta = adjusted_theta
-        elif rope_type == "linear":
-            factor = extra_config["factor"]
-            theta = theta / factor
         else:
-            raise NotImplementedError(f"Not implemented for rope_type={rope_type}")
+            theta = theta / factor
 
     # Create position indices `[0, 1, ..., seq_len - 1]`
     seq_idx = torch.arange(seq_len, device=device) / condense_ratio

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -1,8 +1,7 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import pytest
 import torch
-from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
-from transformers.models.gemma3.modeling_gemma3 import Gemma3RotaryEmbedding, apply_rotary_pos_emb
 from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXRotaryEmbedding
 from transformers.models.gpt_neox.modeling_gpt_neox import apply_rotary_pos_emb as apply_rotary_pos_emb_gptneo
 from transformers.models.llama.configuration_llama import LlamaConfig
@@ -221,8 +220,13 @@ def test_rope_llama_3_2():
 
 
 # See https://huggingface.co/google/gemma-3-27b-it/blob/main/config.json for settings
+# TODO: update HF transformers version to support Gemma3 and fix errors that causes after the update
+@pytest.mark.skip(reason="This test fails due to the HF transformers version not supporting Gemma3")
 @torch.inference_mode()
 def test_rope_gemma_3():
+    from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
+    from transformers.models.gemma3.modeling_gemma3 import Gemma3RotaryEmbedding, apply_rotary_pos_emb
+
     head_dim = 32
     rope_theta = 50_000
     their_rope_config = {

--- a/tests/test_rope.py
+++ b/tests/test_rope.py
@@ -1,13 +1,13 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
 import torch
+from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
+from transformers.models.gemma3.modeling_gemma3 import Gemma3RotaryEmbedding
 from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXRotaryEmbedding
 from transformers.models.gpt_neox.modeling_gpt_neox import apply_rotary_pos_emb as apply_rotary_pos_emb_gptneo
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb as apply_rotary_pos_emb_llama
-from transformers.models.gemma3.modeling_gemma3 import Gemma3RotaryEmbedding, apply_rotary_pos_emb
-from transformers.models.gemma3.configuration_gemma3 import Gemma3TextConfig
 
 from litgpt.model import apply_rope, build_rope_cache
 
@@ -219,6 +219,7 @@ def test_rope_llama_3_2():
     torch.testing.assert_close(theirs_q_rot, ours_q_rot)
     torch.testing.assert_close(theirs_k_rot, ours_k_rot)
 
+
 # See https://huggingface.co/google/gemma-3-27b-it/blob/main/config.json for settings
 @torch.inference_mode()
 def test_rope_gemma_3():
@@ -248,6 +249,7 @@ def test_rope_gemma_3():
     ours_sin = ours_sin.unsqueeze(0)
     torch.testing.assert_close(theirs_cos, ours_cos)
     torch.testing.assert_close(theirs_sin, ours_sin)
+
 
 @torch.inference_mode()
 def test_rope_cos_sin_shapes_if_rope_n_elem_is_odd():


### PR DESCRIPTION
Gemma3 uses the following config for rope:
```
    "rope_scaling": {
      "factor": 8.0,
      "rope_type": "linear"
    },
```

I added a linear rope type within `extra_configs` so that it can properly calculate theta.

Currently the HF transformer version does not have Gemma3, so it is skipped for pytest. With the newest version, it passes the test: see [here](https://www.loom.com/share/c4f69e1f3c5244a18d19734f24e9f9bb?sid=3926848e-fe94-472a-9389-99bdcd96110a).