### PR TITLE
fix(tests): xfail DynamoThunder tests with torch>=2.12

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,3 +175,13 @@ def pytest_collection_modifyitems(items: list[pytest.Function], config: pytest.C
                     reason="currently not working, see https://github.com/Lightning-AI/lightning-thunder/issues/2085",
                 )
             )
+        # TODO: remove once thunder supports torch>=2.12
+        # DynamoThunder tests fail with torch>=2.12 due to MappingKeysView/generator having no len()
+        # in thunder's interpreter.
+        if "DynamoThunder" in test.nodeid and torch.__version__ >= "2.12":
+            test.add_marker(
+                pytest.mark.xfail(
+                    reason="DynamoThunder tests incompatible with torch>=2.12, see thunder upstream",
+                    strict=False,
+                )
+            )


### PR DESCRIPTION
## What does this PR do?

Marks `DynamoThunder` tests as `xfail` when running with `torch>=2.12`.

Thunder's interpreter hits `TypeError: object of type 'MappingKeysView' has no len()` and `TypeError: object of type 'generator' has no len()` when running `DynamoThunder` tests against `torch 2.12.0`. The same thunder version (`0.2.7.dev20260201`) passed cleanly with `torch 2.11.0` (last green CI on main: April 16, 2026).

ref: https://github.com/Lightning-AI/litgpt/actions/runs/26576167375/job/78310662025?pr=2253

This is a thunder-side issue — marking as `xfail` with a `TODO` keeps CI green while the fix is tracked upstream.