### PR TITLE
Add `timeout` parameter to run_server.

### DIFF
--- a/litgpt/deploy/serve.py
+++ b/litgpt/deploy/serve.py
@@ -240,7 +240,7 @@ def run_server(
     openai_spec: bool = False,
     access_token: Optional[str] = None,
     api_path: Optional[str] = "/predict",
-    timeout=30,
+    timeout: int = 30,
 ) -> None:
     """Serve a LitGPT model using LitServe.
 
@@ -283,7 +283,7 @@ def run_server(
             making it easy to integrate with existing applications that use the OpenAI API.
         access_token: Optional API token to access models with restrictions.
         api_path: The custom API path for the endpoint (e.g., "/my_api/classify").
-        timeout: The per-request timeout for the server.
+        timeout: Request timeout in seconds. Defaults to 30.
     """
     checkpoint_dir = auto_download_checkpoint(model_name=checkpoint_dir, access_token=access_token)
     pprint(locals())


### PR DESCRIPTION
## What does this PR do ?
Adds a new `timeout` parameter to the `run_server` function in `litgpt/deploy/serve.py`, allowing users to configure the per-request timeout for the LitGPT serve.

---

**Notes form user:**

Hi!

When working with litgpt for another project I ran into repeated problems with querying the served model with long inputs, where if the generation would take more than 30s the requests would time-out.

The commandline message said to increase the timeout parameter of the LitServe server, for which there was no supported way in the litgpt cmdline.

This PR adds the parameter to the `run_server` function allowing for setting the timeout as required.

Best,
~hv10
