### PR TITLE
fix(model): convert bool mask_cache to float additive mask for softcapping

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -586,6 +586,9 @@ class CausalSelfAttention(nn.Module):
             if mask is None:
                 mask = torch.ones(q.size(2), q.size(2), dtype=q.dtype, device=q.device).triu(diagonal=1)
                 mask.masked_fill_(mask.bool(), torch.finfo(q.dtype).min)
+            elif mask.dtype == torch.bool:
+                # build_mask_cache returns a boolean mask (True=keep); convert to additive float mask
+                mask = torch.zeros_like(mask, dtype=q.dtype).masked_fill_(~mask, torch.finfo(q.dtype).min)
             scores = scores + mask
             scores = F.softmax(scores, dim=-1, dtype=torch.float).to(dtype=q.dtype)
             y = scores @ v
@@ -773,6 +776,9 @@ class MultiheadLatentAttention(nn.Module):
             if mask is None:
                 mask = torch.ones(q.size(2), q.size(2), dtype=q.dtype, device=q.device).triu(diagonal=1)
                 mask.masked_fill_(mask.bool(), torch.finfo(q.dtype).min)
+            elif mask.dtype == torch.bool:
+                # build_mask_cache returns a boolean mask (True=keep); convert to additive float mask
+                mask = torch.zeros_like(mask, dtype=q.dtype).masked_fill_(~mask, torch.finfo(q.dtype).min)
             scores = scores + mask
             scores = F.softmax(scores, dim=-1, dtype=torch.float).to(dtype=q.dtype)
             y = scores @ v

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1816,7 +1816,6 @@ def test_attention_mask_bool_to_float_with_softcapping():
     """Boolean mask_cache must be converted to an additive float mask before being added to
     softcapped attention scores (issue #1672).  Without the fix, True/False (1/0) are added
     instead of 0/-inf, breaking causal masking during KV-cache generation."""
-    from litgpt.model import build_mask_cache
 
     dtype = torch.float32
     batch_size, n_head, seq_len, head_size = 1, 2, 4, 8

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1809,3 +1809,41 @@ def test_sliding_window_kv_cache_prefill_exceeds_window():
     k_out, v_out = cache(input_pos_safe, k_safe, v_safe)
     assert k_out.shape == (batch_size, n_query_groups, safe_len, head_size)
     assert v_out.shape == (batch_size, n_query_groups, safe_len, head_size)
+
+
+@torch.inference_mode()
+def test_attention_mask_bool_to_float_with_softcapping():
+    """Boolean mask_cache must be converted to an additive float mask before being added to
+    softcapped attention scores (issue #1672).  Without the fix, True/False (1/0) are added
+    instead of 0/-inf, breaking causal masking during KV-cache generation."""
+    from litgpt.model import build_mask_cache
+
+    dtype = torch.float32
+    batch_size, n_head, seq_len, head_size = 1, 2, 4, 8
+    config = Config(
+        n_layer=1,
+        n_head=n_head,
+        n_embd=n_head * head_size,
+        n_query_groups=n_head,
+        block_size=seq_len,
+        attention_logit_softcapping=50.0,
+        vocab_size=16,
+    )
+    model = GPT(config).to(dtype)
+    model.set_kv_cache(batch_size=batch_size, max_seq_length=seq_len)
+
+    # Confirm mask_cache is boolean (pre-condition of the bug)
+    assert model.mask_cache is not None
+    assert model.mask_cache.dtype == torch.bool
+
+    # Run prefill — all input positions at once
+    input_ids = torch.randint(0, config.vocab_size, (batch_size, seq_len))
+    input_pos = torch.arange(seq_len)
+    out_with_cache = model(input_ids, input_pos)
+
+    # Run without KV cache for reference
+    model.clear_kv_cache()
+    out_no_cache = model(input_ids)
+
+    # Outputs must be numerically close; if mask was bool-added (+0/+1) they would diverge
+    torch.testing.assert_close(out_with_cache, out_no_cache, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## What does this PR do?

When the KV cache is active, `build_mask_cache()` returns a `torch.bool` tensor where `True` indicates a position that should be attended to (lower triangle). In `scaled_dot_product_attention`, for models that use `attention_logit_softcapping` (e.g. Gemma 2), this boolean mask was added directly to the softcapped scores:

```python
scores = scores + mask  # mask is torch.bool → adds 0 or 1, NOT 0 or -inf
```

This breaks causal masking: future positions received a score boost of `+1` instead of `-inf`, so softmax assigned non-zero attention weight to tokens that should be completely masked out.

### Fix

Add an `elif` branch that converts the incoming boolean mask to a float additive mask before the addition (`True → 0.0`, `False → -inf`). The same fix is applied to both `CausalSelfAttention` and `MultiheadLatentAttention`.

```python
elif mask.dtype == torch.bool:
    # build_mask_cache returns a boolean mask (True=keep); convert to additive float mask
    mask = torch.zeros_like(mask, dtype=q.dtype).masked_fill_(~mask, torch.finfo(q.dtype).min)
scores = scores + mask
```

### Testing

Added `test_attention_mask_bool_to_float_with_softcapping` which:
1. Verifies `mask_cache` is indeed `torch.bool` (pre-condition of the bug)
2. Runs a prefill forward pass with KV cache enabled
3. Runs the same forward pass without KV cache
4. Asserts the two outputs are numerically close — they diverge without the fix because the bool mask corrupts the attention distribution

Fixes #1672