### PR TITLE
fix: clip max_seq_length to block size so small-context models work with defaults

### DIFF
--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -260,7 +260,9 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
+    model.max_seq_length = min(
+        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/adapter.py
+++ b/litgpt/finetune/adapter.py
@@ -260,9 +260,7 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(
-        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
-    )
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -278,9 +278,7 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(
-        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
-    )
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/adapter_v2.py
+++ b/litgpt/finetune/adapter_v2.py
@@ -278,7 +278,9 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
+    model.max_seq_length = min(
+        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -227,7 +227,9 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
+    model.max_seq_length = min(
+        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/full.py
+++ b/litgpt/finetune/full.py
@@ -227,9 +227,7 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(
-        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
-    )
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -301,9 +301,7 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(
-        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
-    )
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/lora.py
+++ b/litgpt/finetune/lora.py
@@ -301,7 +301,9 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
+    model.max_seq_length = min(
+        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/lora_legacy.py
+++ b/litgpt/finetune/lora_legacy.py
@@ -294,7 +294,9 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"))
+    model.max_seq_length = min(
+        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
+    )
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"

--- a/litgpt/finetune/lora_legacy.py
+++ b/litgpt/finetune/lora_legacy.py
@@ -294,9 +294,7 @@ def fit(
     longest_seq_length, longest_seq_ix = get_longest_seq_length(
         ConcatDataset([train_dataloader.dataset, val_dataloader.dataset])
     )
-    model.max_seq_length = min(
-        longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
-    )
+    model.max_seq_length = min(longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size)
     fabric.print(
         f"The longest sequence length in the train data is {longest_seq_length}, the model's maximum sequence length is"
         f" {model.max_seq_length} and context length is {model.config.block_size}"


### PR DESCRIPTION
## Problem

`litgpt finetune lora --checkpoint_dir checkpoints/EleutherAI/pythia-14m` (and full/adapter variants) crash when the training data is longer than the model's block size:

```
ValueError: Cannot attend to 1035, block size is only 512
```

Small-context models (e.g. Pythia-14M with 512 block size) should work out of the box with defaults — the pipeline should clip to the supported context length instead of raising.

## Fix

Added `model.config.block_size` as a third `min()` argument in all 5 finetune entry points:

```python
model.max_seq_length = min(
    longest_seq_length, train.max_seq_length or float("inf"), model.config.block_size
)
```

The existing print statement right after already reports both the effective max_seq_length and block_size, so users can see when clipping happened.

## Files

- litgpt/finetune/full.py
- litgpt/finetune/lora.py
- litgpt/finetune/adapter.py
- litgpt/finetune/adapter_v2.py
- litgpt/finetune/lora_legacy.py

Fixes #1225