### PR TITLE
chore: pin GitHub Actions to verified commit SHAs

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -46,8 +46,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout generic
-        uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -82,8 +82,8 @@ jobs:
     timeout-minutes: 35
     steps:
       - name: Checkout generic
-        uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache-dependency-path: pyproject.toml
@@ -91,7 +91,7 @@ jobs:
 
       # Add caching for HF models and tokenizers
       - name: HF cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         continue-on-error: true
         with:
           path: .cache-HF

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # Step 1: Checkout the repository
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Step 2: Set up Python
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           cache: "pip"

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout source
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.x"
           cache: "pip"
@@ -35,7 +35,7 @@ jobs:
           python -m build
           twine check --strict dist/*
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Pins GitHub Actions to verified commit SHAs for supply chain security.

Follows the same pattern as [pytorch-lightning#21735](https://github.com/Lightning-AI/pytorch-lightning/pull/21735).

## Pinned references

| Action | Release | Commit SHA |
|--------|---------|------------|
| `actions/checkout` | [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2) | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `actions/setup-python` | [v6.2.0](https://github.com/actions/setup-python/releases/tag/v6.2.0) | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `actions/cache` | [v5](https://github.com/actions/cache/releases/tag/v5) | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| `pypa/gh-action-pypi-publish` | [v1.14.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.0) | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |
