### PR TITLE
fix: replace sliding window configuration parameters to sliding windows indices

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -3,7 +3,9 @@ name: CPU tests
 on:
   push:
     branches: [main]
-  pull_request: {}
+  pull_request_target:
+    branches: [main]
+    types: [opened, reopened, ready_for_review, labeled, synchronize]
   workflow_dispatch: {}
 
 concurrency:
@@ -31,6 +33,11 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -59,11 +66,16 @@ jobs:
         os: ["ubuntu-22.04"]
         python-version: ["3.9", "3.10", "3.11"]
         include:
-          - { os: "macOS-14", python-version: "3.9" } # without Thunder
-          - { os: "windows-2022", python-version: "3.9" } # without Thunder
+          - { os: "macOS-14", python-version: "3.9" }
+          - { os: "windows-2022", python-version: "3.9" }
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -71,15 +83,16 @@ jobs:
           cache-dependency-path: pyproject.toml
 
       # Add caching for HF models and tokenizers
-      - name: Restore HF cache
-        uses: actions/cache/restore@v3
+      - name: HF cache
+        uses: actions/cache@v3
+        continue-on-error: true
         with:
           path: .cache-HF
-          key: |
+          key: hf-cache-${{ runner.os }}-${{ matrix.python-version }}
+          restore-keys: |
             hf-cache-${{ runner.os }}-${{ matrix.python-version }}
             hf-cache-${{ runner.os }}-
             hf-cache-
-          fail-on-cache-miss: false
 
       - name: Install dependencies
         run: |
@@ -95,13 +108,6 @@ jobs:
         run: |
           pip install -q py-tree
           python -m py_tree -d 1 .cache-HF
-
-      - name: Dump HF cache
-        if: github.event_name != 'pull_request'
-        uses: actions/cache/save@v3
-        with:
-          path: .cache-HF
-          key: hf-cache-${{ runner.os }}-${{ matrix.python-version }}
 
   testing-guardian:
     runs-on: ubuntu-latest

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Optional, Type, Union, List
+from typing import Any, List, Literal, Optional, Type, Union
 
 import torch
 import yaml

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -81,7 +81,10 @@ class Config:
     scale_embeddings: bool = False
     lm_head_bias: bool = False
     final_logit_softcapping: Optional[float] = None
-
+    # The base period of the RoPE embeddings for local attention.
+    # If not provided, rope_theta will be used for both local and global attention.
+    rope_local_base_freq: Optional[float] = None
+    
     def __post_init__(self):
         if not self.name:
             self.name = self.hf_config.get("name", self.name)

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -1561,7 +1561,6 @@ phi = [
         mlp_class_name="LLaMAMLP",
         parallel_residual=False,
         sliding_window_size=262145,
-        sliding_window_layer_placing="all",
     ),
     # https://huggingface.co/microsoft/Phi-3.5-mini-instruct/blob/main/config.json
     dict(
@@ -1642,7 +1641,6 @@ configs.append(
         mlp_class_name="LLaMAMLP",
         intermediate_size=14336,
         sliding_window_size=4096,
-        sliding_window_layer_placing="all",
     )
 )
 

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -82,7 +82,6 @@ class Config:
     # The base period of the RoPE embeddings for local attention.
     # If not provided, rope_theta will be used for both local and global attention.
     rope_local_base_freq: Optional[float] = None
-    rope_indices: Optional[List] = None
 
     def __post_init__(self):
         if not self.name:

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -84,7 +84,7 @@ class Config:
     # The base period of the RoPE embeddings for local attention.
     # If not provided, rope_theta will be used for both local and global attention.
     rope_local_base_freq: Optional[float] = None
-    
+
     def __post_init__(self):
         if not self.name:
             self.name = self.hf_config.get("name", self.name)

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -82,6 +82,7 @@ class Config:
     # The base period of the RoPE embeddings for local attention.
     # If not provided, rope_theta will be used for both local and global attention.
     rope_local_base_freq: Optional[float] = None
+    rope_indices: Optional[List] = None
 
     def __post_init__(self):
         if not self.name:

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Optional, Type, Union
+from typing import Any, Literal, Optional, Type, Union, List
 
 import torch
 import yaml
@@ -58,9 +58,7 @@ class Config:
     attn_bias: bool = False
     attention_scores_scalar: Optional[int] = None
     sliding_window_size: Optional[int] = None
