### PR TITLE
add testing for py3.12 & py3.13

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -6,7 +6,7 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, ready_for_review, labeled, synchronize]
-  pull_request: {}  # todo
+  pull_request: {} # todo
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -6,6 +6,7 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, ready_for_review, labeled, synchronize]
+  pull_request: {}  # todo
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-22.04"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - { os: "macOS-14", python-version: "3.9" }
           - { os: "windows-2022", python-version: "3.9" }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,8 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
-        exclude: README.md
       - id: trailing-whitespace
+        exclude: README.md
       - id: check-yaml
       - id: check-toml
       #- id: check-docstring-first

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
+        exclude: README.md
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 **20+ high-performance LLMs with recipes to pretrain, finetune, and deploy at scale.**
 
 <pre>
-         ✅ From scratch implementations     ✅ No abstractions    ✅ Beginner friendly
-            ✅ Flash attention                  ✅ FSDP               ✅ LoRA, QLoRA, Adapter
-✅ Reduce GPU memory (fp4/8/16/32)  ✅ 1-1000+ GPUs/TPUs  ✅ 20+ LLMs
+✅ From scratch implementations      ✅ No abstractions         ✅ Beginner friendly
+   ✅ Flash attention                   ✅ FSDP                    ✅ LoRA, QLoRA, Adapter
+✅ Reduce GPU memory (fp4/8/16/32)   ✅ 1-1000+ GPUs/TPUs       ✅ 20+ LLMs         
 </pre>
 
 


### PR DESCRIPTION
Adding testing for latest python versions since we have these tags in package metadata as we are compatible...
Since the PR event has changed this PR is running with dispatch on this branch: https://github.com/Lightning-AI/litgpt/actions/runs/14858720043

Fixing alignement in readme
![image](https://github.com/user-attachments/assets/c01335ee-d7ab-4939-9c69-9563e0b7998d)
