### PR TITLE
Xfail Thunder integration test due to Dynamo bug

### DIFF
--- a/.azure/gpu-test.yml
+++ b/.azure/gpu-test.yml
@@ -84,7 +84,7 @@ jobs:
 
       - bash: |
           # install thunder from source, so that, thunder.tests will be available
-          pip install -U "thunder[test] @ git+https://github.com/Lightning-AI/lightning-thunder.git"
+          pip install -U "lightning-thunder[test] @ git+https://github.com/Lightning-AI/lightning-thunder.git"
           PL_RUN_CUDA_TESTS=0 pytest tests/ext_thunder/test_thunder_networks.py -v # without env var, it filters out all tests
         displayName: "Extra tests w. Thunder [main branch]"
         condition: eq(variables['dependency'], 'compiler')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ else:
 
 def pytest_runtest_setup(item):
     if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
-        pytest.xfail("xfailing due to TypeError, , see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
+        pytest.xfail("currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,6 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
                             reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
                         )
                     )
-                    print(f"xfailing {test.nodeid} because of a known issue")
-
                 if already_skipped:
                     # the test was going to be skipped anyway, filter it out
                     items.pop(i)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ else:
 
 def pytest_runtest_setup(item):
     if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
-        pytest.xfail("currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
+        pytest.xfail("xfailing due to TypeError, , see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,4 +168,3 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
                     reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
                 )
             )
-            print(f"got {test.nodeid} and added xfail marker")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ else:
 
 def pytest_runtest_setup(item):
     if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
-        pytest.xfail("Known issue in Torch Dynamo internals; blocked on NVIDIA to resolve.")
+        pytest.xfail("currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,13 +134,6 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
             conditions.append(env_var)
             for i, test in reversed(list(enumerate(items))):  # loop in reverse, since we are going to pop items
                 already_skipped = any(marker.name == "skip" for marker in test.own_markers)
-                if "test_hf_for_nemo" in test.nodeid and "Qwen/Qwen2.5-7B-Instruct" in test.nodeid:
-                    test.add_marker(
-                        pytest.mark.xfail(
-                            raises=TypeError,
-                            reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
-                        )
-                    )
                 if already_skipped:
                     # the test was going to be skipped anyway, filter it out
                     items.pop(i)
@@ -164,3 +157,15 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
             bold=True,
             purple=True,  # oh yeah, branded pytest messages
         )
+
+    for test in items:
+        if "test_hf_for_nemo" in test.nodeid and "Qwen/Qwen2.5-7B-Instruct" in test.nodeid:
+            test.add_marker(
+                # Don't use `raises=TypeError` because the actual exception is
+                # wrapped inside `torch._dynamo.exc.BackendCompilerFailed`,
+                # which prevents pytest from recognizing it as a TypeError.
+                pytest.mark.xfail(
+                    reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
+                )
+            )
+            print(f"got {test.nodeid} and added xfail marker")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,6 @@ else:
     warnings.warn(f"Could not find extensions directory at {wd}")
 
 
-def pytest_runtest_setup(item):
-    if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
-        pytest.xfail("currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085")
-
-
 @pytest.fixture()
 def fake_checkpoint_dir(tmp_path):
     os.chdir(tmp_path)
@@ -139,6 +134,15 @@ def pytest_collection_modifyitems(items: List[pytest.Function], config: pytest.C
             conditions.append(env_var)
             for i, test in reversed(list(enumerate(items))):  # loop in reverse, since we are going to pop items
                 already_skipped = any(marker.name == "skip" for marker in test.own_markers)
+                if "test_hf_for_nemo" in test.nodeid and "Qwen/Qwen2.5-7B-Instruct" in test.nodeid:
+                    test.add_marker(
+                        pytest.mark.xfail(
+                            raises=TypeError,
+                            reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
+                        )
+                    )
+                    print(f"xfailing {test.nodeid} because of a known issue")
+
                 if already_skipped:
                     # the test was going to be skipped anyway, filter it out
                     items.pop(i)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ else:
 
 def pytest_runtest_setup(item):
     if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
-        pytest.xfail("Known failure from Thunder (SymInt issue with Qwen)")
+        pytest.xfail("Known issue in Torch Dynamo internals; blocked on NVIDIA to resolve.")
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,11 @@ else:
     warnings.warn(f"Could not find extensions directory at {wd}")
 
 
+def pytest_runtest_setup(item):
+    if "test_hf_for_nemo" in item.nodeid and "Qwen/Qwen2.5-7B-Instruct" in item.nodeid:
+        pytest.xfail("Known failure from Thunder (SymInt issue with Qwen)")
+
+
 @pytest.fixture()
 def fake_checkpoint_dir(tmp_path):
     os.chdir(tmp_path)


### PR DESCRIPTION
This PR marks the `test_hf_for_nemo` test as `xfail` for the `Qwen` model due to a known issue in `TorchDynamo` involving SymInt.

The issue originates in Thunder's backend and is currently blocked on a fix from NVIDIA.

