### PR TITLE
req: pin `lm-eval !=0.4.9.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.extra = [
   "litdata==0.2.51",
   # litgpt.deploy:
   "litserve>0.2",
-  "lm-eval>=0.4.2, !=0.4.9.1",
+  "lm-eval>=0.4.2,!=0.4.9.1",
   # litgpt.data.prepare_starcoder.py:
   "pandas>=1.9",
   "pyarrow>=15.0.2",


### PR DESCRIPTION
Addressing the issue when some latest versions of EleutherAI models include unsafe code
This is the trace from the last master run:
```
FAILED tests/test_evaluate.py::test_evaluate_script - ValueError: The repository for EleutherAI/logiqa contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/EleutherAI/logiqa.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.
```
ref: https://github.com/Lightning-AI/litgpt/actions/runs/16931211393/job/47976955212