### PR TITLE
fix(finetune): all_reduce val_loss for initial/final evaluation in multi-GPU training

### DIFF
--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -191,9 +191,13 @@ def main(
     # Final evaluation
     if eval.final_validation:
         val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        val_loss_tensor = val_loss.detach().clone().to(fabric.device)
+        fabric.all_reduce(val_loss_tensor, reduce_op="mean")
+        metrics = {"val_loss": val_loss_tensor, "val_ppl": math.exp(val_loss_tensor)}
         fabric.log_dict(metrics, step=state["iter_num"])
-        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+        fabric.print(
+            f"Final evaluation | val loss: {val_loss_tensor.item():.3f} | val ppl: {math.exp(val_loss_tensor):.3f}"
+        )
 
     # Save the final checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth"
@@ -241,7 +245,9 @@ def fit(
 
     if eval.initial_validation:
         val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-        val_loss = f"{val_loss:.3f}"
+        val_loss_tensor = val_loss.detach().clone().to(fabric.device)
+        fabric.all_reduce(val_loss_tensor, reduce_op="mean")
+        val_loss = f"{val_loss_tensor.item():.3f}"
     else:
         fabric.print("Verifying settings ...")
         validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=2), verbose=False)  # sanity check

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -259,9 +259,13 @@ def main(
     # Final evaluation
     if eval.final_validation:
         val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-        metrics = {"val_loss": val_loss, "val_ppl": math.exp(val_loss)}
+        val_loss_tensor = val_loss.detach().clone().to(fabric.device)
+        fabric.all_reduce(val_loss_tensor, reduce_op="mean")
+        metrics = {"val_loss": val_loss_tensor, "val_ppl": math.exp(val_loss_tensor)}
         fabric.log_dict(metrics)
-        fabric.print(f"Final evaluation | val loss: {val_loss.item():.3f} | val ppl: {math.exp(val_loss):.3f}")
+        fabric.print(
+            f"Final evaluation | val loss: {val_loss_tensor.item():.3f} | val ppl: {math.exp(val_loss_tensor):.3f}"
+        )
 
     # Save the final LoRA checkpoint at the end of training
     save_path = out_dir / "final" / "lit_model.pth.lora"
@@ -309,7 +313,9 @@ def fit(
 
     if eval.initial_validation:
         val_loss = validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=len(val_dataloader)))
-        val_loss = f"{val_loss:.3f}"
+        val_loss_tensor = val_loss.detach().clone().to(fabric.device)
+        fabric.all_reduce(val_loss_tensor, reduce_op="mean")
+        val_loss = f"{val_loss_tensor.item():.3f}"
     else:
         fabric.print("Verifying settings ...")
         validate(fabric, model, val_dataloader, dataclasses.replace(eval, max_iters=2), verbose=False)  # sanity check


### PR DESCRIPTION
## What does this PR do?

Fixes #2116

Both `lora.py` and `full.py` have three validation checkpoints:

| Checkpoint | Reduces across devices? |
|------------|------------------------|
| Periodic (every `eval.interval` steps) | ✅ **Yes** — `fabric.all_reduce(…, reduce_op="mean")` |
| Initial (before training starts) | ❌ **No** — single-rank value logged/printed |
| Final (after training ends) | ❌ **No** — single-rank value logged/printed |

In a multi-GPU run this means the initial and final validation metrics only reflect the local data slice of rank-0, which is both incorrect and non-reproducible.

**Fix:** Apply the same `detach / clone / all_reduce` pattern used in the periodic loop to both the initial and final validation blocks in `lora.py` and `full.py`.

## Before submitting

- [x] Was this discussed/approved via a GitHub issue? Yes, #2116
- [x] Did you make sure to update the docs?
- [x] Did you write any new unit tests?
