### PR TITLE
docs: update CODEOWNERS with patterns and retired committers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,19 +2,20 @@
 
 # These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for review when someone opens a pull request.
-* @lianakoleva @KaelanDt @k223kim @andyland @t-vi
+* @lianakoleva @k223kim @andyland @t-vi
 
 # Core source
-/litgpt/                             @lianakoleva @KaelanDt @k223kim @andyland
+/litgpt/                             @lianakoleva @k223kim @andyland
 
 # CI/CD and configs
-/.github/                            @lianakoleva @KaelanDt @k223kim
-*.yml                                @lianakoleva @KaelanDt @k223kim
+/.github/                            @lianakoleva @k223kim
+*.yml                                @lianakoleva @k223kim
 
 # Docs
-/README.md                           @williamfalcon @lantiga @lianakoleva
+/README.md                           @williamfalcon @lianakoleva
 
 # Retired committers
-#   @rasbt    (Sebastian Raschka)
+#   @lantiga    (Luca Antiga)
+#   @rasbt      (Sebastian Raschka)
 #   @awaelchli  (Adrian Wälchli)
-#   @borda    (Jirka Borovec)
+#   @borda      (Jirka Borovec)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,15 @@
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in the repo. Unless a later match takes
-# precedence, they will be requested for review when someone opens a pull request.
-* @lantiga @t-vi @lianakoleva @KaelanDt @k223kim @andyland
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for review when someone opens a pull request.
+* @lianakoleva @KaelanDt @k223kim @andyland @t-vi
 
 # Core source
-/litgpt/                             @lantiga @t-vi @lianakoleva @KaelanDt @k223kim @andyland
+/litgpt/                             @lianakoleva @KaelanDt @k223kim @andyland
 
 # CI/CD and configs
-/.github/                            @lantiga @t-vi
-*.yml                                @lantiga @t-vi
+/.github/                            @lianakoleva @KaelanDt @k223kim
+*.yml                                @lianakoleva @KaelanDt @k223kim
 
 # Docs
 /README.md                           @williamfalcon @lantiga @lianakoleva

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,20 @@
 # Each line is a file pattern followed by one or more owners.
-# Owners are automatically requested for review when someone opens a pull
-# request that modifies the matching files. For details, see:
-# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# ----------------------------------------------------------------------------
-# Current project owners
-# ----------------------------------------------------------------------------
-# These owners are the default reviewers for everything in the repository.
-# Unless a later match takes precedence, they are requested for review when
-# someone opens a pull request.
+# These owners will be the default owners for everything in the repo. Unless a later match takes
+# precedence, they will be requested for review when someone opens a pull request.
 * @lantiga @t-vi @lianakoleva @KaelanDt @k223kim @andyland
 
+# Core source
+/litgpt/                             @lantiga @t-vi @lianakoleva @KaelanDt @k223kim @andyland
+
+# CI/CD and configs
+/.github/                            @lantiga @t-vi
+*.yml                                @lantiga @t-vi
+
+# Docs
 /README.md                           @williamfalcon @lantiga @lianakoleva
 
-# ----------------------------------------------------------------------------
 # Retired committers
-# ----------------------------------------------------------------------------
-# Past maintainers who made significant contributions to the project and are
-# no longer active. Kept here for historical credit only; they are intentionally
-# not assigned as code owners above so they are not requested for review.
-#   @carmocca      (Carlos Mocholí)
-#   @awaelchli     (Adrian Wälchli)
-#   @apaz-cli      (apaz)
-#   @JustinGoheen  (Justin Goheen)
+#   @rasbt    (Sebastian Raschka)
+#   @awaelchli  (Adrian Wälchli)
+#   @borda    (Jirka Borovec)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,25 @@
+# Each line is a file pattern followed by one or more owners.
+# Owners are automatically requested for review when someone opens a pull
+# request that modifies the matching files. For details, see:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# ----------------------------------------------------------------------------
+# Current project owners
+# ----------------------------------------------------------------------------
+# These owners are the default reviewers for everything in the repository.
+# Unless a later match takes precedence, they are requested for review when
+# someone opens a pull request.
 * @lantiga @t-vi @lianakoleva @KaelanDt @k223kim @andyland
+
 /README.md                           @williamfalcon @lantiga @lianakoleva
+
+# ----------------------------------------------------------------------------
+# Retired committers
+# ----------------------------------------------------------------------------
+# Past maintainers who made significant contributions to the project and are
+# no longer active. Kept here for historical credit only; they are intentionally
+# not assigned as code owners above so they are not requested for review.
+#   @carmocca      (Carlos Mocholí)
+#   @awaelchli     (Adrian Wälchli)
+#   @apaz-cli      (apaz)
+#   @JustinGoheen  (Justin Goheen)


### PR DESCRIPTION
## What does this PR do?

Updates `.github/CODEOWNERS` to address the [PyTorch Ecosystem 6-month review](https://github.com/pytorch-fdn/ecosystem/issues/26) requirement:

> CODEOWNERS that define individuals or teams responsible for code in a repository; document current project owners and Retired committers.

**Changes:**
- Adds granular file-pattern ownership for core source (`/litgpt/`), CI/config (`/.github/`, `*.yml`), and docs (`/README.md`) — modelled after [litData](https://github.com/Lightning-AI/litData/blob/main/.github/CODEOWNERS) and [pytorch-lightning](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CODEOWNERS)
- Adds a **Retired committers** section derived from this file's own git history: `@rasbt`, `@awaelchli`, `@borda`