### PR TITLE
fix(tests): Fix 3 test failures introduced by the validate PR

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_cli():
         "{download,chat,finetune,finetune_lora,finetune_full,finetune_adapter,finetune_adapter_v2,"
         "pretrain,generate,generate_full,generate_adapter,generate_adapter_v2,generate_sequentially,"
         "generate_speculatively,generate_tp,convert_to_litgpt,convert_from_litgpt,convert_pretrained_checkpoint,"
-        "merge_lora,evaluate,serve}" in out
+        "merge_lora,evaluate,serve,validate}" in out
     )
     assert (
         """Available subcommands:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -170,12 +170,12 @@ class TestEstimateModelMemory:
         assert result["param_memory_gb"] < 1.0
 
     def test_training_multiplier(self):
-        """Training should use ~3× multiplier."""
+        """Training should use ~4× multiplier (params + gradients + Adam optimizer states)."""
         config = Config.from_name("pythia-14m")
         inference = estimate_model_memory(config, dtype=torch.float32, training=False)
         training = estimate_model_memory(config, dtype=torch.float32, training=True)
         assert training["estimated_total_gb"] > inference["estimated_total_gb"]
-        # Should be approximately 3×
+        # Should be approximately 4× (params + gradients + Adam optimizer states)
         ratio = training["estimated_total_gb"] / inference["estimated_total_gb"]
         assert 3.5 < ratio < 4.5
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -177,7 +177,7 @@ class TestEstimateModelMemory:
         assert training["estimated_total_gb"] > inference["estimated_total_gb"]
         # Should be approximately 3×
         ratio = training["estimated_total_gb"] / inference["estimated_total_gb"]
-        assert 2.5 < ratio < 3.5
+        assert 3.5 < ratio < 4.5
 
     def test_dtype_affects_memory(self):
         """Half precision should use ~half the parameter memory."""
@@ -215,7 +215,7 @@ def test_tokenizer_json_warning(tmp_path):
 
     (checkpoint_dir / "generation_config.json").write_text(invalid_json)
     (checkpoint_dir / "tokenizer_config.json").write_text(
-        json.dumps({"tokenizer_class": "GPT2Tokenizer", "bos_token": "<s>", "eos_token": "</s>"})
+        json.dumps({"tokenizer_class": "GPT2Tokenizer"})
     )
 
     # Create a minimal tokenizer.json that the HF tokenizer can load

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -214,9 +214,7 @@ def test_tokenizer_json_warning(tmp_path):
     invalid_json = '{\n  "bos_token_id": 1,\n  "eos_token_id": 2,\n}'  # trailing comma
 
     (checkpoint_dir / "generation_config.json").write_text(invalid_json)
-    (checkpoint_dir / "tokenizer_config.json").write_text(
-        json.dumps({"tokenizer_class": "GPT2Tokenizer"})
-    )
+    (checkpoint_dir / "tokenizer_config.json").write_text(json.dumps({"tokenizer_class": "GPT2Tokenizer"}))
 
     # Create a minimal tokenizer.json that the HF tokenizer can load
     minimal_tokenizer_json = {

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -175,7 +175,8 @@ class TestEstimateModelMemory:
         inference = estimate_model_memory(config, dtype=torch.float32, training=False)
         training = estimate_model_memory(config, dtype=torch.float32, training=True)
         assert training["estimated_total_gb"] > inference["estimated_total_gb"]
-        # Should be approximately 4× (params + gradients + Adam optimizer states)
+        # Should be approximately 4× (params + gradients + Adam optimizer states).
+        # Bounds are loose (3.5–4.5) to absorb rounding from the two round() calls in the function.
         ratio = training["estimated_total_gb"] / inference["estimated_total_gb"]
         assert 3.5 < ratio < 4.5
 


### PR DESCRIPTION
## What does this PR do?

Fixes 3 tests that broke after #2214 added the `validate` subcommand and related utilities.
ref: [ci](https://github.com/Lightning-AI/litgpt/actions/runs/24114716944/job/70719410112)

## Changes

**`tests/test_cli.py`**
- Added `validate` to the expected subcommand list in `test_cli` (was missing after #2214 registered it).

**`tests/test_validate.py`**
- `test_training_multiplier`: corrected the ratio upper bound from `3.5` → `4.5`; `estimate_model_memory` uses a 4× multiplier for Adam optimizer states, not 3×.
- `test_tokenizer_json_warning`: removed `bos_token`/`eos_token` from the `tokenizer_config.json` fixture — having `bos_token: "<s>"` resolved it to id `0` via vocab lookup, preventing `generation_config.json` from setting `bos_id` to the expected `1`.