### PR TITLE
adding flag for running eval with `confirm_run_unsafe_code`

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -37,7 +37,7 @@ def convert_and_evaluate(
     seed: int = 1234,
     save_filepath: Optional[Path] = None,
     access_token: Optional[str] = None,
-confirm_run_unsafe_code: bool = False,
+    confirm_run_unsafe_code: bool = False,
 ) -> None:
     """Evaluate a model with the LM Evaluation Harness.
 

--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -37,6 +37,7 @@ def convert_and_evaluate(
     seed: int = 1234,
     save_filepath: Optional[Path] = None,
     access_token: Optional[str] = None,
+confirm_run_unsafe_code: bool = False,
 ) -> None:
     """Evaluate a model with the LM Evaluation Harness.
 
@@ -56,6 +57,8 @@ def convert_and_evaluate(
         save_filepath: The file where the results will be saved.
             Saves to `out_dir/results.json` by default.
         access_token: Optional API token to access models with restrictions.
+        confirm_run_unsafe_code: Set to `True` to confirm that you have read the
+            warning and understand the risks of running unsafe code.
     """
     if tasks is None:
         from lm_eval.tasks import TaskManager
@@ -119,5 +122,6 @@ def convert_and_evaluate(
         random_seed=seed,
         numpy_random_seed=seed,
         torch_random_seed=seed,
+        confirm_run_unsafe_code=confirm_run_unsafe_code,
     )
     prepare_results(results, save_filepath)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -61,6 +61,7 @@ def test_evaluate_script(tmp_path):
             limit=5,
             tasks="logiqa",
             batch_size=1,  # Valid case
+            confirm_run_unsafe_code=True,
         )
     stdout = stdout.getvalue()
     assert (tmp_path / "out_dir" / "results.json").is_file()


### PR DESCRIPTION
Addressing issue when some latest versions if EleutherAI models include unsafe code
this is the trace from last master run:
```
FAILED tests/test_evaluate.py::test_evaluate_script - ValueError: The repository for EleutherAI/logiqa contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/EleutherAI/logiqa.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.
```
ref: https://github.com/Lightning-AI/litgpt/actions/runs/16931211393/job/47976955212