### PR TITLE
Moving to lazy root imports to make config loading snappy

### DIFF
--- a/litgpt/__init__.py
+++ b/litgpt/__init__.py
@@ -3,11 +3,25 @@
 import logging
 import re
 
-from litgpt.api import LLM
-from litgpt.config import Config
-from litgpt.model import GPT  # needs to be imported before config
-from litgpt.prompts import PromptStyle
-from litgpt.tokenizer import Tokenizer
+
+def __getattr__(name):
+    if name == "LLM":
+        from litgpt.api import LLM
+        return LLM
+    elif name == "Config":
+        from litgpt.config import Config
+        return Config
+    elif name == "GPT":
+        from litgpt.model import GPT
+        return GPT
+    elif name == "PromptStyle":
+        from litgpt.prompts import PromptStyle
+        return PromptStyle
+    elif name == "Tokenizer":
+        from litgpt.tokenizer import Tokenizer
+        return Tokenizer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 # Suppress excessive warnings, see https://github.com/pytorch/pytorch/issues/111632
 pattern = re.compile(".*Profiler function .* will be ignored")

--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, List, Literal, Optional, Type, Union
 
-import torch
 import yaml
 from typing_extensions import Self
 
@@ -184,6 +183,7 @@ class Config:
         # `self.norm_class_name` cannot be the type to keep the config serializable
 
         from functools import partial
+        import torch
 
         if self.norm_class_name == "RMSNorm":
             from litgpt.model import RMSNorm


### PR DESCRIPTION
# Problem
While the goal of https://github.com/Lightning-AI/litgpt/pull/2034 was great, it didn't go far enough to ensure that imports would actually avoid pulling the whole litgpt tree. At the moment the behavior is something like:
```
from litgpt.args import EvalArgs
...
import time:      3605 |   11016312 |     litgpt.api
import time:      1768 |   11032303 |   litgpt
import time:      1919 |   11034222 | litgpt.args
```
For simple scripts that queue jobs elsewhere, this import delay is pretty brutal. The crux of the issue is in the `litgpt.__init__` module, which is always getting imported no matter what.

# Changes
This PR edits `__init__.py` to move all of the key imports into a `__getattr__`, such that the imports can be done lazily when someone _actually_ wants to `from litgpt import LLM` or similar, but doesn't cause all these imports to trigger when you're trying to just get an arg or config class.

It also delays the load of `torch` inside of `Config` for similar reasons, though this is _less_ critical (saves a few seconds).

# Testing
Config imports are (comparatively) blazing fast:
```
>>> from litgpt import Config
...
import time:     10049 |     186252 | litgpt.config

# new shell
>>> from litgpt.args import EvalArgs
...
import time:      2795 |      28360 | litgpt.args
```

Can still import everything with the old semantics:
```
>>> from litgpt import *
...
>>> LLM
<class 'litgpt.api.LLM'>
>>> Config
<class 'litgpt.config.Config'>
>>> GPT
<class 'litgpt.model.GPT'>
>>> PromptStyle
<class 'litgpt.prompts.PromptStyle'>
>>> Tokenizer
<class 'litgpt.tokenizer.Tokenizer'>
```