### PR TITLE
Cast tensors in KVCache only when needed

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -791,8 +791,10 @@ class KVCache(nn.Module):
 
         """
         # move the buffer to the activation dtype for when AMP is used
-        self.k = self.k.to(k.dtype)
-        self.v = self.v.to(v.dtype)
+        if self.k.dtype != k.dtype:
+            self.k = self.k.to(k.dtype)
+        if self.v.dtype != v.dtype:
+            self.v = self.v.to(v.dtype)
         # update the cache
         bs = k.size(0)
         k = batched_index_copy_(self.k[:bs, ...], -2, input_pos, k)


### PR DESCRIPTION
Hi there 👋 

One more small perf improvement.

While looking at the stack track from PyTorch profiling, I've noticed that `KVCache.forward` call takes a surprisingly long amount of time (relatively, of course).

 
<img width="651" alt="Screenshot 2025-04-16 at 8 50 31 PM" src="https://github.com/user-attachments/assets/955ba44e-cbe2-43c4-93da-c5200afddaae" />

If to zoom-in, one can see that there are a couple of `__setattr__` calls.

<img width="1039" alt="Screenshot 2025-04-16 at 8 51 03 PM" src="https://github.com/user-attachments/assets/47a5add9-00f5-405f-8518-d4f874cf3a51" />

That is caused by these two lines:
https://github.com/Lightning-AI/litgpt/blob/3d66f32b894b16415bc85839b9c6ba15f72af07e/litgpt/model.py#L793-L795

If `self.k` and `k` (and similarly `self.v` and `v`) are already of the same dtype, the `.to(k.dtype)` operation is effectively a no-op. However, PyTorch still incurs some overhead in checking and potentially preparing for the operation.

--------------

A quick benchmark with `Qwen2.5-7B-Instruct` on `Nvidia L4`, 3 runs of generating 500 new tokens, gave me such numbers: 
| Branch | Main | PR|
|-|-|-|
| Tok/sec| 15.05 | 15.21 |

Teeny-tiny improvement, but still counts 🙂. 