### PR TITLE
fix: Pretraining text files with recent litdata versions

### DIFF
--- a/litgpt/data/text_files.py
+++ b/litgpt/data/text_files.py
@@ -51,6 +51,7 @@ class TextFiles(DataModule):
 
     def prepare_data(self) -> None:
         from litdata import optimize
+        from litdata.streaming import TokensLoader
 
         train_files = sorted(glob.glob(str(self.train_data_path / "*.txt")))
         assert len(train_files) > 0, f"No .txt files found in train data {train_files}"
@@ -76,6 +77,7 @@ class TextFiles(DataModule):
                 output_dir=str(self.out_path_train),
                 num_workers=use_workers,
                 chunk_bytes="50MB",
+                item_loader=TokensLoader(block_size=self.max_seq_length),
             )
         else:
             print(
@@ -93,6 +95,7 @@ class TextFiles(DataModule):
                 output_dir=str(self.out_path_val),
                 num_workers=use_workers,
                 chunk_bytes="50MB",
+                item_loader=TokensLoader(block_size=self.max_seq_length),
             )
         else:
             print(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ optional-dependencies.extra = [
   "datasets>=2.18",
   # download:
   "huggingface-hub[hf-transfer]>=0.21",
-  "litdata==0.2.17",
+  "litdata==0.2.45",
   # litgpt.deploy:
   "litserve<=0.2.7",
   "lm-eval>=0.4.2",

--- a/tests/data/test_textfiles.py
+++ b/tests/data/test_textfiles.py
@@ -1,6 +1,10 @@
+import json
+
 import torch
-from litdata import optimize
+from litdata import TokensLoader, optimize
 from torch.utils._pytree import tree_map
+
+from litgpt.data.text_files import TextFiles
 
 
 class Tokenizer:
@@ -18,7 +22,14 @@ def tokenize(data):
 
 
 def fake_chunk(path, data):
-    optimize(fn=tokenize, inputs=[data] * len(data), output_dir=str(path), num_workers=1, chunk_bytes="200MB")
+    optimize(
+        fn=tokenize,
+        inputs=[data] * len(data),
+        output_dir=str(path),
+        num_workers=1,
+        chunk_bytes="200MB",
+        item_loader=TokensLoader(),
+    )
 
 
 def test_textfiles_datamodule(tmp_path):
@@ -35,22 +46,87 @@ def test_textfiles_datamodule(tmp_path):
     datamodule.setup()
 
     tr_dataloader = datamodule.train_dataloader()
-    torch.manual_seed(123)
+    tr_dataloader.shuffle = False
 
     actual = tree_map(torch.Tensor.tolist, list(tr_dataloader))
+
     # there is 1 sample per index in the data (13)
     assert actual == [
-        [[1999, 0, 13]],
-        [[0, 13, 12]],
-        [[1, 1999, 0]],
-        [[63, 0, 73]],
-        [[5, 0, 1]],
-        [[0, 73, 5]],
-        [[0, 23, 15]],
-        [[0, 1, 1999]],
-        [[15, 63, 0]],
         [[73, 5, 0]],
         [[12, 0, 23]],
-        [[23, 15, 63]],
+        [[5, 0, 1]],
+        [[0, 73, 5]],
+        [[1999, 0, 13]],
+        [[0, 1, 1999]],
+        [[1, 1999, 0]],
+        [[0, 23, 15]],
         [[13, 12, 0]],
+        [[63, 0, 73]],
+        [[23, 15, 63]],
+        [[15, 63, 0]],
+        [[0, 13, 12]],
     ]
+
+
+class MockTokenizer:
+    bos_id = 0
+    eos_id = 1
+    use_bos = True
+
+    def encode(self, text, bos=True, eos=False, device=None, max_length=-1):
+        # Simple: map each character to its ordinal + 2
+        tokens = [ord(c) + 2 for c in text]
+        if bos:
+            tokens = [self.bos_id] + tokens
+        if eos:
+            tokens.append(self.eos_id)
+        if max_length > 0:
+            tokens = tokens[:max_length]
+        return torch.tensor(tokens, dtype=torch.long, device=device)
+
+    def decode(self, tensor):
+        ids = tensor.tolist() if tensor.ndim > 0 else [tensor.item()]
+        chars = []
+        for tid in ids:
+            if tid == self.bos_id:
+                chars.append("<BOS>")
+            elif tid == self.eos_id:
+                chars.append("<EOS>")
+            else:
+                chars.append(chr(tid - 2))
+        return "".join(chars)
+
+    def decode_stream(self, token_stream, device=None):
+        for token in token_stream:
+            yield self.decode(token)
+
+    @property
+    def vocab_size(self):
+        return 130
+
+
+def test_textfiles_token_loader(tmp_path):
+    # Create the directory for text files
+    data_dir = tmp_path / "textfiles"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write sample training data to the directory
+    sample_texts = ["hello world", "foo bar", "lorem ipsum"]
+    for i, text in enumerate(sample_texts):
+        (data_dir / f"{i}.txt").write_text(text)
+
+    datamodule = TextFiles(train_data_path=data_dir, num_workers=1)
+    datamodule.connect(max_seq_length=2, tokenizer=MockTokenizer())
+    datamodule.prepare_data()
+
+    # ensure training set uses tokens loader
+    index_json = data_dir / "train" / "index.json"
+    assert index_json.exists()
+    meta = json.loads(index_json.read_text())
+    assert meta["config"]["item_loader"] == "TokensLoader"
+
+    # ensure validation set uses tokens loader
+    index_json = data_dir / "val" / "index.json"
+    assert index_json.exists()
+    meta = json.loads(index_json.read_text())
+    assert meta["config"]["item_loader"] == "TokensLoader"

--- a/tests/data/test_tinystories.py
+++ b/tests/data/test_tinystories.py
@@ -13,7 +13,14 @@ def tokenize(data):
 
 
 def fake_chunk(path, data):
-    optimize(fn=tokenize, inputs=[data] * len(data), output_dir=str(path), num_workers=1, chunk_bytes="200MB")
+    optimize(
+        fn=tokenize,
+        inputs=[data] * len(data),
+        output_dir=str(path),
+        num_workers=1,
+        chunk_bytes="200MB",
+        item_loader=TokensLoader(),
+    )
 
 
 @pytest.mark.parametrize(
@@ -76,21 +83,23 @@ def test_tinystories_datamodule(tmp_path):
     datamodule.setup()
 
     tr_dataloader = datamodule.train_dataloader()
-    torch.manual_seed(0)
+    tr_dataloader.shuffle = False
+
     actual = tree_map(torch.Tensor.tolist, list(tr_dataloader))
+
     # there is 1 sample per index in the data (13)
     assert actual == [
-        [[1999, 0, 13]],
-        [[0, 13, 12]],
-        [[1, 1999, 0]],
-        [[63, 0, 73]],
-        [[5, 0, 1]],
-        [[0, 73, 5]],
-        [[0, 23, 15]],
-        [[0, 1, 1999]],
-        [[15, 63, 0]],
         [[73, 5, 0]],
         [[12, 0, 23]],
-        [[23, 15, 63]],
+        [[5, 0, 1]],
+        [[0, 73, 5]],
+        [[1999, 0, 13]],
+        [[0, 1, 1999]],
+        [[1, 1999, 0]],
+        [[0, 23, 15]],
         [[13, 12, 0]],
+        [[63, 0, 73]],
+        [[23, 15, 63]],
+        [[15, 63, 0]],
+        [[0, 13, 12]],
     ]


### PR DESCRIPTION
Demo: https://www.loom.com/share/6644999da8484f7483df27defb21765a

Recent versions of litdata have breaking changes that affect pretraining of text files in litgpt.  The issue is that `PyTreeLoader` is the default loader and `TokensLoader` needs to be explicitly specified.  This includes 0.2.45, which is the current default installed in Lightning studios.  As a result, pretraining is broken when installing litgpt in a default studio.
