### PR TITLE
ci: migrate PyPI release to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -63,7 +63,6 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: pypi
     permissions:
       id-token: write
 

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -63,9 +63,7 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment:
-      name: pypi
-      url: https://pypi.org/p/litgpt
+    environment: pypi
     permissions:
       id-token: write
 

--- a/.github/workflows/publish-pkg.yml
+++ b/.github/workflows/publish-pkg.yml
@@ -8,15 +8,13 @@ on:
   push:
     tags:
       - "v*"
+  release:
+    types: [published]
+
 jobs:
-  build-n-publish:
-    name: Build and publish to PyPI
+  build:
+    name: Build source and wheel distributions
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/litgpt
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout source
@@ -34,8 +32,50 @@ jobs:
           pip install importlib_metadata==7.2.1
           python -m build
           twine check --strict dist/*
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+
+  upload-release-assets:
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+
+      - run: ls -lh dist/
+
+      - name: Upload to release
+        uses: AButler/upload-release-assets@34491005a5d7ec239a784e460807ce844fde7962 # v4.0.0
+        with:
+          files: "dist/*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-pypi:
+    needs: build
+    if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: pypi
+      url: https://pypi.org/p/litgpt
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pypi-packages-${{ github.sha }}
+          path: dist
+
+      - run: ls -lh dist/
+
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Migrates the PyPI release workflow from token-based authentication to [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/using-a-publisher/), following the same pattern as Lightning-AI/litData#827.

- Splits the workflow into `build`, `upload-release-assets`, and `publish-pypi` jobs
- Shares `dist/` through a GitHub artifact between jobs
- Uploads built distributions to GitHub Releases on `release` events
- Publishes to PyPI with OIDC (`permissions: id-token: write`) and removes the `PYPI_API_TOKEN` secret requirement

**Pre-requisite before merging:** configure a trusted publisher on the litgpt PyPI project (Manage → Publishing) with owner `Lightning-AI`, repo `litgpt`, workflow `publish-pkg.yml`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in GitHub issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