### PR TITLE
fix: pin `lm-eval<0.4.9.1` for trust_remote_code issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,9 @@ optional-dependencies.extra = [
   "litdata==0.2.51",
   # litgpt.deploy:
   "litserve>0.2",
-  "lm-eval>=0.4.2,!=0.4.9.1",
+  # lm-eval: pinned <0.4.9.1 due to trust_remote_code issues with datasets like logiqa.
+  # See: https://github.com/EleutherAI/lm-evaluation-harness/issues/3171
+  "lm-eval>=0.4.2,<0.4.9.1",
   # litgpt.data.prepare_starcoder.py:
   "pandas>=1.9",
   "pyarrow>=15.0.2",


### PR DESCRIPTION
## What does this PR do?
Fixes failing `test_evaluate.py::test_evaluate_script` test on master by pinning `lm-eval<0.4.9.1`.

ref: ci : https://github.com/Lightning-AI/litgpt/actions/runs/19823757338/job/56877042404?pr=2164
> Also unblocks other prs 

```
FAILED tests/test_evaluate.py::test_evaluate_script - ValueError: The repository for EleutherAI/logiqa contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/EleutherAI/logiqa.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.
```

ref:  #2102 (previously pin was added here)

- Upstream issue: https://github.com/EleutherAI/lm-evaluation-harness/issues/3171
