### PR TITLE
fix(ci): unblock check-links and stabilize GPU serve tests

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         # a newer version of mistune is incompatible with nbconvert
         # pytest>=9 removed the `path` arg from pytest_collect_file; pytest-check-links still uses it
-        run: uv pip install "mistune<3.1" "pytest<9" pytest-check-links
+        run: uv pip install "mistune<3.1" "pytest" pytest-check-links
 
       - name: Check links
         run: pytest --check-links README.md tutorials --check-links-ignore "http*"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Install dependencies
         # a newer version of mistune is incompatible with nbconvert
-        run: uv pip install "mistune<3.1" pytest pytest-check-links
+        # pytest>=9 removed the `path` arg from pytest_collect_file; pytest-check-links still uses it
+        run: uv pip install "mistune<3.1" "pytest<9" pytest-check-links
 
       - name: Check links
         run: pytest --check-links README.md tutorials --check-links-ignore "http*"

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         # a newer version of mistune is incompatible with nbconvert
         # pytest>=9 removed the `path` arg from pytest_collect_file; pytest-check-links still uses it
-        run: uv pip install "mistune<3.1" "pytest" pytest-check-links
+        run: uv pip install "mistune<3.1" "pytest<9" pytest-check-links
 
       - name: Check links
         run: pytest --check-links README.md tutorials --check-links-ignore "http*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 
+import gc
 import os
 import shutil
 import sys
@@ -16,6 +17,15 @@ else:
     import warnings
 
     warnings.warn(f"Could not find extensions directory at {wd}")
+
+
+@pytest.fixture(autouse=True)
+def reclaim_cuda_memory():
+    """Free GPU memory after each test to avoid accumulation across CUDA tests (e.g. the serve suite)."""
+    yield
+    if torch.cuda.is_available():
+        gc.collect()
+        torch.cuda.empty_cache()
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,13 @@ else:
 
 @pytest.fixture(autouse=True)
 def reclaim_cuda_memory():
-    """Free GPU memory after each test to avoid accumulation across CUDA tests (e.g. the serve suite)."""
+    """Free GPU memory after a test that actually used it, to avoid accumulation across CUDA tests.
+
+    Gated on ``memory_allocated`` (a cheap counter read) so the expensive ``gc.collect`` is skipped
+    for the many CPU-only tests that never touch the GPU.
+    """
     yield
-    if torch.cuda.is_available():
+    if torch.cuda.is_available() and torch.cuda.memory_allocated() > 0:
         gc.collect()
         torch.cuda.empty_cache()
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -253,15 +253,6 @@ def test_serve_with_openai_spec(tmp_path):
     finally:
         if process:
             kill_process_tree(process.pid)
-            # Surface the server's captured output so failures (e.g. a 500) are debuggable in CI.
-            try:
-                stdout, stderr = process.communicate(timeout=10)
-            except (subprocess.TimeoutExpired, ValueError):
-                stdout, stderr = None, None
-            if stdout:
-                print(f"Server stdout:\n{stdout}")
-            if stderr:
-                print(f"Server stderr:\n{stderr}")
         server_thread.join()
 
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -253,6 +253,15 @@ def test_serve_with_openai_spec(tmp_path):
     finally:
         if process:
             kill_process_tree(process.pid)
+            # Surface the server's captured output so failures (e.g. a 500) are debuggable in CI.
+            try:
+                stdout, stderr = process.communicate(timeout=10)
+            except (subprocess.TimeoutExpired, ValueError):
+                stdout, stderr = None, None
+            if stdout:
+                print(f"Server stdout:\n{stdout}")
+            if stderr:
+                print(f"Server stderr:\n{stderr}")
         server_thread.join()
 
 
@@ -278,6 +287,8 @@ def test_serve_with_generate_strategy(tmp_path, generate_strategy):
 
     # Test with generate strategy
     run_command = ["litgpt", "serve", tmp_path, "--generate_strategy", generate_strategy]
+    if generate_strategy == "tensor_parallel":
+        run_command += ["--devices", "2"]
 
     process = None
 


### PR DESCRIPTION
## What does this PR do?

Fixes a few failing Lightning CI jobs:

### `check-links` workflow
- `pytest>=9` removed the `path` argument from `pytest_collect_file`, which `pytest-check-links` still relies on. Pinned `pytest<9` so link checking runs again.

### GPU `serve` tests
- **`test_serve_with_generate_strategy[tensor_parallel]`** requested 2 GPUs but never passed `--devices`, so it ran the tensor-parallel strategy on a single device. Now passes `--devices 2`.
- Added an autouse fixture that reclaims CUDA memory after tests that actually allocated it, preventing memory accumulation across the serve suite (which was surfacing as OOM / `500` failures). Gated on `memory_allocated()` so CPU-only tests skip the cost.

---

Failing LitJob Link for ref: https://lightning.ai/lightning-ai/ci/jobs/ci-run-lightning-ai-litgpt-76dbe6e-tests-yaml-lit-job-n-a-8467a479?app_id=jobs&job_detail_tab=logs

<img width="1343" height="74" alt="image" src="https://github.com/user-attachments/assets/5bfde82e-db2f-4c1e-9789-4216a595c485" />
