### PR TITLE
fix: raise error when prefill exceeds sliding window KV cache size

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -1090,6 +1090,14 @@ class KVCache(nn.Module):
         bs = k.size(0)
         if self.is_sliding_window:
             # Circular buffer for sliding window
+            prefill_len = input_pos.shape[-1]
+            if prefill_len > self.max_cache_len:
+                raise ValueError(
+                    f"Prefill length ({prefill_len}) exceeds the sliding window size ({self.max_cache_len}). "
+                    f"This causes the ring-buffer KV cache to overwrite entries, but the attention mask is not "
+                    f"rebuilt to reflect the true positions, which silently violates causality. "
+                    f"Please use chunked prefill with chunk size <= {self.max_cache_len} to avoid this issue."
+                )
             cache_positions = input_pos % self.max_cache_len
             k = batched_index_copy_(self.k[:bs, ...], -2, cache_positions, k)
             v = batched_index_copy_(self.v[:bs, ...], -2, cache_positions, v)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1762,3 +1762,50 @@ def test_forward_with_without_input_pos_maxp1():
     logits_with_maxp1 = model(idx, input_pos, input_pos_maxp1=input_pos_maxp1)
     logits_no_maxp1 = model(idx, input_pos)
     torch.testing.assert_close(logits_with_maxp1, logits_no_maxp1)
+
+
+@torch.inference_mode()
+def test_sliding_window_kv_cache_prefill_exceeds_window():
+    """Test that prefilling with more tokens than sliding_window_size raises an error.
+
+    When prefill length exceeds the sliding window size, the ring-buffer KV cache
+    overwrites entries but the attention mask (a global causal matrix truncated by
+    length) does not reflect the true absolute positions. This causes early query
+    tokens to attend to overwritten future KV entries, silently violating causality.
+
+    See: https://github.com/Lightning-AI/litgpt/issues/2182
+    """
+    from litgpt.model import KVCache
+
+    sliding_window_size = 4
+    batch_size = 1
+    n_query_groups = 2
+    head_size = 8
+
+    k_shape = (batch_size, n_query_groups, sliding_window_size, head_size)
+    v_shape = (batch_size, n_query_groups, sliding_window_size, head_size)
+
+    cache = KVCache(
+        k_shape,
+        v_shape,
+        is_sliding_window=True,
+        sliding_window_size=sliding_window_size,
+    )
+
+    # Prefill with more tokens than the sliding window size
+    prefill_len = sliding_window_size + 2  # 6 > 4
+    input_pos = torch.arange(prefill_len)
+    k = torch.randn(batch_size, n_query_groups, prefill_len, head_size)
+    v = torch.randn(batch_size, n_query_groups, prefill_len, head_size)
+
+    with pytest.raises(ValueError, match="Prefill length.*exceeds the sliding window size"):
+        cache(input_pos, k, v)
+
+    # Prefill within the window size should work fine
+    safe_len = sliding_window_size
+    input_pos_safe = torch.arange(safe_len)
+    k_safe = torch.randn(batch_size, n_query_groups, safe_len, head_size)
+    v_safe = torch.randn(batch_size, n_query_groups, safe_len, head_size)
+    k_out, v_out = cache(input_pos_safe, k_safe, v_safe)
+    assert k_out.shape == (batch_size, n_query_groups, safe_len, head_size)
+    assert v_out.shape == (batch_size, n_query_groups, safe_len, head_size)


### PR DESCRIPTION
## Summary

- Adds a guard in `KVCache.forward()` that raises `ValueError` when the prefill length exceeds the sliding window size
- When prefill length > sliding window size, the ring-buffer KV cache overwrites entries, but the attention mask (a global causal matrix truncated by length) does not reflect the true absolute positions -- early query tokens silently attend to overwritten future KV entries, violating causality
- Chose the safe "raise error with guidance" approach over rebuilding the mask, since an incorrect mask fix would be worse than the current silent corruption

## Details

The root cause is in the interaction between:
1. `build_mask_cache()` which creates a standard lower-triangular causal mask of shape `(1, 1, max_seq_length, max_seq_length)`
2. `KVCache.forward()` which uses ring-buffer indexing (`input_pos % max_cache_len`) for sliding window layers
3. The mask truncation at line 474 (`mask = mask[..., :actual_kv_len]`) which assumes positions are contiguous, but after ring-buffer wrap-around they are not

The error message guides users to use chunked prefill with chunk size <= sliding_window_size.

Fixes #2182

## Test plan

- [x] Added `test_sliding_window_kv_cache_prefill_exceeds_window` that verifies:
  - Prefill exceeding window size raises `ValueError` with descriptive message
  - Prefill within window size continues to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)