### PR TITLE
debug failing standalone tests with Thunder

### DIFF
--- a/.azure/gpu-test.yml
+++ b/.azure/gpu-test.yml
@@ -84,7 +84,6 @@ jobs:
 
       - bash: pytest -v
         displayName: "All tests"
-        #condition: eq(variables['dependency'], 'compiler')
         timeoutInMinutes: "15"
 
       - bash: |


### PR DESCRIPTION
Trying to resolve the failing main for Thunder tests
ref: [dev.azure.com/Lightning-AI/lit%20Models/_build/results?buildId=234715&view=logs&j=47e66f3c-897a-5428-da11-bf5c7745762e&t=8ec4ada6-1a54-5cba-5628-67d3de5b9e16](https://dev.azure.com/Lightning-AI/lit%20Models/_build/results?buildId=234715&view=logs&j=47e66f3c-897a-5428-da11-bf5c7745762e&t=8ec4ada6-1a54-5cba-5628-67d3de5b9e16)