### PR TITLE
chore(api): add type annotations to LLM class and module-level functions

### DIFF
--- a/litgpt/api.py
+++ b/litgpt/api.py
@@ -39,12 +39,12 @@ class LLM(torch.nn.Module):
     def __init__(
         self,
         model: GPT,
-        preprocessor=None,
-        prompt_style: PromptStyle = None,
-        devices: int | list[int] = None,
-        config: Config = None,
-        checkpoint_dir: Path = None,
-        fabric: L.Fabric = None,
+        preprocessor: "Preprocessor | None" = None,
+        prompt_style: PromptStyle | None = None,
+        devices: int | list[int] | None = None,
+        config: Config | None = None,
+        checkpoint_dir: Path | None = None,
+        fabric: L.Fabric | None = None,
         generate_strategy: Literal["sequential", "tensor_parallel"] | None = None,
         kv_cache_initialized: bool = False,
         fixed_kv_cache_size: int | Literal["max_model_supported"] | None = None,
@@ -74,13 +74,13 @@ class LLM(torch.nn.Module):
     """
 
     @property
-    def tokenizer(self):
+    def tokenizer(self) -> Tokenizer:
         return self.preprocessor.tokenizer
 
-    def state_dict(self, destination=None, prefix="", keep_vars=False):
+    def state_dict(self, destination: dict | None = None, prefix: str = "", keep_vars: bool = False) -> dict:
         return self.model.state_dict(destination=destination, prefix=prefix, keep_vars=keep_vars)
 
-    def load_state_dict(self, state_dict, strict=True):
+    def load_state_dict(self, state_dict: dict, strict: bool = True) -> Any:
         return self.model.load_state_dict(state_dict, strict=strict)
 
     def forward(
@@ -574,7 +574,7 @@ class LLM(torch.nn.Module):
         input_ids = self.preprocessor.encode(prompt)
         return input_ids
 
-    def benchmark(self, num_iterations=1, **kwargs):
+    def benchmark(self, num_iterations: int = 1, **kwargs: Any) -> tuple[str, dict]:
         """
         A wrapper around the .generate() method to calculate runtime performance.
 
@@ -633,7 +633,7 @@ class Preprocessor:
         return self.tokenizer.decode(token_ids)
 
 
-def calculate_number_of_devices(devices):
+def calculate_number_of_devices(devices: int | list[int]) -> int:
     """
     Utility function to calculate the number of devices.
     """
@@ -641,7 +641,7 @@ def calculate_number_of_devices(devices):
     return num_devices
 
 
-def benchmark_dict_to_markdown_table(data):
+def benchmark_dict_to_markdown_table(data: dict) -> str:
     """
     Converts .benchmark() outputs to a markdown table
     """


### PR DESCRIPTION
## What does this PR do?

Adds missing Python 3.10+ style type annotations to `litgpt/api.py`. `api.py` had the most unannotated functions of any non-`utils.py` file in the codebase (11 functions), and also contained several implicit-`Optional` signatures that mypy flags as errors.

### Changes

| Location | Change |
|---|---|
| `LLM.__init__` | `preprocessor: "Preprocessor \| None" = None` |
| `LLM.__init__` | `prompt_style: PromptStyle \| None = None` |
| `LLM.__init__` | `devices: int \| list[int] \| None = None` |
| `LLM.__init__` | `config: Config \| None = None` |
| `LLM.__init__` | `checkpoint_dir: Path \| None = None` |
| `LLM.__init__` | `fabric: L.Fabric \| None = None` |
| `LLM.tokenizer` property | `-> Tokenizer` |
| `LLM.state_dict` | `destination: dict \| None`, `prefix: str`, `keep_vars: bool`, `-> dict` |
| `LLM.load_state_dict` | `state_dict: dict`, `strict: bool`, `-> Any` |
| `LLM.benchmark` | `num_iterations: int`, `**kwargs: Any`, `-> tuple[str, dict]` |
| `calculate_number_of_devices` | `devices: int \| list[int]`, `-> int` |
| `benchmark_dict_to_markdown_table` | `data: dict`, `-> str` |

The `preprocessor` parameter uses a forward reference string (`"Preprocessor | None"`) because `Preprocessor` is defined later in the same file.

No new imports needed — `Any` was already imported from `typing`.

## Before submitting

- [x] Was this discussed/approved via a GitHub issue? Follows the type-annotation pattern from #2221 and #2237.
- [x] Did you make sure to update the docs? N/A — annotation-only change.
- [x] Did you write any new unit tests? N/A — no behavioural change.