### PR TITLE
Omit ChatML system turn when there is no system message (Qwen3 emitted literal 'None')

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -374,9 +374,9 @@ class ChatML(PromptStyle):
 
     def apply(self, prompt: str, *, sys_prompt: str | None = None, **kwargs: str) -> str:
         sys_prompt = sys_prompt or self.system_message
-        return (
-            f"<|im_start|>system\n{sys_prompt}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
-        )
+        # omit the system turn when there is no system message (e.g. Qwen3)
+        system = f"<|im_start|>system\n{sys_prompt}<|im_end|>\n" if sys_prompt else ""
+        return f"{system}<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
 
 
 class Qwen2_5(ChatML):


### PR DESCRIPTION
### Problem

`Qwen3` is defined as `ChatML` with no default system message:

```python
class Qwen3(ChatML):
    def __init__(self):
        super().__init__()   # system_message = None
```

`ChatML.apply` then does `sys_prompt = sys_prompt or self.system_message` (both `None`) and unconditionally formats it:

```python
return f"<|im_start|>system\n{sys_prompt}<|im_end|>\n..."
```

So a Qwen3 prompt becomes `"<|im_start|>system\nNone<|im_end|>\n..."` — the literal string **`None`** is injected as the system message.

### Fix

Emit the system turn only when a system prompt is actually present, matching the Qwen3 chat template (which omits the system block when there's no system content). ChatML subclasses that set a `system_message` (Qwen2_5, QwQ, SmolLM2, …) are unchanged.

### Verification

```
Qwen3().apply("Hello")                      -> "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n"   (no "None", no system block)
Qwen2_5().apply("Hello")                    -> still starts with "<|im_start|>system\nYou are Qwen..."
Qwen3().apply("Hello", sys_prompt="Be terse.") -> "<|im_start|>system\nBe terse.<|im_end|>\n..."
```
