### PR TITLE
fix(tokenizer): look up the decoding-fix dummy token instead of hardcoding its id

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -68,12 +68,14 @@ class Tokenizer:
             raise NotImplementedError
 
         # NOTE: A temporary fix until it's resolved on Tokenizers side.
-        # LlaMA tokenizer strips leading spaces if to decode a single token at a time.
+        # LLaMA and Mistral tokenizers strip leading spaces when decoding a single token at a time,
+        # because both are backed by SentencePiece which encodes word boundaries with a prefix space (▁).
         # https://github.com/huggingface/transformers/issues/31643
         self.apply_decoding_fix = None
         if (config_path := checkpoint_dir / "tokenizer_config.json").is_file():
             with open(config_path, encoding="utf-8") as fp:
-                self.apply_decoding_fix = "LlamaTokenizer" in json.load(fp)["tokenizer_class"]
+                tokenizer_class = json.load(fp).get("tokenizer_class", "")
+                self.apply_decoding_fix = "LlamaTokenizer" in tokenizer_class or "MistralTokenizer" in tokenizer_class
 
     @property
     def vocab_size(self) -> int:

--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -68,14 +68,13 @@ class Tokenizer:
             raise NotImplementedError
 
         # NOTE: A temporary fix until it's resolved on Tokenizers side.
-        # LLaMA and Mistral tokenizers strip leading spaces when decoding a single token at a time,
-        # because both are backed by SentencePiece which encodes word boundaries with a prefix space (▁).
+        # LlaMA tokenizer strips leading spaces if to decode a single token at a time.
         # https://github.com/huggingface/transformers/issues/31643
         self.apply_decoding_fix = None
         if (config_path := checkpoint_dir / "tokenizer_config.json").is_file():
             with open(config_path, encoding="utf-8") as fp:
-                tokenizer_class = json.load(fp).get("tokenizer_class", "")
-                self.apply_decoding_fix = "LlamaTokenizer" in tokenizer_class or "MistralTokenizer" in tokenizer_class
+                self.apply_decoding_fix = "LlamaTokenizer" in json.load(fp)["tokenizer_class"]
+        self._dummy_token_id = None
 
     @property
     def vocab_size(self) -> int:
@@ -149,15 +148,28 @@ class Tokenizer:
             tokens = tokens[:max_length]
         return torch.tensor(tokens, dtype=torch.int, device=device)
 
+    def _find_dummy_token_id(self) -> int:
+        r"""Find a token that decodes to "\x1e", used as a prefix by the decoding fix.
+
+        Its id differs per vocabulary: 33 in the LlaMA vocabularies, 165 in salamandra. Both of
+        those ids are control tokens that decode to "" in the Mistral vocabularies, which turned
+        the decoding fix into a silent no-op there, so fall back to looking the token up.
+        """
+        for dummy_token_id in (33, 165):
+            if self.processor.decode([dummy_token_id]) == "\x1e":
+                return dummy_token_id
+        try:
+            return self.token_to_id("\x1e")
+        except ValueError:
+            return 33
+
     def decode(self, tensor: torch.Tensor) -> str:
         tokens = [tensor.item()] if tensor.ndim == 0 else tensor.tolist()
         if len(tokens) == 1 and self.apply_decoding_fix:
-            dummy_token_id = 33  # \x1e
-            dummy_token = self.processor.decode([dummy_token_id])
-            if dummy_token != "\x1e":
-                dummy_token_id = 165  # \x1e is different in salamandra tokenizers
-                dummy_token = self.processor.decode([dummy_token_id])
-            return self.processor.decode([dummy_token_id] + tokens)[len(dummy_token) :]
+            if self._dummy_token_id is None:
+                self._dummy_token_id = self._find_dummy_token_id()
+            dummy_token = self.processor.decode([self._dummy_token_id])
+            return self.processor.decode([self._dummy_token_id] + tokens)[len(dummy_token) :]
         return self.processor.decode(tokens)
 
     def decode_stream(self, token_stream: Iterable[torch.Tensor], device: torch.device | None = None) -> Iterator[str]:

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -100,11 +100,10 @@ def test_tokenizer_against_hf(config, tmp_path):
     assert actual.tolist() == expected
     assert ours.decode(actual) == theirs.decode(expected, skip_special_tokens=True)
 
-    if not config.name.startswith(("Mistral", "Mixtral")):
-        decoded_output = "".join([ours.decode(x) for x in actual])
-        if ours.apply_decoding_fix and decoded_output[0] == " ":
-            decoded_output = decoded_output[1:]  # the "hack" adds an empty space to the beginning
-        assert decoded_output == ours.decode(actual), type(theirs)
+    decoded_output = "".join([ours.decode(x) for x in actual])
+    if ours.apply_decoding_fix and decoded_output[0] == " ":
+        decoded_output = decoded_output[1:]  # the "hack" adds an empty space to the beginning
+    assert decoded_output == ours.decode(actual), type(theirs)
 
 
 def test_tokenizer_input_validation():


### PR DESCRIPTION
Fixes #1822.

`Tokenizer.decode` works around the SentencePiece leading-space stripping by prepending a token that decodes to `\x1e`, then slicing that prefix back off. The id was probed as 33, falling back to 165 for salamandra. In the Mistral vocabularies neither is right - id 33 is `[control_31]` and 165 is `[control_163]`, both of which decode to an empty string, so `dummy_token` is `""`, the slice is a no-op, and every single-token decode loses its leading space. That is the run-on output in the issue.

Repro against the real `mistralai/Mistral-7B-Instruct-v0.3` tokenizer:

```
full decode      : "Hello, readers of this test!"
per-token decode : "Hello,readersofthistest!"    # before
per-token decode : " Hello, readers of this test!"  # after
```

The fix keeps the 33/165 fast path and otherwise looks `\x1e` up in the vocabulary (it is id 31918 for Mistral v0.3). Llama is unaffected - it still resolves to 33 and produces identical output, checked against TinyLlama-1.1B-Chat-v1.0.

`test_tokenizer_against_hf` had a `if not config.name.startswith(("Mistral", "Mixtral"))` guard around the per-token decode assertion, which is exactly the case that was broken, so this removes it.

I could not run the full test module locally (`lightning` is not installed on this machine), so I verified by loading `litgpt/tokenizer.py` directly against tokenizer assets downloaded from the two HF repos above rather than by running pytest. CI should cover the rest.
