### PR TITLE
fix: make convert_from_litgpt output loadable with AutoModel.from_pretrained

### DIFF
--- a/litgpt/eval/evaluate.py
+++ b/litgpt/eval/evaluate.py
@@ -8,7 +8,7 @@ from pprint import pprint
 import torch
 
 from litgpt.scripts.convert_lit_checkpoint import convert_lit_checkpoint
-from litgpt.utils import auto_download_checkpoint, copy_config_files
+from litgpt.utils import auto_download_checkpoint
 
 
 def prepare_results(results, save_filepath, print_results=True):
@@ -44,7 +44,7 @@ def convert_and_evaluate(
         out_dir: Directory in which to save the converted checkpoints for evaluation.
             Saves to `checkpoint_dir`/evaluate by default.
         force_conversion: Set to `True` to reconvert the model and override
-            an existing model.pth from a previous evaluation call.
+            an existing pytorch_model.bin from a previous evaluation call.
         tasks: CSV of task names to evaluate. Example: "hellaswag,truthfulqa_mc2,mmlu"
         num_fewshot: Number of examples in few-shot context.
         batch_size: Batch size configuration as positive integer value (default: 1),
@@ -92,15 +92,7 @@ def convert_and_evaluate(
 
     model_path = out_dir / "pytorch_model.bin"
     if not model_path.exists() or force_conversion:
-        copy_config_files(source_dir=checkpoint_dir, out_dir=out_dir)
         convert_lit_checkpoint(checkpoint_dir=checkpoint_dir, output_dir=out_dir)
-
-        # Hack: LitGPT's conversion doesn't save a pickle file that is compatible to be loaded with
-        # `torch.load(..., weights_only=True)`, which is a requirement in HFLM.
-        # So we're `torch.load`-ing and `torch.save`-ing it again to work around this.
-        state_dict = torch.load(out_dir / "model.pth")
-        torch.save(state_dict, model_path)
-        os.remove(out_dir / "model.pth")
 
     from lm_eval.models.huggingface import HFLM
 

--- a/litgpt/scripts/convert_lit_checkpoint.py
+++ b/litgpt/scripts/convert_lit_checkpoint.py
@@ -11,7 +11,7 @@ from lightning.fabric.utilities.load import _NotYetLoadedTensor as NotYetLoadedT
 
 from litgpt import Config
 from litgpt.scripts.convert_hf_checkpoint import layer_template, load_param
-from litgpt.utils import extend_checkpoint_dir, incremental_save, lazy_load
+from litgpt.utils import copy_config_files, extend_checkpoint_dir, incremental_save, lazy_load
 
 
 def copy_weights_falcon(
@@ -550,7 +550,8 @@ def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
     config = Config.from_file(checkpoint_dir / "model_config.yaml")
 
     output_dir.mkdir(parents=True, exist_ok=True)
-    output_path = output_dir / "model.pth"
+    # use the Hugging Face filename so `transformers.AutoModel.from_pretrained(output_dir)` finds the weights
+    output_path = output_dir / "pytorch_model.bin"
 
     if "falcon" in config.name:
         copy_fn = partial(copy_weights_falcon, config)
@@ -581,3 +582,7 @@ def convert_lit_checkpoint(checkpoint_dir: Path, output_dir: Path) -> None:
         copy_fn(sd, lit_weights, saver=saver)
         gc.collect()
         saver.save(sd)
+
+    # copy the config and tokenizer files so the output directory can be loaded directly with
+    # `transformers.AutoModel.from_pretrained(output_dir)`
+    copy_config_files(source_dir=checkpoint_dir, out_dir=output_dir)

--- a/tests/convert/test_lit_checkpoint.py
+++ b/tests/convert/test_lit_checkpoint.py
@@ -51,13 +51,52 @@ def test_convert_lit_checkpoint(tmp_path, model_name):
 
     convert_lit_checkpoint(checkpoint_path.parent, output_dir)
     assert set(os.listdir(tmp_path)) == {"lit_model.pth", "model_config.yaml", "out_dir"}
-    assert os.path.isfile(output_dir / "model.pth")
+    assert os.path.isfile(output_dir / "pytorch_model.bin")
+    # config files available in the checkpoint dir are copied to make the output loadable with HF transformers
+    assert os.path.isfile(output_dir / "model_config.yaml")
 
     # check checkpoint is unwrapped
     torch.save({"model": ours_model.state_dict()}, checkpoint_path)
     convert_lit_checkpoint(checkpoint_path.parent, output_dir)
-    converted_sd = torch.load(output_dir / "model.pth")
+    converted_sd = torch.load(output_dir / "pytorch_model.bin", weights_only=True)
     assert "model" not in converted_sd
+
+
+def test_convert_lit_checkpoint_loads_with_automodel(tmp_path):
+    """Regression test for https://github.com/Lightning-AI/litgpt/issues/1871"""
+    ours_config = Config.from_name("pythia-14m", block_size=8, n_layer=2, n_embd=32, n_head=2, padding_multiple=128)
+    theirs_config = GPTNeoXConfig(
+        hidden_act="gelu",
+        hidden_size=ours_config.n_embd,
+        num_attention_heads=ours_config.n_head,
+        num_hidden_layers=ours_config.n_layer,
+        initializer_range=0.02,
+        intermediate_size=ours_config.intermediate_size,
+        layer_norm_eps=1e-05,
+        max_position_embeddings=ours_config.block_size,
+        rotary_emb_base=10000,
+        rotary_pct=ours_config.rotary_percentage,
+        vocab_size=ours_config.padded_vocab_size,
+        use_parallel_residual=ours_config.parallel_residual,
+    )
+
+    checkpoint_dir = tmp_path / "checkpoint_dir"
+    checkpoint_dir.mkdir()
+    ours_model = GPT(ours_config)
+    torch.save(ours_model.state_dict(), checkpoint_dir / "lit_model.pth")
+    with open(checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
+        yaml.dump(asdict(ours_config), fp)
+    # checkpoint dirs from `litgpt download/pretrain/finetune` also contain the HF `config.json`
+    theirs_config.to_json_file(checkpoint_dir / "config.json")
+
+    output_dir = tmp_path / "out_dir"
+    convert_lit_checkpoint(checkpoint_dir, output_dir)
+
+    theirs_model = AutoModelForCausalLM.from_pretrained(output_dir, local_files_only=True)
+    x = torch.randint(0, ours_config.padded_vocab_size, size=(2, ours_config.block_size), dtype=torch.int64)
+    ours_y = ours_model(x)
+    theirs_y = theirs_model(x)["logits"]
+    torch.testing.assert_close(ours_y, theirs_y)
 
 
 @torch.inference_mode()

--- a/tutorials/0_to_litgpt.md
+++ b/tutorials/0_to_litgpt.md
@@ -545,23 +545,15 @@ Sometimes, it can be useful to convert LitGPT model weights for third-party and 
 litgpt convert_from_litgpt microsoft/phi-2 out/converted_model/
 ```
 
-Certain tools like the `.from_pretrained` method in Hugging Face `transformers` also require the original `config.json` file that originally came with the downloaded model:
+This saves the weights as a `pytorch_model.bin` file and copies the configuration and tokenizer files (such as the `config.json` that originally came with the downloaded model) into the output directory.
 
-```bash
-cp checkpoints/microsoft/phi-2/config.json out/converted_model/config.json
-```
+You can now load the model into a Hugging Face transformers model and save it in a `.safetensors` format as follows:
 
-You can now load the model into a Hugging Face transformers model and safe it in a `.safetensors` format as follows:
-
-```bash
-import torch
+```python
 from transformers import AutoModel
 
 # Load model
-state_dict = torch.load('out/converted_model/model.pth')
-model = AutoModel.from_pretrained(
-    "microsoft/phi-2", state_dict=state_dict
-)
+model = AutoModel.from_pretrained("out/converted_model/", local_files_only=True)
 
 # Save .safetensors files
 model.save_pretrained("out/converted_model/")
@@ -574,21 +566,13 @@ total 16G
 -rw-r--r-- 1 sebastian sebastian 4.7G Mar 20 17:08 model-00001-of-00003.safetensors
 -rw-r--r-- 1 sebastian sebastian 4.7G Mar 20 17:09 model-00002-of-00003.safetensors
 -rw-r--r-- 1 sebastian sebastian 601M Mar 20 17:09 model-00003-of-00003.safetensors
--rw-r--r-- 1 sebastian sebastian 5.2G Mar 20 16:30 model.pth
+-rw-r--r-- 1 sebastian sebastian 5.2G Mar 20 16:30 pytorch_model.bin
 -rw-r--r-- 1 sebastian sebastian  33K Mar 20 17:09 model.safetensors.index.json
 ```
 
 You can then use the model with external tools, for example, Eleuther AI's [LM Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness) (see the `lm_eval` installation instructions [here](https://github.com/EleutherAI/lm-evaluation-harness?tab=readme-ov-file#install)).
 
-The LM Evaluation Harness requires a tokenizer to be present in the model checkpoint folder, which we can copy from the original download checkpoint:
-
-```bash
-# Copy the tokenizer needed by the Eval Harness
-cp checkpoints/microsoft/phi-2/tokenizer*
-out/converted_model
-```
-
-Then, we can run the Evaluation Harness as follows:
+For example, we can run the Evaluation Harness as follows:
 
 ```bash
 lm_eval --model hf \

--- a/tutorials/convert_lit_models.md
+++ b/tutorials/convert_lit_models.md
@@ -12,30 +12,14 @@ These paths are just placeholders, you will need to customize them based on whic
 
 ### Loading converted LitGPT checkpoints into transformers
 
-
-For example,
-
-```bash
-cp checkpoints/repo_id/config.json converted/config.json
-```
-
-Then, you can load the checkpoint file in a Python session as follows:
+The conversion saves the weights as a `pytorch_model.bin` file and copies the configuration and tokenizer files
+(such as `config.json` and `tokenizer.json`) from the source checkpoint directory. You can then load the converted
+checkpoint in a Python session as follows:
 
 ```python
-import torch
 from transformers import AutoModel
 
-
-state_dict = torch.load("output_dir/model.pth")
-model = AutoModel.from_pretrained(
-    "output_dir/", local_files_only=True, state_dict=state_dict
-)
-```
-
-Alternatively, you can also load the model without copying the `config.json` file as follows:
-
-```python
-model = AutoModel.from_pretrained("online_repo_id", state_dict=state_dict)
+model = AutoModel.from_pretrained("converted_dir/", local_files_only=True)
 ```
 
 
@@ -104,11 +88,9 @@ litgpt convert_from_litgpt $finetuned_dir/final/ out/hf-tinyllama/converted
 5. Load the model into a `transformers` model:
 
 ```python
-import torch
 from transformers import AutoModel
 
-state_dict = torch.load('out/hf-tinyllama/converted/model.pth')
-model = AutoModel.from_pretrained("TinyLlama/TinyLlama-1.1B-intermediate-step-1431k-3T", state_dict=state_dict)
+model = AutoModel.from_pretrained("out/hf-tinyllama/converted/", local_files_only=True)
 ```
 
 &nbsp;
@@ -126,13 +108,7 @@ Alternatively, if you wish to use converted LitGPT models with the LM Evaluation
 model.save_pretrained("out/hf-tinyllama/converted/")
 ```
 
-3. Copy the tokenizer files into the model-containing directory:
-
-```bash
-cp checkpoints/$repo_id/tokenizer* out/hf-tinyllama/converted
-```
-
-4. Run the evaluation harness, for example:
+3. Run the evaluation harness, for example:
 
 ```bash
 lm_eval --model hf \


### PR DESCRIPTION
Fixes #1871.

`litgpt convert_from_litgpt` produced a directory transformers cannot load: only
`model.pth`, no `pytorch_model.bin`, no config/tokenizer files. This PR saves the
converted weights directly as `pytorch_model.bin` and copies the config and tokenizer
files from the source checkpoint, so `AutoModel.from_pretrained(converted_dir)` just
works — the same thing `litgpt evaluate` already did internally before handing the
directory to HFLM.

One extra finding: the torch.load/torch.save re-save hack in `litgpt/eval/evaluate.py`
(added in #1357 when the `incremental_save` pickle wasn't `weights_only=True`-compatible)
is no longer needed. On every supported torch version (>=2.7) the incremental_save file
loads cleanly with `weights_only=True` (verified on 2.7.0 and 2.12, incl. `mmap=True`,
which transformers uses) — evaluate.py's own un-flagged `torch.load` has effectively
been doing a weights-only load of it in CI since torch 2.6 flipped the default. So the
weights are written once, with no full-state-dict re-save, keeping conversion
memory-friendly for large models, and evaluate.py now just calls the conversion.

Note the output filename changes from `model.pth` to `pytorch_model.bin`; both tutorials
that referenced `model.pth` (and the manual `cp config.json` / `cp tokenizer*` steps,
now unnecessary) are updated. `litgpt evaluate` output directories are unaffected —
they already contained `pytorch_model.bin`.

Tested with an updated `tests/convert/test_lit_checkpoint.py` plus a new regression
test that converts a tiny pythia-14m-config checkpoint and checks
`AutoModelForCausalLM.from_pretrained` loads it with matching logits. Also verified the
issue's full pretrain-convert-load repro on CPU.
