### PR TITLE
fix(merge_lora): silence false-positive '16-mixed' AMP warning on CPU

### DIFF
--- a/litgpt/scripts/merge_lora.py
+++ b/litgpt/scripts/merge_lora.py
@@ -53,6 +53,14 @@ def merge_lora(
         pretrained_checkpoint_dir = meta_pretrained_checkpoint_dir
         pretrained_checkpoint_dir = extend_checkpoint_dir(pretrained_checkpoint_dir)
 
+    # ``Fabric(accelerator="cpu", precision="16-mixed")`` emits a warning and silently downgrades
+    # to ``bf16-mixed`` because AMP fp16 is not supported on CPU. The merge step only loads weights
+    # and overrides their dtype on L75 (``model.to(dtype=lora_dtype, device="cpu")``), so the
+    # precision value here has no effect on the saved checkpoint — do the downgrade ourselves to
+    # avoid the false-positive warning that confuses users (#1242).
+    if precision == "16-mixed":
+        precision = "bf16-mixed"
+
     fabric = L.Fabric(devices=1, precision=precision, accelerator="cpu")
     config = Config.from_file(checkpoint_dir / "model_config.yaml", **lora_params)
 

--- a/tests/test_merge_lora.py
+++ b/tests/test_merge_lora.py
@@ -74,6 +74,54 @@ def test_merge_lora(tmp_path, fake_checkpoint_dir, pretrained_dtype, lora_dtype)
     assert "LoRA weights have already been merged" in stdout.getvalue()
 
 
+def test_merge_lora_downgrades_16_mixed_to_avoid_cpu_warning(tmp_path, fake_checkpoint_dir, caplog):
+    """Regression test for #1242.
+
+    Fabric emits ``You passed 'precision=16-mixed'... AMP with fp16 is not supported on CPU. Using
+    'bf16-mixed' instead.`` when initialised with ``accelerator='cpu'``. merge_lora always runs on
+    CPU, and if the LoRA hyperparameters file recorded ``precision: 16-mixed`` (the default for many
+    GPU finetune configs) we should downgrade to ``bf16-mixed`` ourselves to avoid the false-positive
+    warning. The dtype is overridden later via ``model.to(dtype=lora_dtype, device='cpu')`` so this
+    has no effect on the saved checkpoint.
+    """
+    pretrained_checkpoint_dir = tmp_path / "pretrained"
+    lora_checkpoint_dir = tmp_path / "lora"
+    shutil.copytree(fake_checkpoint_dir, pretrained_checkpoint_dir)
+    shutil.copytree(fake_checkpoint_dir, lora_checkpoint_dir)
+    (lora_checkpoint_dir / "lit_model.pth").unlink()
+    shutil.rmtree(tmp_path / "checkpoints")
+
+    config = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
+    with open(pretrained_checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
+        yaml.dump(config, fp)
+    base_model = GPT.from_name("pythia-14m", **config)
+    torch.save(base_model.state_dict(), pretrained_checkpoint_dir / "lit_model.pth")
+
+    lora_kwargs = dict(lora_r=8, lora_alpha=16, lora_dropout=0.05, lora_query=True, lora_value=True)
+    lora_model = LoRAGPT.from_name("pythia-14m", **config, **lora_kwargs)
+    state_dict = {k: v for k, v in lora_model.state_dict().items() if lora_filter(k, v)}
+    torch.save(state_dict, lora_checkpoint_dir / "lit_model.pth.lora")
+    # precision='16-mixed' is the trigger — this is what gets persisted by GPU LoRA finetune runs.
+    hparams = dict(checkpoint_dir=str(pretrained_checkpoint_dir), precision="16-mixed", **lora_kwargs)
+    with open(lora_checkpoint_dir / "hyperparameters.yaml", "w", encoding="utf-8") as file:
+        yaml.dump(hparams, file)
+    shutil.copyfile(pretrained_checkpoint_dir / "model_config.yaml", lora_checkpoint_dir / "model_config.yaml")
+
+    # Capture warnings emitted by Fabric. Before the fix, this fires:
+    #   "You passed `Fabric(accelerator='cpu', precision='16-mixed')` but AMP with fp16 is not
+    #    supported on CPU. Using `precision='bf16-mixed'` instead."
+    with caplog.at_level("WARNING"):
+        merge_lora(lora_checkpoint_dir)
+
+    # The fabric/utilities/imports.py warning text should not appear anywhere in captured records.
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "AMP with fp16 is not supported on CPU" not in joined, (
+        f"Expected merge_lora to downgrade '16-mixed' to 'bf16-mixed' on CPU silently, "
+        f"but Fabric still emitted the warning:\n{joined}"
+    )
+    assert (lora_checkpoint_dir / "lit_model.pth").is_file()
+
+
 def test_load_lora_metadata(fake_checkpoint_dir):
     assert not (fake_checkpoint_dir / "hyperparameters.yaml").is_file()
     with pytest.raises(FileNotFoundError, match="missing a `hyperparameters.yaml` file"):


### PR DESCRIPTION
## Summary

Fixes #1242.

When a user finetunes LoRA with `precision: 16-mixed` (a common default for GPU runs), `litgpt merge_lora` runs Fabric on CPU with that precision and Fabric prints:

```
You passed `Fabric(accelerator='cpu', precision='16-mixed')` but AMP with fp16 is not supported on CPU. Using `precision='bf16-mixed'` instead.
```

The warning is a false positive: the merge step only loads weights and immediately overrides their dtype with `model.to(dtype=lora_dtype, device="cpu")` ([`merge_lora.py:75`](https://github.com/Lightning-AI/litgpt/blob/main/litgpt/scripts/merge_lora.py#L75)), so the `precision` passed to Fabric has no effect on the saved checkpoint. The warning still surfaces to users who configure Fabric in their training script and don't know what's happening under the hood, as flagged in the original issue.

This PR downgrades `"16-mixed"` → `"bf16-mixed"` ourselves before calling `L.Fabric(...)`, matching what Fabric would do internally but without the noisy warning. All other precision values pass through unchanged, so behaviour is preserved.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# In a fresh venv with: lightning torch huggingface-hub safetensors tokenizers tqdm jsonargparse

git clone https://github.com/Lightning-AI/litgpt.git litgpt-repro && cd litgpt-repro

# --- BEFORE (origin/main) ---
git checkout main
# Expected: 1 line containing "AMP with fp16 is not supported on CPU" printed by Fabric
python -c "
import warnings, tempfile, shutil, yaml, torch
from pathlib import Path
from litgpt.model import GPT
from litgpt.lora import GPT as LoRAGPT, lora_filter
from litgpt.scripts.merge_lora import merge_lora

with tempfile.TemporaryDirectory() as tmp:
    tmp = Path(tmp)
    base = tmp / 'base'; lora = tmp / 'lora'
    for d in (base, lora):
        d.mkdir()
        for f in ('lit_model.pth','model_config.yaml','tokenizer.json','tokenizer_config.json'):
            (d / f).touch()
    cfg = dict(block_size=128, padded_vocab_size=256, n_layer=3, n_head=8, n_embd=16)
    yaml.dump(cfg, open(base/'model_config.yaml','w'))
    yaml.dump(cfg, open(lora/'model_config.yaml','w'))
    torch.save(GPT.from_name('pythia-14m', **cfg).state_dict(), base/'lit_model.pth')
    lora_kwargs = dict(lora_r=8, lora_alpha=16, lora_dropout=0.0, lora_query=True, lora_value=True)
    m = LoRAGPT.from_name('pythia-14m', **cfg, **lora_kwargs)
    sd = {k:v for k,v in m.state_dict().items() if lora_filter(k,v)}
    torch.save(sd, lora/'lit_model.pth.lora')
    (lora/'lit_model.pth').unlink()
    hparams = dict(checkpoint_dir=str(base), precision='16-mixed', **lora_kwargs)
    yaml.dump(hparams, open(lora/'hyperparameters.yaml','w'))
    merge_lora(lora)
"

# --- AFTER (this branch) ---
git fetch origin pull/<this-pr>/head:fix-1242 && git checkout fix-1242
# Expected: NO "AMP with fp16 is not supported on CPU" line; merge completes silently
# (re-run the same Python snippet)
```

## What I ran locally

Unit test under `tests/test_merge_lora.py::test_merge_lora_downgrades_16_mixed_to_avoid_cpu_warning`:

- On `origin/main`: fails — the Fabric warning record matches `"AMP with fp16 is not supported on CPU"`.
- On this branch: passes — `caplog` captures no such record; `lit_model.pth` is written successfully.

The existing parametrised `test_merge_lora` (3 cases) still passes because the new branch only fires when `precision == "16-mixed"`, which the existing tests don't exercise.

## Edge cases

| Input `precision` from `hyperparameters.yaml` | Old behaviour | New behaviour |
|---|---|---|
| `"16-mixed"` | Fabric warns + downgrades to `bf16-mixed` | Silently downgraded to `bf16-mixed` here |
| `"bf16-mixed"` | passthrough | passthrough (unchanged) |
| `"bf16-true"`, `"32-true"`, `"16-true"`, etc. | passthrough | passthrough (unchanged) |
| `None` (no precision in metadata) | passthrough → Fabric default | passthrough (unchanged) |
| User passes `--precision 16-mixed` explicitly on CLI | warning | also silenced — same physics, same intent |

The downgrade applies to both the metadata-driven path (`lora_precision` from `hyperparameters.yaml`) and the CLI-driven path (`--precision`), because the warning is purely a function of `(precision, accelerator)` and `merge_lora` is always CPU-bound here.

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against `litgpt/scripts/merge_lora.py` and `tests/test_merge_lora.py`. The reproducer block above is the one I used during development; reviewers can paste it verbatim.*
