### PR TITLE
gpu: use `CUBLAS_WORKSPACE_CONFIG: ":4096:8"`

### DIFF
--- a/.azure/gpu-test.yml
+++ b/.azure/gpu-test.yml
@@ -34,6 +34,7 @@ jobs:
       CUDA_VERSION: "12.6.3"
       TORCH_VERSION: "2.7.1"
       CUDNN_FRONTEND_VERSION: "1.10.0"
+      CUBLAS_WORKSPACE_CONFIG: ":4096:8"
     container:
       # image: "pytorchlightning/pytorch_lightning:base-cuda-py$(PYTHON_VERSION)-torch$(TORCH_VERSION)-cuda$(CUDA_VERSION)"
       # pytorchlightning/lightning-thunder:ubuntu22.04-cuda12.1.1-cudnn-fe1.5.0-py3.10-pt_main-dev

--- a/.lightning/workflows/tests.yaml
+++ b/.lightning/workflows/tests.yaml
@@ -17,6 +17,7 @@ parametrize:
 env:
   SKIP_WITH_CI: "1" # skip single tests with CI
   NCCL_DEBUG: "INFO"
+  CUBLAS_WORKSPACE_CONFIG: ":4096:8"
   NCCL_IGNORE_DISABLED_P2P: "1"
   TORCH_VERSION: "2.7.1"
   RUN_ONLY_CUDA_TESTS: "1" # run CUDA tests only


### PR DESCRIPTION
addresses `E       RuntimeError: Deterministic behavior was enabled with either torch.use_deterministic_algorithms(True)orat::Context::setDeterministicAlgorithms(true), but this operation is not deterministic because it uses CuBLAS and you have CUDA >= 10.2. To enable deterministic behavior in this case, you must set an environment variable before running your PyTorch application: CUBLAS_WORKSPACE_CONFIG=:4096:8 or CUBLAS_WORKSPACE_CONFIG=:16:8. For more information, go to https://docs.nvidia.com/cuda/cublas/index.html#results-reproducibility`