### PR TITLE
ci: migrate workflows from pip to uv

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,18 +15,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          activate-environment: true
           python-version: "3.10"
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "mistune<3.1"  # a newer version is incompatible with nbconvert
-          pip install pytest pytest-check-links
+        # a newer version of mistune is incompatible with nbconvert
+        run: uv pip install "mistune<3.1" pytest pytest-check-links
 
       - name: Check links
-        run: |
-          pytest --check-links README.md --check-links-ignore "http*"
-          pytest --check-links tutorials --check-links-ignore "http*"
+        run: pytest --check-links README.md tutorials --check-links-ignore "http*"
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -33,7 +33,7 @@ env:
   TRANSFORMERS_CACHE: .cache-HF/transformers
   DATASETS_CACHE: .cache-HF/datasets
   HF_DATASETS_CACHE: .cache-HF/datasets
-  TORCH_URL: "https://download.pytorch.org/whl/cpu/"
+  UV_TORCH_BACKEND: cpu
 
 jobs:
   testing-imports:
@@ -47,14 +47,17 @@ jobs:
     steps:
       - name: Checkout generic
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          activate-environment: true
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
 
       - name: Install minimal dependencies
         run: |
-          pip install . -U --extra-index-url="${TORCH_URL}"
-          pip list
+          uv sync --no-dev
+          uv pip list
 
       - name: Testing package imports
         # make sure all modules are still importable with only the minimal dependencies available
@@ -66,6 +69,9 @@ jobs:
           )
           echo "$modules"
           python -c "$modules"
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
 
   pytester:
     runs-on: ${{ matrix.os }}
@@ -83,11 +89,12 @@ jobs:
     steps:
       - name: Checkout generic
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
+          activate-environment: true
           python-version: ${{ matrix.python-version }}
-          cache-dependency-path: pyproject.toml
-          cache: "pip"
+          enable-cache: true
 
       # Add caching for HF models and tokenizers
       - name: HF cache
@@ -103,13 +110,12 @@ jobs:
 
       - name: Set min. dependencies
         if: matrix.requires == 'oldest'
-        run: |
-          pip install 'lightning-utilities[cli]>=0.15.1'
-          python -m lightning_utilities.cli requirements set-oldest --req_files=pyproject.toml
+        run: uv run --no-project --with 'lightning-utilities[cli]>=0.15.1' python -m lightning_utilities.cli requirements set-oldest --req_files=pyproject.toml
+
       - name: Install dependencies
         run: |
-          pip install '.[extra,compiler,test]' -U --upgrade-strategy eager --extra-index-url="${TORCH_URL}"
-          pip list
+          uv sync --all-extras
+          uv pip list
 
       - name: Run tests
         env:
@@ -117,9 +123,10 @@ jobs:
         run: pytest -v litgpt/ tests/ --timeout=180 --durations=100
 
       - name: Show cache
-        run: |
-          pip install -q py-tree
-          python -m py_tree -d 1 .cache-HF
+        run: uvx py-tree -d 1 .cache-HF
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
 
   testing-guardian:
     runs-on: ubuntu-latest

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -14,14 +14,17 @@ jobs:
       # Step 1: Checkout the repository
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # Step 2: Set up Python
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      # Step 2: Install uv
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          python-version: "3.x"
-          cache: "pip"
+          activate-environment: true
+          python-version: "3.10"
+          enable-cache: true
 
       # Step 3: Install MkDocs and dependencies
-      - run: pip install mkdocs mkdocs-material mkdocs-pagetree-plugin
+      - run: uv pip install mkdocs mkdocs-material mkdocs-pagetree-plugin
+
       # Step 4: Deploy to GitHub Pages
       - run: |
           mkdir -p gh-pages/docs
@@ -30,3 +33,6 @@ jobs:
           mv docs/mkdocs.yml mkdocs.yml
           echo "{{ pagetree }}" > docs/index.md
           mkdocs gh-deploy --force
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci


### PR DESCRIPTION
## What does this PR do?

Migrates CI workflows (`cpu-tests`, `check-links`, `mkdocs-deploy`) from pip to [uv](https://github.com/astral-sh/uv) for faster, more reproducible dependency installs. Follows the same pattern used in [LitServe](https://github.com/Lightning-AI/LitServe) and [litData](https://github.com/Lightning-AI/litData).

- Replaces `actions/setup-python` + pip with `astral-sh/setup-uv`
- Uses `UV_TORCH_BACKEND: cpu` instead of a manual PyTorch CPU index URL
- Keeps `lightning_utilities set-oldest` for the `oldest` matrix job (confirmed equivalent to the original pip approach)
- Adds `uv cache prune --ci` to all jobs

`publish-pkg.yml` is out of scope.

Did you have fun? Yes 🎉