### PR TITLE
Add pip list command after installing dependencies in GPU tests

### DIFF
--- a/.azure/gpu-test.yml
+++ b/.azure/gpu-test.yml
@@ -56,6 +56,7 @@ jobs:
       - script: |
           pip install --upgrade pip
           pip install '.[extra,test]' -U
+          pip list
         displayName: "Install dependencies"
 
       - script: |


### PR DESCRIPTION
Include a `pip list` command to verify installed dependencies after the installation step in GPU tests.

> This would also help us verify the Pydantic version used in the GPU test (#2029), which is likely causing the issue.