### PR TITLE
Deferring import of torch in config to allow faster import

### DIFF
--- a/litgpt/config.py
+++ b/litgpt/config.py
@@ -183,7 +183,8 @@ class Config:
         # `self.norm_class_name` cannot be the type to keep the config serializable
 
         from functools import partial
-        import torch # Torch import is lazy to make config loading faster
+
+        import torch  # Torch import is lazy to make config loading faster
 
         if self.norm_class_name == "RMSNorm":
             from litgpt.model import RMSNorm


### PR DESCRIPTION
As titled, right now importing `Config` for the purpose of _just_ using the config (as discussed in https://github.com/Lightning-AI/litgpt/pull/2073) requires pulling in torch. This isn't desirable if you're only trying to pull `litgpt` configuration classes (via an approach as in [this comment](https://github.com/Lightning-AI/litgpt/pull/2073#issuecomment-2980328470)) for use in setup or configuration scripts.