### PR TITLE
Attempt to fix #2220: Enable Flash Attention in KV-cache path

### DIFF
--- a/litgpt/model.py
+++ b/litgpt/model.py
@@ -343,6 +343,12 @@ class CausalSelfAttention(nn.Module):
             scores = torch.nn.functional.softmax(scores, dim=-1, dtype=torch.float).to(dtype=q.dtype)
             y = scores @ v
         else:
+            # 修复 #2220: 在单步解码 (decoding) 阶段，q 的序列长度为 1，
+            # 此时不需要因果掩码，丢弃 mask 可以让 PyTorch 启用 Flash Attention 加速。
+            if mask is not None and q.size(2) == 1:
+                mask = None
+
+            # 注意这里！把 F. 换成了完整的 torch.nn.functional.
             y = torch.nn.functional.scaled_dot_product_attention(
                 q, k, v, attn_mask=mask, dropout_p=0.0, scale=scale, is_causal=mask is None
             )


### PR DESCRIPTION
Fixes #2220 

**What I did:**
I noticed in #2220 that passing an explicit `attn_mask` disables the PyTorch SDPA Flash Attention fast path. I tried to drop the mask during the decoding phase (`q.size(2) == 1`) in `CausalSelfAttention.scaled_dot_product_attention` to re-enable it.

**The Issue:**
Running `pytest tests/test_model.py` results in `AssertionError: Tensor-likes are not close!` for a few tests (e.g., `test_against_gpt_neox_model`). 
I realize that simply dropping the mask causes the query to attend to the uninitialized/padded parts of the `k` and `v` tensors in the `KVCache` if `input_pos_maxp1` is not aggressively slicing them.

**Question for reviewers:**
Could you guide me on the safest way to slice the KV-cache or formulate the `is_causal` flag here so that we can safely drop the explicit mask without reading uninitialized memory? I would love to finish this PR with your guidance!