### PR TITLE
req: pin `bitsandbytes>=0.45.2,<0.45.5`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.compiler = [
 optional-dependencies.extra = [
   "bitsandbytes>=0.42,<0.43; sys_platform=='darwin'",
   # quantization:
-  "bitsandbytes>=0.45.2,<0.46; sys_platform=='linux' or sys_platform=='win32'",
+  "bitsandbytes>=0.45.2,<0.45.5; sys_platform=='linux' or sys_platform=='win32'",
   # litgpt.evaluate:
   "datasets>=2.18",
   # download:


### PR DESCRIPTION
resolves thunder extra tests

```
    def populate_item_wrappers(l):
        ctx: InterpreterCompileCtx = get_interpretercompilectx()
        if not ctx._with_provenance_tracking:
            return
    
        assert isinstance(l, WrappedValue)
        # to do: generalize
        if wrapped_isinstance(l, (list, tuple)):
            if l.item_wrappers is None:
                l.item_wrappers = [None for _ in range(len(l.value))]
            assert isinstance(l.item_wrappers, list)
            assert len(l.value) == len(l.item_wrappers), f"{len(l.value)=} {len(l.item_wrappers)=}"
    
            for i, v in enumerate(l.value):
                if l.item_wrappers[i] is None:
                    wv = wrap_binary_subscr(v, l, i)
                    l.item_wrappers[i] = wv
            return
    
        if wrapped_isinstance(l, dict):
            assert isinstance(l.item_wrappers, dict)
>           for k, v in l.value.items():
E           RuntimeError: dictionary changed size during iteration

/usr/local/lib/python3.10/dist-packages/thunder/core/interpreter.py:361: RuntimeError