### PR TITLE
drop upper bounds in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ dependencies = [
   "huggingface-hub>=0.23.5",
   "jsonargparse[signatures]>=4.30.1,<=4.32.1; python_version<='3.9'", # 4.33 does not seem to be compatible with Python 3.9
   "jsonargparse[signatures]>=4.37; python_version>'3.9'",             # required to work with python3.12+
-  "lightning>=2.5,<2.6",
+  "lightning>=2.5",
   "numpy<2",                                                          # for older Torch versions
   "psutil==7",
   "safetensors>=0.4.3",
   # tokenization in most models:
   "tokenizers>=0.15.2",
-  "torch>=2.5,<2.7",
+  "torch>=2.5",
   # convert_hf_checkpoint
   "tqdm>=4.66",
 ]


### PR DESCRIPTION
For PyTorch and PyTorch Lightning, the insistence to only use "tested / approved" versions leads to very annoying downgrades when installing litgpt.