### PR TITLE
fix(tests): use Gutenberg mirror to fix flaky book downloads

### DIFF
--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -108,13 +108,6 @@ jobs:
             hf-cache_${{ runner.os }}-
             hf-cache_
 
-      - name: Gutenberg books cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        continue-on-error: true
-        with:
-          path: custom_texts
-          key: gutenberg-books
-
       - name: Set min. dependencies
         if: matrix.requires == 'oldest'
         run: uv run --no-project --with 'lightning-utilities[cli]>=0.15.1' python -m lightning_utilities.cli requirements set-oldest --req_files=pyproject.toml

--- a/.github/workflows/cpu-tests.yml
+++ b/.github/workflows/cpu-tests.yml
@@ -108,6 +108,13 @@ jobs:
             hf-cache_${{ runner.os }}-
             hf-cache_
 
+      - name: Gutenberg books cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        continue-on-error: true
+        with:
+          path: custom_texts
+          key: gutenberg-books
+
       - name: Set min. dependencies
         if: matrix.requires == 'oldest'
         run: uv run --no-project --with 'lightning-utilities[cli]>=0.15.1' python -m lightning_utilities.cli requirements set-oldest --req_files=pyproject.toml

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -71,9 +71,11 @@ def test_download_model():
 def test_download_books():
     CUSTOM_TEXTS_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Use the gutenberg.pglaf.org mirror: www.gutenberg.org blocks datacenter/CI IPs,
+    # so curl times out (exit 28) on GitHub runners. The mirror serves the same paths.
     books = [
-        ("https://www.gutenberg.org/cache/epub/24440/pg24440.txt", "book1.txt"),
-        ("https://www.gutenberg.org/cache/epub/26393/pg26393.txt", "book2.txt"),
+        ("https://gutenberg.pglaf.org/cache/epub/24440/pg24440.txt", "book1.txt"),
+        ("https://gutenberg.pglaf.org/cache/epub/26393/pg26393.txt", "book2.txt"),
     ]
     for url, filename in books:
         dest = CUSTOM_TEXTS_DIR / filename

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -71,34 +71,16 @@ def test_download_model():
 def test_download_books():
     CUSTOM_TEXTS_DIR.mkdir(parents=True, exist_ok=True)
 
-    # Use the gutenberg.pglaf.org mirror: www.gutenberg.org blocks datacenter/CI IPs,
-    # so curl times out (exit 28) on GitHub runners. The mirror serves the same paths.
+    # gutenberg.pglaf.org is the official high-speed US mirror (see gutenberg.org/MIRRORS.ALL)
     books = [
         ("https://gutenberg.pglaf.org/cache/epub/24440/pg24440.txt", "book1.txt"),
         ("https://gutenberg.pglaf.org/cache/epub/26393/pg26393.txt", "book2.txt"),
     ]
     for url, filename in books:
-        dest = CUSTOM_TEXTS_DIR / filename
-        if dest.exists():
-            continue
         subprocess.run(
-            [
-                "curl",
-                url,
-                "--output",
-                str(dest),
-                "--retry",
-                "2",
-                "--retry-delay",
-                "10",
-                "--connect-timeout",
-                "30",
-                "--max-time",
-                "120",
-            ],
+            ["curl", url, "--output", str(CUSTOM_TEXTS_DIR / filename), "--retry", "2", "--retry-delay", "10", "--connect-timeout", "30", "--max-time", "120"],
             check=True,
         )
-        # Verify each book is downloaded
         assert (CUSTOM_TEXTS_DIR / filename).exists(), f"{filename} not downloaded"
 
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -80,7 +80,20 @@ def test_download_books():
         if dest.exists():
             continue
         subprocess.run(
-            ["curl", url, "--output", str(dest), "--retry", "2", "--retry-delay", "10", "--connect-timeout", "30", "--max-time", "120"],
+            [
+                "curl",
+                url,
+                "--output",
+                str(dest),
+                "--retry",
+                "2",
+                "--retry-delay",
+                "10",
+                "--connect-timeout",
+                "30",
+                "--max-time",
+                "120",
+            ],
             check=True,
         )
         # Verify each book is downloaded

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -76,7 +76,13 @@ def test_download_books():
         ("https://www.gutenberg.org/cache/epub/26393/pg26393.txt", "book2.txt"),
     ]
     for url, filename in books:
-        subprocess.run(["curl", url, "--output", str(CUSTOM_TEXTS_DIR / filename)], check=True)
+        dest = CUSTOM_TEXTS_DIR / filename
+        if dest.exists():
+            continue
+        subprocess.run(
+            ["curl", url, "--output", str(dest), "--retry", "2", "--retry-delay", "10", "--connect-timeout", "30", "--max-time", "120"],
+            check=True,
+        )
         # Verify each book is downloaded
         assert (CUSTOM_TEXTS_DIR / filename).exists(), f"{filename} not downloaded"
 

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -78,7 +78,20 @@ def test_download_books():
     ]
     for url, filename in books:
         subprocess.run(
-            ["curl", url, "--output", str(CUSTOM_TEXTS_DIR / filename), "--retry", "2", "--retry-delay", "10", "--connect-timeout", "30", "--max-time", "120"],
+            [
+                "curl",
+                url,
+                "--output",
+                str(CUSTOM_TEXTS_DIR / filename),
+                "--retry",
+                "2",
+                "--retry-delay",
+                "10",
+                "--connect-timeout",
+                "30",
+                "--max-time",
+                "120",
+            ],
             check=True,
         )
         assert (CUSTOM_TEXTS_DIR / filename).exists(), f"{filename} not downloaded"


### PR DESCRIPTION
## What does this PR do?

`test_download_books` was timing out (curl exit 28) because `www.gutenberg.org` blocks CI/datacenter IPs.

Switched to the official high-speed US mirror (`gutenberg.pglaf.org`) listed in [gutenberg.org/MIRRORS.ALL](https://gutenberg.org/MIRRORS.ALL), and added curl retry/timeout flags for resilience.