-    sliding_window_layer_placing: Optional[Literal["all", "interleaved"]] = None
-    sliding_window_layer_stride: Optional[int] = None
-    sliding_window_offset: int = 0
+    sliding_window_indices: Optional[List] = None
     # if `attention_logit_softcapping` is used, cannot use optimized
     # `torch.nn.functional.scaled_dot_product_attention` (which implements
     # Flash attention), may result in higher memory and runtime footprint.
@@ -114,14 +112,11 @@ class Config:
 
         self.rope_n_elem = int(self.rotary_percentage * self.head_size)
 
-        if self.sliding_window_size is not None:
-            self.sliding_window_layer_stride = (
-                (1 if (self.sliding_window_layer_placing is None or self.sliding_window_layer_placing == "all") else 2)
-                if self.sliding_window_layer_stride is None
-                else self.sliding_window_layer_stride
-            )
+        if self.sliding_window_size is not None and self.sliding_window_indices is None:
+            self.sliding_window_indices = [1] * self.n_layer
 
-        self.sliding_window_block_idx_map_fn = lambda x: x + self.sliding_window_offset
+        if self.rope_local_base_freq is not None and self.rope_indices is None:
+            self.rope_indices = [1] * self.n_layer
 
     @classmethod
     def from_name(cls, name: str, **kwargs: Any) -> Optional[Self]:
