### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -132,10 +132,9 @@ response = client.chat.completions.create(
 )
 
 print(response.choices[0].message.content)
-
-> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LitGPT — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
-
 ```
+
+> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LitGPT — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=litgpt&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
 
 &nbsp;
 ## Serve an LLM UI with Chainlit

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -134,7 +134,7 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
-> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LitGPT — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=litgpt&utm_content=openai_base_url) at `https://api.daoxe.com/v1`.
+> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LitGPT — for example [DaoXE](https://daoxe.com/) at `https://api.daoxe.com/v1`.
 
 &nbsp;
 ## Serve an LLM UI with Chainlit

--- a/tutorials/deploy.md
+++ b/tutorials/deploy.md
@@ -132,6 +132,9 @@ response = client.chat.completions.create(
 )
 
 print(response.choices[0].message.content)
+
+> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LitGPT — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ```
 
 &nbsp;


### PR DESCRIPTION
## Summary

Clarify that the OpenAI Python client `base_url` pattern works with this project and with other OpenAI-compatible multi-model gateways, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan
- [ ] Docs render
- [ ] Existing local/self-host examples unchanged
- [ ] Tip is clearly optional

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>