### PR TITLE
fix(docs): update broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)
-![cpu-tests](https://github.com/lightning-AI/lit-stablelm/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/lit-stablelm/blob/master/LICENSE) [![Discord](https://img.shields.io/discord/1077906959069626439)](https://discord.gg/VptPCZkGNa)
+![cpu-tests](https://github.com/Lightning-AI/litgpt/actions/workflows/cpu-tests.yml/badge.svg) [![license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/Lightning-AI/litgpt/blob/main/LICENSE.md) [![Discord](https://img.shields.io/discord/1077906959069626439)](https://discord.gg/VptPCZkGNa)
 
 <p align="center">
   <a href="#quick-start">Quick start</a> •
@@ -716,7 +716,7 @@ This implementation extends on [Lit-LLaMA](https://github.com/lightning-AI/lit-l
 
 ### License
 
-LitGPT is released under the [Apache 2.0](https://github.com/Lightning-AI/litgpt/blob/main/LICENSE) license.
+LitGPT is released under the [Apache 2.0](https://github.com/Lightning-AI/litgpt/blob/main/LICENSE.md) license.
 
 ### Citation
 


### PR DESCRIPTION
## What does this PR do?

Fixes three broken links in README.md that were pointing to the old `lit-stablelm` repository and the renamed license file:

- **cpu-tests badge**: was pointing to `lightning-AI/lit-stablelm` → now points to `Lightning-AI/litgpt`
- **License badge**: was pointing to `Lightning-AI/lit-stablelm/blob/master/LICENSE` → now points to `Lightning-AI/litgpt/blob/main/LICENSE.md`
- **License section link**: was pointing to `...litgpt/blob/main/LICENSE` → now points to `...litgpt/blob/main/LICENSE.md` (updated after the license file was renamed)