### PR TITLE
input_pos_maxp1 as a Python integer

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -77,7 +77,7 @@ def next_token(
     model: GPT,
     input_pos: torch.Tensor,
     x: torch.Tensor,
-    input_pos_maxp1: Optional[torch.Tensor] = None,
+    input_pos_maxp1: Optional[int] = None,
     **sample_kwargs: Dict[str, Any],
 ) -> torch.Tensor:
     logits = model(x, input_pos, input_pos_maxp1=input_pos_maxp1)

--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -180,10 +180,7 @@ def generate_fn(
     input_pos = torch.arange(0, prompt_size, device=device, dtype=torch.int64)
     # input_pos_maxp1 introduces data-dependent shapes and control flow.
     # We want to skip if ThunderModules are involved, either directly or wrapped in LightningModule etc.
-    if not any(m.__class__.__name__ == "ThunderModule" for m in model.modules()):
-        input_pos_maxp1 = torch.tensor(prompt_size, device=device)
-    else:
-        input_pos_maxp1 = None
+    input_pos_maxp1 = prompt_size if all(m.__class__.__name__ != "ThunderModule" for m in model.modules()) else None
     for current_idx in range(max_returned_tokens - prompt_size):
         # Generate the token
         token = next_token(
@@ -231,7 +228,7 @@ def generate_fn(
         else:
             input_pos.add_(1)
         if input_pos_maxp1 is not None:
-            input_pos_maxp1.add_(1)
+            input_pos_maxp1 += 1
 
     # Yield any remaining tokens
     if yielded_idx < len(tokens):

--- a/litgpt/generate/sequentially.py
+++ b/litgpt/generate/sequentially.py
@@ -108,7 +108,7 @@ def layer_to_device(
 def move_block_input(device: torch.device, module: torch.nn.Module, ins):
     """``forward_pre_hook`` to move a Block's input before forward."""
     # during inference, none of the inputs are None: x, cos, sin, mask, input_pos
-    return tuple(t.to(device) for t in ins)
+    return tuple(t.to(device) if torch.is_tensor(t) else t for t in ins)
 
 
 def move_block_output(device: torch.device, module: torch.nn.Module, ins, outs) -> torch.Tensor:

--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -84,7 +84,7 @@ class GPT(nn.Module):
         self,
         idx: torch.Tensor,
         input_pos: Optional[torch.Tensor] = None,
-        input_pos_maxp1: Optional[torch.Tensor] = None,
+        input_pos_maxp1: Optional[int] = None,
         lm_head_chunk_size: int = 0,
     ) -> Union[torch.Tensor, List[torch.Tensor]]:
         """
@@ -291,7 +291,7 @@ class Block(nn.Module):
         sin: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         input_pos: Optional[torch.Tensor] = None,
-        input_pos_maxp1: Optional[torch.Tensor] = None,
+        input_pos_maxp1: Optional[int] = None,
     ) -> torch.Tensor:
         """
         Non-parallel residual       Parallel residual
@@ -361,7 +361,7 @@ class CausalSelfAttention(nn.Module):
         sin: torch.Tensor,
         mask: Optional[torch.Tensor] = None,
         input_pos: Optional[torch.Tensor] = None,
-        input_pos_maxp1: Optional[torch.Tensor] = None,
+        input_pos_maxp1: Optional[int] = None,
     ) -> torch.Tensor:
         # Notation:
         # - B          | batch size

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1461,7 +1461,7 @@ def test_forward_with_without_input_pos_maxp1():
     model.set_kv_cache(batch_size)
     idx = torch.randint(0, config.padded_vocab_size, (1, 10))
     input_pos = torch.arange(1, 11)
-    input_pos_maxp1 = torch.tensor(11)
+    input_pos_maxp1 = 11
     logits_with_maxp1 = model(idx, input_pos, input_pos_maxp1=input_pos_maxp1)
     logits_no_maxp1 = model(idx, input_pos)
     torch.testing.assert_close(logits_with_maxp1, logits_no_maxp1)


### PR DESCRIPTION
Hi there 👋 

While I was profiling the code to see whether I can improve the speed of speculative decoding, I noticed two weird things:
1. Relatively long KV-cache call (that's whole another story)
2. `cudaStreamSynchronize` call in `CausalSelfAttention.forward` from `model.py` 

> [!NOTE]
> All number are provided for `Qwen2.5-7B-Instruct` on `Nvidia L4`

<img width="868" alt="Screenshot 2025-04-15 at 8 11 42 PM" src="https://github.com/user-attachments/assets/3bed2299-ac93-4a4a-9dc2-fdd58ffeecf3" />


This is caused by implicit call of `.item()` when doing slicing with a tensor.

https://github.com/Lightning-AI/litgpt/blob/3d66f32b894b16415bc85839b9c6ba15f72af07e/litgpt/model.py#L418-L421

It's worth admitting, when @mseeger added `input_pos_maxp1` he initially used it as a Python integer, but I insisted on changing it to a tensor, so it works properly with the rest of the code (for example a function that moves arguments to a device in sequential generation code).
Now it's time to roll it back 😊.

----

When doing a quick benchmark multiple times by generating 500 new tokens, the speed was improved by ~1 token/sec (`16.19` in this PR vs `15.10` in main branch).