### PR TITLE
chore(data): add return type annotations to FLAN dataloader methods

### DIFF
--- a/litgpt/data/flan.py
+++ b/litgpt/data/flan.py
@@ -44,7 +44,7 @@ class FLAN(DataModule):
     train_dataset: SFTDataset | None = field(default=None, init=False, repr=False)
     test_dataset: SFTDataset | None = field(default=None, init=False, repr=False)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         super().__init__()
         if isinstance(self.prompt_style, str):
             self.prompt_style = PromptStyle.from_name(self.prompt_style)
@@ -73,10 +73,10 @@ class FLAN(DataModule):
                 data_file_url = f"{self.url}/{split}/{subset}_{split}.jsonl"
                 download_if_missing(data_file_path, data_file_url)
 
-    def train_dataloader(self):
+    def train_dataloader(self) -> DataLoader:
         return self._dataloader("train")
 
-    def val_dataloader(self):
+    def val_dataloader(self) -> DataLoader:
         return self._dataloader("test")
 
     def _dataloader(self, split: str) -> DataLoader:


### PR DESCRIPTION
## What does this PR do?

Adds missing return type annotations to three methods in `litgpt/data/flan.py` that were previously unannotated:

| Method | Added |
|---|---|
| `FLAN.__post_init__` | `-> None` |
| `FLAN.train_dataloader` | `-> DataLoader` |
| `FLAN.val_dataloader` | `-> DataLoader` |

`DataLoader` was already imported at the top of the file, so no new imports are needed.

This follows the pattern established in #2221 (which bumped `ruff` `target-version` to `py310`) and continues the type annotation work started in #2237.

## Before submitting

- [x] Was this discussed/approved via a GitHub issue? Follows the type-annotation pattern from #2221 and #2237.
- [x] Did you make sure to update the docs? N/A — annotation-only change.
- [x] Did you write any new unit tests? N/A — no behavioural change.