### PR TITLE
fix: Add fallback chat template

### DIFF
--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -160,6 +160,7 @@ class OpenAISpecLitAPI(BaseLitAPI):
             config = json.load(fp)
             chat_template = config.get("chat_template", None)
             if chat_template is None:
+                print("The tokenizer config does not contain chat_template, falling back to a default.")
                 chat_template = "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}Assistant: "
             self.chat_template = chat_template
 

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -160,12 +160,7 @@ class OpenAISpecLitAPI(BaseLitAPI):
             config = json.load(fp)
             chat_template = config.get("chat_template", None)
             if chat_template is None:
-                chat_template = (
-                    "{% for m in messages %}"
-                    "{{ m.role }}: {{ m.content }}\n"
-                    "{% endfor %}"
-                    "Assistant: "
-                )
+                chat_template = "{% for m in messages %}{{ m.role }}: {{ m.content }}\n{% endfor %}Assistant: "
             self.chat_template = chat_template
 
         self.template = Template(self.chat_template)

--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -160,7 +160,12 @@ class OpenAISpecLitAPI(BaseLitAPI):
             config = json.load(fp)
             chat_template = config.get("chat_template", None)
             if chat_template is None:
-                raise ValueError("chat_template not found in tokenizer config file.")
+                chat_template = (
+                    "{% for m in messages %}"
+                    "{{ m.role }}: {{ m.content }}\n"
+                    "{% endfor %}"
+                    "Assistant: "
+                )
             self.chat_template = chat_template
 
         self.template = Template(self.chat_template)

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -160,27 +160,18 @@ def test_serve_with_openai_spec_missing_chat_template(tmp_path):
     def run_server():
         nonlocal process
         try:
-            process = subprocess.Popen(run_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
         except subprocess.TimeoutExpired:
             print("Server start-up timeout expired")
-        return None, None
 
     server_thread = threading.Thread(target=run_server)
     server_thread.start()
 
-    time.sleep(30)  # Give the server some time to start and raise the error
+    _wait_and_check_response()
 
-    try:
-        stdout = process.stdout.read().strip() if process.stdout else ""
-        stderr = process.stderr.read().strip() if process.stderr else ""
-        output = (stdout or "") + (stderr or "")
-        assert "ValueError: chat_template not found in tokenizer config file." in output, (
-            "Expected ValueError for missing chat_template not found."
-        )
-    finally:
-        if process:
-            kill_process_tree(process.pid)
-        server_thread.join()
+    if process:
+        kill_process_tree(process.pid)
+    server_thread.join()
 
 
 @_RunIf(min_cuda_gpus=1)


### PR DESCRIPTION
Demo: https://www.loom.com/share/e3243c822aca496fb5f86e4697bd439a

Currently, the library errors on serving models with the OpenAI spec if a chat template is not included with the tokenizer config.  Some of the models we support, like microsoft Phi do not contain one.  This PR adds a basic fallback template that can be used in the case one does not exist.

This PR fixes serving microsoft phi and probably some others