### PR TITLE
fix(ci): cap torch<2.13 for the thunder compiler extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ dependencies = [
 optional-dependencies.compiler = [
   # compilaton:
   "lightning-thunder>=0.2.dev20250119; python_version>='3.10' and sys_platform=='linux'",
+  # thunder references torch's named-tensor APIs at import time, removed in torch 2.13
+  # (pytorch/pytorch#173895). No thunder release supports 2.13 yet, so cap it here only.
+  "torch<2.13; python_version>='3.10' and sys_platform=='linux'",
 ]
 optional-dependencies.extra = [
   "bitsandbytes>=0.42,<0.43; sys_platform=='darwin'",


### PR DESCRIPTION
## What does this PR do?

Caps `torch<2.13` for the `compiler` extra to unbreak CPU tests.
<img width="778" height="181" alt="image" src="https://github.com/user-attachments/assets/12fd9695-0eb2-44b0-8baf-2314b023b18d" />
ref: https://github.com/Lightning-AI/litgpt/actions/runs/31010745789/job/94277649710?pr=2294

### The problem

torch 2.13 removed the named-tensor APIs ([pytorch/pytorch#173895](https://github.com/pytorch/pytorch/pull/173895), listed as BC-breaking in the [2.13.0 notes](https://github.com/pytorch/pytorch/releases/tag/v2.13.0)). `lightning-thunder` still touches four of them at import time, so test collection dies before a single test runs:

```
thunder/torch/default_torch_ops.py:364: in <module>
    torch.Tensor.align_as,
E   AttributeError: type object 'Tensor' has no attribute 'align_as'
!!!!! Interrupted: 1 error during collection !!!!!
```

`litgpt/constants.py` probes thunder with `RequirementCache("thunder")`, which triggers that import.

### Why now

Neither `torch>=2.7` (here) nor `torch>=2.7.1` (thunder) has an upper bound, so `uv sync --all-extras` picks up torch 2.13.0. Not caused by any one PR — it reproduces on a no-op commit and hits every `pytester (ubuntu-22.04, *, latest)` job.

- macOS / Windows pass — thunder is linux-gated
- `oldest` passes — pins torch 2.7

No thunder release works with 2.13: 0.2.6 and the latest dev build both still carry all four references.

### Scope

| install | torch |
|---|---|
| `--extra compiler` (linux) | 2.12.1 |
| core, no compiler extra | 2.13.0 |

Only thunder users are held back. Drop the cap once thunder supports 2.13.
