### PR TITLE
fix: handle empty prompt list in R1Base.apply()

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -248,7 +248,7 @@ class R1Base(PromptStyle):
 
             # Extract system prompt (if any)
             system_prompt = ""
-            if prompt[0].get("role") == "system":
+            if prompt and prompt[0].get("role") == "system":
                 system_prompt = prompt[0]["content"]
                 prompt = prompt[1:]  # Remove system message from the list
 


### PR DESCRIPTION
## Summary

When `R1Base.apply()` is called with an empty list `[]`, it raises an `IndexError` because the code tries to access `prompt[0]` without checking if the list is empty.

## Fix

Add a check to ensure the list is non-empty before accessing the first element.

```python
# Before
if prompt[0].get("role") == "system":

# After
if prompt and prompt[0].get("role") == "system":
```

## Test

```python
from litgpt.prompts import R1Base
p = R1Base()
result = p.apply([])  # Previously raised IndexError, now returns formatted prompt
```

## Related

This is similar to how the `Llama3` class handles this case with its `has_system_prompt` helper function.