@@ -974,7 +969,7 @@ gemma = [
         block_size=8192,
         sliding_window_size=4096,
         # only layer with idx 0, 2, 4, ... have sliding window attention
-        sliding_window_layer_placing="interleaved",
+        sliding_window_indices=[1 if i % 2 == 0 else 0 for i in range(26)],
         intermediate_size=9216,
         n_embd=2304,
         n_layer=26,
@@ -1002,7 +997,7 @@ gemma = [
         block_size=8192,
         sliding_window_size=4096,
         # only layer with idx 0, 2, 4, ... have sliding window attention
-        sliding_window_layer_placing="interleaved",
+        sliding_window_indices=[1 if i % 2 == 0 else 0 for i in range(42)],
         intermediate_size=14336,
         n_embd=3584,
         n_layer=42,
@@ -1032,7 +1027,7 @@ gemma = [
         block_size=8192,
         sliding_window_size=4096,
         # only layer with idx 0, 2, 4, ... have sliding window attention
-        sliding_window_layer_placing="interleaved",
+        sliding_window_indices=[1 if i % 2 == 0 else 0 for i in range(46)],
         intermediate_size=36864,
         n_embd=4608,
         n_layer=46,
@@ -1549,7 +1544,6 @@ phi = [
         mlp_class_name="LLaMAMLP",
         parallel_residual=False,
         sliding_window_size=2048,
-        sliding_window_layer_placing="all",
     ),
     # https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/blob/main/config.json
     dict(
@@ -1622,7 +1616,6 @@ phi = [
         mlp_class_name="LLaMAMLP",
         parallel_residual=False,
         sliding_window_size=262145,
-        sliding_window_layer_placing="all",
     ),
 ]
 configs.extend(phi)
@@ -1670,7 +1663,6 @@ mistral = [
         mlp_class_name="LLaMAMLP",
         intermediate_size=14336,
         sliding_window_size=4096,
-        sliding_window_layer_placing="all",
     ),
     # https://huggingface.co/mistralai/Mixtral-8x7B-v0.1/blob/main/config.json
     dict(

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -628,7 +628,6 @@ def build_rope_cache(
         local_theta = 1.0 / (rope_local_base_freq ** (torch.arange(0, n_elem, 2, device=device).float() / n_elem))
         local_idx_theta = torch.outer(seq_idx, local_theta)
         local_idx_theta = local_idx_theta.repeat(1, 2)
-        print("local_idx_theta.shape", local_idx_theta.shape)  # torch.Size([20, 128])
         if local_idx_theta.shape[-1] > n_elem > 1:
             local_idx_theta = local_idx_theta[..., :n_elem]
 

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -154,8 +154,19 @@ class GPT(nn.Module):
         if self.config.scale_embeddings:
             x = x * torch.tensor(self.config.n_embd**0.5, dtype=x.dtype)
 
-        for block in self.transformer.h:
-            x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
+        for block_idx, block in enumerate(self.transformer.h):
+            if self.config.rope_indices is not None:
+                x = block(
+                    x,
+                    cos[..., self.config.rope_indices[block_idx]],
+                    sin[..., self.config.rope_indices[block_idx]],
+                    mask,
+                    input_pos,
+                    input_pos_maxp1,
+                )
+            else:
+                x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
+
         x = self.transformer.ln_f(x)
         clamp_head = (
             partial(do_softcapping, thresh=self.config.final_logit_softcapping)
@@ -215,7 +226,10 @@ class GPT(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         if rope_cache_length is None:
-            rope_cache_length = self.cos.size(-1)
+            if len(self.cos.shape) == 2:
+                rope_cache_length = self.cos.size(-1)
+            else:
+                rope_cache_length = self.cos.size(-2)
 
         if max_seq_length is None:
             max_seq_length = self.max_seq_length

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -324,7 +324,7 @@ class CausalSelfAttention(nn.Module):
         self.proj = nn.Linear(config.head_size * config.n_head, config.n_embd, bias=config.bias)
         # disabled by default
         self.kv_cache: Optional[KVCache] = None
-        self.apply_sliding_window_attention = False 
+        self.apply_sliding_window_attention = False
         if config.sliding_window_size is not None and config.sliding_window_indices is not None:
             self.apply_sliding_window_attention = config.sliding_window_indices[block_idx]
 

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -628,7 +628,7 @@ def build_rope_cache(
         local_theta = 1.0 / (rope_local_base_freq ** (torch.arange(0, n_elem, 2, device=device).float() / n_elem))
         local_idx_theta = torch.outer(seq_idx, local_theta)
         local_idx_theta = local_idx_theta.repeat(1, 2)
-        print("local_idx_theta.shape", local_idx_theta.shape) # torch.Size([20, 128])
+        print("local_idx_theta.shape", local_idx_theta.shape)  # torch.Size([20, 128])
         if local_idx_theta.shape[-1] > n_elem > 1:
             local_idx_theta = local_idx_theta[..., :n_elem]
 

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -154,19 +154,8 @@ class GPT(nn.Module):
         if self.config.scale_embeddings:
             x = x * torch.tensor(self.config.n_embd**0.5, dtype=x.dtype)
 
-        for block_idx, block in enumerate(self.transformer.h):
-            if self.config.rope_indices is not None:
-                x = block(
-                    x,
-                    cos[..., self.config.rope_indices[block_idx]],
-                    sin[..., self.config.rope_indices[block_idx]],
-                    mask,
-                    input_pos,
-                    input_pos_maxp1,
-                )
-            else:
-                x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
-
+        for block in self.transformer.h:
+            x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
         x = self.transformer.ln_f(x)
         clamp_head = (
             partial(do_softcapping, thresh=self.config.final_logit_softcapping)
@@ -226,10 +215,7 @@ class GPT(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         if rope_cache_length is None:
-            if len(self.cos.shape) == 2:
-                rope_cache_length = self.cos.size(-1)
-            else:
-                rope_cache_length = self.cos.size(-2)
+            rope_cache_length = self.cos.size(-1)
 
         if max_seq_length is None:
             max_seq_length = self.max_seq_length

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -324,10 +324,9 @@ class CausalSelfAttention(nn.Module):
         self.proj = nn.Linear(config.head_size * config.n_head, config.n_embd, bias=config.bias)
         # disabled by default
         self.kv_cache: Optional[KVCache] = None
-        self.apply_sliding_window_attention = (
-            config.sliding_window_size is not None
-            and config.sliding_window_block_idx_map_fn(block_idx) % config.sliding_window_layer_stride == 0
-        )
+        self.apply_sliding_window_attention = False 
+        if config.sliding_window_size is not None and config.sliding_window_indices is not None:
+            self.apply_sliding_window_attention = config.sliding_window_indices[block_idx]
 
         if config.norm_qk:
             self.norm_q = config.norm_class(config.head_size * config.n_head, eps=config.norm_eps)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -420,7 +420,6 @@ def test_against_mistral_hf_models(device, dtype, model_name):
         padded_vocab_size=10000,
         block_size=T,
         sliding_window_size=T // 2,
-        sliding_window_layer_placing="all",
         n_layer=2,
         n_embd=32,
         n_head=8,


### PR DESCRIPTION
Different models have different sliding window pattersn that are difficult to configure with simple `stride` and `offset` parameters. For instance, in the case of Gemma 3, it applies sliding for 5 layers and skips the next layer (which is difficult to represent with stride and offsets). Other supported models that uses sliding windows so far used either sliding windows for all layers or alternating layers; however, for future variations of sliding windows, I think this approach is the most straight forward approach.