### PR TITLE
fix(finetune): run generate_example only on rank 0 in multi-GPU training

### DIFF
--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -339,11 +339,13 @@ def fit(
         iter_t0 = time.perf_counter()
         batch = next(train_iterator)
         if train_iterator.epoch >= train.epochs:
-            generate_example(fabric, model, tokenizer, eval, data)
+            if fabric.global_rank == 0:
+                generate_example(fabric, model, tokenizer, eval, data)
             fabric.print(f"Number of epochs {train.epochs} reached, stopping training...")
             break
         if iter_t0 - total_t0 > max_time:
-            generate_example(fabric, model, tokenizer, eval, data)
+            if fabric.global_rank == 0:
+                generate_example(fabric, model, tokenizer, eval, data)
             fabric.print(f"Max time ({max_time / 60.0:.2f}m) reached, stopping training...")
             break
         input_ids, targets = batch["input_ids"], batch["labels"]
@@ -402,7 +404,9 @@ def fit(
         if not is_accumulating and step_count % eval.interval == 0:
             t0 = time.perf_counter()
             val_loss = validate(fabric, model, val_dataloader, eval)
-            generate_example(fabric, model, tokenizer, eval, data)
+            if fabric.global_rank == 0:
+                generate_example(fabric, model, tokenizer, eval, data)
+            fabric.barrier()
             t1 = time.perf_counter() - t0
 
             val_loss_tensor = val_loss.detach().clone().to(fabric.device)


### PR DESCRIPTION
Fixes #1957

## Summary
When training with multiple GPUs using Fabric, the `generate_example()` function was redundantly called on every GPU/rank, but only rank 0's output was displayed. This caused significant delays when using many devices due to redundant computation.

## Changes
- Wrapped `generate_example()` calls with `if fabric.global_rank == 0:` check in `litgpt/finetune/lora.py`
- Added `fabric.barrier()` after the main evaluation generation to keep ranks synchronized before timing measurement
- Applied the fix to all three call sites: evaluation interval, epoch limit reached, and max time reached

## Testing
The fix ensures that:
1. Only rank 0 generates examples, eliminating redundant computation on other ranks
2. All ranks wait at the barrier before continuing, keeping timing measurements consistent
3. The existing `fabric.print()` in `generate_example()` already handles rank 0-only output

```
 litgpt/finetune/lora.py | 10 +++++++---
 1 file changed, 7 insertions(+), 3 deletions(-)
```