### PR TITLE
feat: add rope indices

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -82,6 +82,7 @@ class Config:
     # The base period of the RoPE embeddings for local attention.
     # If not provided, rope_theta will be used for both local and global attention.
     rope_local_base_freq: Optional[float] = None
+    rope_indices: Optional[List] = None
 
     def __post_init__(self):
         if not self.name:

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -229,7 +229,7 @@ class GPT(nn.Module):
             if len(self.cos.shape) == 2:
                 rope_cache_length = self.cos.size(-1)
             else:
-                rope_cache_length = self.cos[..., 0].size(-1)
+                rope_cache_length = self.cos.size(-2)
 
         if max_seq_length is None:
             max_seq_length = self.max_seq_length

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -154,8 +154,12 @@ class GPT(nn.Module):
         if self.config.scale_embeddings:
             x = x * torch.tensor(self.config.n_embd**0.5, dtype=x.dtype)
 
-        for block in self.transformer.h:
-            x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
+        for block_idx, block in enumerate(self.transformer.h):
+            if self.config.rope_indices is not None:
+                x = block(x, cos[..., self.config.rope_indices[block_idx]], sin[..., self.config.rope_indices[block_idx]], mask, input_pos, input_pos_maxp1)
+            else:
+                x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
+
         x = self.transformer.ln_f(x)
         clamp_head = (
             partial(do_softcapping, thresh=self.config.final_logit_softcapping)
@@ -215,7 +219,10 @@ class GPT(nn.Module):
         dtype: Optional[torch.dtype] = None,
     ) -> None:
         if rope_cache_length is None:
-            rope_cache_length = self.cos.size(-1)
+            if len(self.cos.shape) == 2:
+                rope_cache_length = self.cos.size(-1)
+            else:
+                rope_cache_length = self.cos[..., 0].size(-1)
 
         if max_seq_length is None:
             max_seq_length = self.max_seq_length

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -156,7 +156,14 @@ class GPT(nn.Module):
 
         for block_idx, block in enumerate(self.transformer.h):
             if self.config.rope_indices is not None:
-                x = block(x, cos[..., self.config.rope_indices[block_idx]], sin[..., self.config.rope_indices[block_idx]], mask, input_pos, input_pos_maxp1)
+                x = block(
+                    x,
+                    cos[..., self.config.rope_indices[block_idx]],
+                    sin[..., self.config.rope_indices[block_idx]],
+                    mask,
+                    input_pos,
+                    input_pos_maxp1,
+                )
             else:
                 x = block(x, cos, sin, mask, input_pos, input_pos_maxp1)
 


### PR DESCRIPTION
For Gemma 3, local and global rotary embeddings take different base frequencies. Therefore, `rope_indices` provide a way to select appropriate embeddings by selecting the proper dimension for `cos` and `sin` values.