### PR TITLE
Remove dependency from config to utils

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -9,7 +9,18 @@ import torch
 import yaml
 from typing_extensions import Self
 
-from litgpt.utils import find_multiple
+
+def find_multiple(n: int, k: int) -> int:
+    """Utility function for finding the nearest value to n which is a multiple of k.
+
+    NOTE: We define this function in this module rather than `litgpt.utils` so that users can import
+    this file to do configuration manipulations in Python environments which do not include all the dependencies
+    demanded by `litgpt.utils`.
+    """
+    assert k > 0
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
 
 
 @dataclass

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -63,13 +63,6 @@ def find_resume_path(resume: Union[bool, Literal["auto"], Path], out_dir: Path) 
     return resume_path
 
 
-def find_multiple(n: int, k: int) -> int:
-    assert k > 0
-    if n % k == 0:
-        return n
-    return n + k - (n % k)
-
-
 def num_parameters(module: nn.Module, requires_grad: Optional[bool] = None) -> int:
     total = 0
     for p in module.parameters():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,7 @@ import yaml
 
 import litgpt.config as config_module
 from litgpt import Config
+from litgpt.config import find_multiple
 
 
 def test_config():
@@ -103,3 +104,13 @@ def test_head_size(head_size):
     config = Config(head_size)
 
     assert config.head_size == head_size or config.n_embd // config.n_head
+
+
+def test_find_multiple():
+    assert find_multiple(17, 5) == 20
+    assert find_multiple(30, 7) == 35
+    assert find_multiple(10, 2) == 10
+    assert find_multiple(5, 10) == 10
+    assert find_multiple(50254, 128) == 50304
+    assert find_multiple(50254, 256) == 50432
+    assert find_multiple(50254, 512) == 50688

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,7 +31,6 @@ from litgpt.utils import (
     chunked_cross_entropy,
     copy_config_files,
     extend_checkpoint_dir,
-    find_multiple,
     find_resume_path,
     fix_and_load_json,
     incremental_save,
@@ -43,16 +42,6 @@ from litgpt.utils import (
     save_hyperparameters,
     select_sft_generate_example,
 )
-
-
-def test_find_multiple():
-    assert find_multiple(17, 5) == 20
-    assert find_multiple(30, 7) == 35
-    assert find_multiple(10, 2) == 10
-    assert find_multiple(5, 10) == 10
-    assert find_multiple(50254, 128) == 50304
-    assert find_multiple(50254, 256) == 50432
-    assert find_multiple(50254, 512) == 50688
 
 
 # match fails on windows. why did they have to use backslashes?


### PR DESCRIPTION
I have some code which constructs and writes out to YAML files configs which are used to queue up litgpt training jobs on remote machines. Unfortunately this code starts up really slowly because importing the `litgpt.config` submodule pulls in a *ton* of transitive dependencies due to its `from litgpt.utils import find_multiple` line (eventually torch, triton, etc. are imported). This causes as much as a 30+ second delay to any script I write that manipulates litgpt config objects.

I noticed that `find_multiple` is actually only ever used in `litgpt.config` anyhow, so I was wondering if it would be okay to scoot this function over and remove the dependency from `config` on `utils`. With this change, it is possible to write code which imports the config submodule alone and thus runs very quickly (not pulling in any of the heavy deps that current come into the Python interpreter).

Is this change something y'all might be amenable to?