### PR TITLE
fix: make sample() produce greedy decoding when temperature=0

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -63,7 +63,7 @@ def sample(
         # do not use `torch.where` as in nanogpt because it will repeat top-k collisions
         logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
     # optionally scale the logits and sample from a probability distribution
-    if temperature > 0.0 or top_p > 0.0:
+    if temperature > 0.0 and top_p > 0.0:
         if temperature > 0.0:
             logits = logits / temperature
         # optionally crop the logits to smallest set of logits with a cumulative probability above top_p

--- a/litgpt/generate/speculative_decoding.py
+++ b/litgpt/generate/speculative_decoding.py
@@ -47,7 +47,7 @@ def sample(
         fill_value = float("-inf") if apply_softmax else float(0)
         logits = torch.full_like(logits, fill_value).scatter_(-1, i, v)
     # optionally scale the logits and sample from a probability distribution
-    if temperature > 0.0 or top_p > 0.0:
+    if temperature > 0.0 and top_p > 0.0:
         if temperature > 0.0:
             logits = logits / temperature
         # optionally crop the logits to smallest set of logits with a cumulative probability above top_p

--- a/tests/generate/test_main.py
+++ b/tests/generate/test_main.py
@@ -134,9 +134,9 @@ def test_sample_temperature_zero_is_greedy():
 
     for top_p in (0.0, 0.5, 1.0):
         results = [sample(logits, temperature=0.0, top_p=top_p).item() for _ in range(10)]
-        assert all(
-            r == expected for r in results
-        ), f"temperature=0 with top_p={top_p} should always return argmax ({expected}), got {results}"
+        assert all(r == expected for r in results), (
+            f"temperature=0 with top_p={top_p} should always return argmax ({expected}), got {results}"
+        )
 
 
 def test_sample_top_p_zero_is_greedy():
@@ -146,9 +146,9 @@ def test_sample_top_p_zero_is_greedy():
 
     for temperature in (0.0, 0.5, 1.0):
         results = [sample(logits, temperature=temperature, top_p=0.0).item() for _ in range(10)]
-        assert all(
-            r == expected for r in results
-        ), f"top_p=0 with temperature={temperature} should always return argmax ({expected}), got {results}"
+        assert all(r == expected for r in results), (
+            f"top_p=0 with temperature={temperature} should always return argmax ({expected}), got {results}"
+        )
 
 
 def test_generate_different_results_with_different_top_p():

--- a/tests/generate/test_main.py
+++ b/tests/generate/test_main.py
@@ -126,6 +126,31 @@ def test_sample(temperature):
     assert token.tolist() == [0]
 
 
+def test_sample_temperature_zero_is_greedy():
+    """Regression test: temperature=0 must always produce greedy (argmax) decoding,
+    regardless of the top_p value. See https://github.com/Lightning-AI/litgpt/issues/2238"""
+    logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
+    expected = torch.argmax(logits[0, -1], dim=-1).item()  # index 2 (value 3.1)
+
+    for top_p in (0.0, 0.5, 1.0):
+        results = [sample(logits, temperature=0.0, top_p=top_p).item() for _ in range(10)]
+        assert all(
+            r == expected for r in results
+        ), f"temperature=0 with top_p={top_p} should always return argmax ({expected}), got {results}"
+
+
+def test_sample_top_p_zero_is_greedy():
+    """top_p=0 must also produce greedy decoding regardless of temperature."""
+    logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
+    expected = torch.argmax(logits[0, -1], dim=-1).item()
+
+    for temperature in (0.0, 0.5, 1.0):
+        results = [sample(logits, temperature=temperature, top_p=0.0).item() for _ in range(10)]
+        assert all(
+            r == expected for r in results
+        ), f"top_p=0 with temperature={temperature} should always return argmax ({expected}), got {results}"
+
+
 def test_generate_different_results_with_different_top_p():
     config = Config(block_size=128, vocab_size=16, n_layer=1, n_head=4, n_embd=8)
     model = GPT(config)


### PR DESCRIPTION
## Summary

Fixes #2238

`sample()` with `temperature=0` does not produce greedy (argmax) decoding when `top_p` is at its default value of `1.0`. Instead, the logits go through `softmax` + `multinomial`, making `temperature=0` completely ineffective.

**Root cause:** The branch guard on line 66 of `generate/base.py`:

```python
if temperature > 0.0 or top_p > 0.0:  # Bug: should be `and`
```

When `temperature=0` and `top_p=1.0` (default), this evaluates to `False or True` → `True`, so the code enters the probabilistic sampling path instead of falling through to `argmax`.

**Fix:** Change `or` to `and`, so that **either** `temperature=0` **or** `top_p=0` is sufficient to produce greedy decoding. Applied to both `generate/base.py` and `generate/speculative_decoding.py`.

## Reproduction

```python
import torch
from litgpt.generate.base import sample

logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
expected = torch.argmax(logits[0, -1], dim=-1).item()  # 2 (the 3.1)

# Before fix: returns random values (e.g., [7, 5, 7, 5, 0, 2, 5, 1, ...])
# After fix: returns [2, 2, 2, 2, 2, 2, 2, 2, 2, 2]
results = [sample(logits, temperature=0.0, top_p=1.0).item() for _ in range(10)]
```

## Test plan

- [x] Added `test_sample_temperature_zero_is_greedy` -- verifies temperature=0 always returns argmax for top_p in {0.0, 0.5, 1.0}
- [x] Added `test_sample_top_p_zero_is_greedy` -- verifies top_p=0 always returns argmax for temperature in {0.0, 0.5, 1.0}
- [x] Existing `test_sample` (3 parametrized cases) still passes
- [x] Existing `test_generate_different_results_with_different_top_p` still passes