### PR TITLE
Doc: add uv options advanced installation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,10 @@ Install from source:
 ```bash
 git clone https://github.com/Lightning-AI/litgpt
 cd litgpt
-pip install -e '.[all]'
+# if using uv
+uv sync --all-extras
+# if using pip
+pip install -e ".[extra,compiler,test]"
 ```
 </details>
 


### PR DESCRIPTION
On conversation in issue #2181 
- the `.[all]` extras doesn’t exist in this project, so the installation may not have completed as expected
- add uv option since it work
- add extras with pip to `.[extra,compiler,test]` since it's also work