### PR TITLE
security: remove `pull_request_target` trigger from CPU tests workflow

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -3,10 +3,12 @@ name: CPU tests
 on:
   push:
     branches: [main]
-  pull_request_target:
+  # Note: using `pull_request` (not `pull_request_target`) for security reasons.
+  # This means PRs from external forks will NOT have access to secrets (e.g. HF_TOKEN)
+  # and some tests may fail or be skipped on fork PRs until we find a better solution.
+  pull_request:
     branches: [main]
     types: [opened, reopened, ready_for_review, labeled, synchronize]
-  pull_request: {} # todo
   workflow_dispatch: {}
 
 # lock down all permissions by default
@@ -36,7 +38,6 @@ env:
 jobs:
   testing-imports:
     runs-on: ${{ matrix.os }}
-    if: github.event_name != 'pull_request_target'
     strategy:
       fail-fast: false
       matrix:
@@ -67,14 +68,6 @@ jobs:
           python -c "$modules"
 
   pytester:
-    # Route PRs based on contributor type to avoid duplicate runs:
-    # - Collaborators: use pull_request (tests workflow changes from PR)
-    # - External forks: use pull_request_target (uses trusted workflow from main)
-    # - Always run for push to main and workflow_dispatch
-    if: |
-      (github.event_name == 'pull_request' && contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)) ||
-      (github.event_name == 'pull_request_target' && !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)) ||
-      (github.event_name != 'pull_request' && github.event_name != 'pull_request_target')
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -90,12 +83,6 @@ jobs:
     steps:
       - name: Checkout generic
         uses: actions/checkout@v6
-        if: github.event_name != 'pull_request_target'
-      - name: Checkout for `pull_request_target`
-        uses: actions/checkout@v6
-        if: github.event_name == 'pull_request_target'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
@@ -137,9 +124,7 @@ jobs:
   testing-guardian:
     runs-on: ubuntu-latest
     needs: [pytester, testing-imports]
-    if: |
-      (github.event_name == 'pull_request_target' && !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association)) ||
-      (github.event_name == 'pull_request' && contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association))
+    if: github.event_name == 'pull_request'
     steps:
       - run: echo "${{ needs.pytester.result }}"
       - name: failing...


### PR DESCRIPTION
## What does this PR do?

Removes `pull_request_target` from the CPU tests workflow and replaces it with `pull_request` to fix a security concern — `pull_request_target` runs with write permissions and access to secrets even for fork PRs, which creates a risk of secret exfiltration.

**Note:** Fork PRs may not have access to secrets (e.g. `HF_TOKEN`) until a better alternative solution is in place.