### PR TITLE
Fix Mistral chat generating text with no spaces

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -155,18 +155,10 @@ class Tokenizer:
     def decode_stream(
         self, token_stream: Iterable[torch.Tensor], device: Optional[torch.device] = None
     ) -> Iterator[str]:
-        if self.backend == "huggingface":
-            try:
-                for token in token_stream:
-                    yield self.decode(token)
-            except KeyboardInterrupt:
-                return
-        elif self.backend == "sentencepiece":
-            # TODO: Is there a way to not have to do this?
-            # This may actually affect our tokens per second.
-
-            # sentencepiece does not support decoding token-by-token because it adds spaces based on the surrounding tokens
-            # meaning that we need to decode everything each time
+        # Accumulate tokens and re-decode the full sequence each time to preserve
+        # correct spacing. Decoding token-by-token strips spaces for tokenizers
+        # that use a metaspace prefix (e.g., sentencepiece, Mistral, LLaMA).
+        if self.backend in ("huggingface", "sentencepiece"):
             so_far = torch.tensor([], dtype=torch.long, device=device)
             decoded_so_far = ""
             try:


### PR DESCRIPTION
## Summary

Fixes #1822

The `decode_stream` method in `Tokenizer` had separate code paths for the `huggingface` and `sentencepiece` backends. The `huggingface` path decoded tokens one at a time, which strips the metaspace prefix (the leading space encoded as `▁` in each BPE token). This caused Mistral and other models using SentencePiece-based BPE tokenizers via the HuggingFace tokenizers library to produce output with no spaces:

```
Hello!I'mjustacomputerprogram,soIdon'thavefeelingslikeahumandoes.
```

The `sentencepiece` backend already had the correct fix: accumulate tokens and re-decode the full sequence each time to preserve correct spacing. This PR unifies both backends to use the same approach.

## Changes

- **`litgpt/tokenizer.py`**: Unified the `huggingface` and `sentencepiece` branches in `decode_stream` to both use the accumulate-and-redecode approach. This is a minimal, focused change (4 lines added, 12 removed).

## Test plan

- [ ] Existing `test_decode` in `tests/test_chat.py` validates that `decode_stream` produces correct output for `EleutherAI/pythia-14m` (huggingface backend)
- [ ] The accumulate-and-redecode logic is identical to the battle-tested sentencepiece path
- [ ] Manually verified with Mistral-7B-Instruct-v0.3 tokenizer that spaces are preserved