### PR TITLE
ci: run `pull_request` only on own PRs

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -25,6 +25,8 @@ env:
 
 jobs:
   testing-imports:
+    # no need to run it twice on a PR
+    if: github.event_name != 'pull_request_target'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -34,11 +36,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-        if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
-        if: github.event_name == 'pull_request_target'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -60,6 +57,8 @@ jobs:
           python -c "$modules"
 
   pytester:
+    # skip PR trigger if secrets are not shared as for all forked PRs
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && secrets.HF_TOKEN != '')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -71,9 +70,11 @@ jobs:
           - { os: "windows-2022", python-version: "3.9" }
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout generic
+        uses: actions/checkout@v4
         if: github.event_name != 'pull_request_target'
-      - uses: actions/checkout@v4
+      - name: Checkout for `pull_request_target`
+        uses: actions/checkout@v4
         if: github.event_name == 'pull_request_target'
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -58,7 +58,12 @@ jobs:
 
   pytester:
     # skip PR trigger if secrets are not shared as for all forked PRs
-    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && secrets.HF_TOKEN != '')
+    if: |
+      github.event_name != 'pull_request' ||
+      (
+        github.event_name == 'pull_request' &&
+        contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)
+      )
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
This reduces false signals from PRs by omitting the failing test due to not avalible HF token