### PR TITLE
fix(tests): de-flake serve tests by isolating ports and failing fast

### DIFF
--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -64,10 +64,12 @@ def _wait_until_ready(url: str, process: subprocess.Popen, log_path: Path) -> No
             raise AssertionError(
                 f"Server exited with code {process.returncode} before it was ready.{_log_tail(log_path)}"
             )
-        with contextlib.suppress(requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        try:
             if requests.get(url, timeout=10).status_code == 200:
                 return
             err = "the server responded, but not with status 200"
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as ex:
+            err = str(ex)
         time.sleep(1)
     raise AssertionError(f"Server was not ready within {_STARTUP_TIMEOUT}s: {err}{_log_tail(log_path)}")
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,220 +1,154 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+import contextlib
 import json
 import platform
 import shutil
+import socket
 import subprocess
-import threading
 import time
+from collections.abc import Iterator
 from dataclasses import asdict
+from pathlib import Path
 
+import psutil
 import pytest
 import requests
 import torch
 import yaml
 from lightning.fabric import seed_everything
-from urllib3.exceptions import MaxRetryError
 
 from litgpt import GPT, Config
 from litgpt.scripts.download import download_from_hub
 from litgpt.utils import _RunIf, kill_process_tree
 
+# Startup includes the interpreter and torch imports, loading the checkpoint and, for the distributed
+# strategies, setting up the process group. A generous budget is cheap because `_wait_until_ready`
+# also watches the process and gives up as soon as it exits.
+_STARTUP_TIMEOUT = 120
 
-def _wait_and_check_response(waiting: int = 30):
-    response_status_code, err = -1, None
-    for _ in range(waiting):
-        try:
-            response = requests.get("http://127.0.0.1:8000", timeout=10)
-            response_status_code = response.status_code
-        except (MaxRetryError, requests.exceptions.ConnectionError) as ex:
-            response_status_code = -1
-            err = str(ex)
-        if response_status_code == 200:
-            break
+
+def _find_free_port() -> int:
+    """Return a port that is currently unused.
+
+    Each test serves on its own port. Sharing one made a server that had not finished shutting down
+    yet fail the next one at bind time, which surfaced as an unrelated connection error.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _prepare_checkpoint(checkpoint_dir: Path, repo_id: str) -> None:
+    """Write a randomly initialized checkpoint and the matching tokenizer to ``checkpoint_dir``."""
+    seed_everything(123)
+    config = Config.from_name(repo_id.split("/")[-1])
+    download_from_hub(repo_id=repo_id, tokenizer_only=True, checkpoint_dir=checkpoint_dir)
+    for filename in ("tokenizer.json", "tokenizer_config.json"):
+        shutil.move(str(checkpoint_dir.joinpath(*repo_id.split("/"), filename)), str(checkpoint_dir))
+    torch.save(GPT(config).state_dict(), checkpoint_dir / "lit_model.pth")
+    with open(checkpoint_dir / "model_config.yaml", "w", encoding="utf-8") as fp:
+        yaml.dump(asdict(config), fp)
+
+
+def _log_tail(log_path: Path, max_chars: int = 8000) -> str:
+    output = log_path.read_text(encoding="utf-8", errors="replace")[-max_chars:]
+    return f"\n--- server output (tail) ---\n{output}" if output else ""
+
+
+def _wait_until_ready(url: str, process: subprocess.Popen, log_path: Path) -> None:
+    """Poll ``url`` until the server answers, it exits, or ``_STARTUP_TIMEOUT`` passes."""
+    deadline = time.monotonic() + _STARTUP_TIMEOUT
+    err = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError(
+                f"Server exited with code {process.returncode} before it was ready.{_log_tail(log_path)}"
+            )
+        with contextlib.suppress(requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            if requests.get(url, timeout=10).status_code == 200:
+                return
+            err = "the server responded, but not with status 200"
         time.sleep(1)
-    assert response_status_code == 200, f"Server did not respond as expected. Error: {err}"
+    raise AssertionError(f"Server was not ready within {_STARTUP_TIMEOUT}s: {err}{_log_tail(log_path)}")
+
+
+def _terminate(process: subprocess.Popen) -> None:
+    """Kill the server process tree and wait for it to be gone.
+
+    ``kill_process_tree`` only sends the signals. The port stays bound until every process holding it
+    has exited, so returning earlier would leave the next server unable to bind.
+    """
+    try:
+        children = psutil.Process(process.pid).children(recursive=True)
+    except psutil.NoSuchProcess:
+        children = []
+    kill_process_tree(process.pid)
+    psutil.wait_procs(children, timeout=30)
+    with contextlib.suppress(subprocess.TimeoutExpired):
+        process.wait(timeout=30)
+
+
+@contextlib.contextmanager
+def _serve(checkpoint_dir: Path, *extra_args: str) -> Iterator[str]:
+    """Run ``litgpt serve`` on a free port and yield its base URL once it is ready to answer."""
+    port = _find_free_port()
+    url = f"http://127.0.0.1:{port}"
+    # Log to a file rather than a pipe: nothing reads the pipe while the server starts up, so a full
+    # buffer would block it. Keep the file out of the checkpoint directory that is being served.
+    log_path = checkpoint_dir.parent / f"{checkpoint_dir.name}-server.log"
+    command = ["litgpt", "serve", str(checkpoint_dir), "--port", str(port), *extra_args]
+    with open(log_path, "w", encoding="utf-8") as log_fp:
+        process = subprocess.Popen(command, stdout=log_fp, stderr=subprocess.STDOUT, text=True)
+        try:
+            _wait_until_ready(url, process, log_path)
+            yield url
+        finally:
+            _terminate(process)
 
 
 # todo: try to resolve this issue
 @pytest.mark.flaky(reruns=2, reruns_delay=30)
 @pytest.mark.xfail(condition=platform.system() == "Darwin", reason="it passes locally but having some issues on CI")
 def test_simple(tmp_path):
-    seed_everything(123)
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
-
-    run_command = ["litgpt", "serve", tmp_path]
-
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response(waiting=60)
-
-    if process:
-        kill_process_tree(process.pid)
-    server_thread.join()
+    _prepare_checkpoint(tmp_path, "EleutherAI/pythia-14m")
+    with _serve(tmp_path):
+        pass
 
 
 @_RunIf(min_cuda_gpus=1)
 def test_quantize(tmp_path):
-    seed_everything(123)
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
-
-    run_command = ["litgpt", "serve", tmp_path, "--quantize", "bnb.nf4"]
-
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response()
-
-    if process:
-        kill_process_tree(process.pid)
-    server_thread.join()
+    _prepare_checkpoint(tmp_path, "EleutherAI/pythia-14m")
+    with _serve(tmp_path, "--quantize", "bnb.nf4"):
+        pass
 
 
 @_RunIf(min_cuda_gpus=2)
 def test_multi_gpu_serve(tmp_path):
-    seed_everything(123)
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
-
-    run_command = ["litgpt", "serve", tmp_path, "--devices", "2"]
-
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response()
-
-    if process:
-        kill_process_tree(process.pid)
-    server_thread.join()
+    _prepare_checkpoint(tmp_path, "EleutherAI/pythia-14m")
+    with _serve(tmp_path, "--devices", "2"):
+        pass
 
 
 @_RunIf(min_cuda_gpus=1)
 def test_serve_with_openai_spec_missing_chat_template(tmp_path):
-    seed_everything(123)
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
-
-    run_command = ["litgpt", "serve", tmp_path, "--openai_spec", "true"]
-
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response()
-
-    if process:
-        kill_process_tree(process.pid)
-    server_thread.join()
+    _prepare_checkpoint(tmp_path, "EleutherAI/pythia-14m")
+    with _serve(tmp_path, "--openai_spec", "true"):
+        pass
 
 
 @_RunIf(min_cuda_gpus=1)
 def test_serve_with_openai_spec(tmp_path):
-    seed_everything(123)
-    ours_config = Config.from_name("SmolLM2-135M-Instruct")
-    download_from_hub(repo_id="HuggingFaceTB/SmolLM2-135M-Instruct", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "HuggingFaceTB" / "SmolLM2-135M-Instruct" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "HuggingFaceTB" / "SmolLM2-135M-Instruct" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
+    _prepare_checkpoint(tmp_path, "HuggingFaceTB/SmolLM2-135M-Instruct")
 
-    run_command = ["litgpt", "serve", tmp_path, "--openai_spec", "true"]
-
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response()
-
-    try:
+    with _serve(tmp_path, "--openai_spec", "true") as url:
         # Test server health
-        response = requests.get("http://127.0.0.1:8000/health")
+        response = requests.get(f"{url}/health")
         assert response.status_code == 200, f"Server health check failed with status code {response.status_code}"
         assert response.text == "ok", "Server did not respond as expected."
 
         # Test non-streaming chat completion
         response = requests.post(
-            "http://127.0.0.1:8000/v1/chat/completions",
+            f"{url}/v1/chat/completions",
             json={
                 "model": "SmolLM2-135M-Instruct",
                 "messages": [{"role": "user", "content": "Hello!"}],
@@ -233,7 +167,7 @@ def test_serve_with_openai_spec(tmp_path):
 
         # Test streaming chat completion
         stream_response = requests.post(
-            "http://127.0.0.1:8000/v1/chat/completions",
+            f"{url}/v1/chat/completions",
             json={
                 "model": "SmolLM2-135M-Instruct",
                 "messages": [{"role": "user", "content": "Hello!"}],
@@ -250,10 +184,6 @@ def test_serve_with_openai_spec(tmp_path):
                 assert "choices" in data, "Response JSON does not contain 'choices'."
                 assert "delta" in data["choices"][0], "Response JSON does not contain 'delta' in 'choices'."
                 assert "content" in data["choices"][0]["delta"], "Response JSON does not contain 'content' in 'delta'."
-    finally:
-        if process:
-            kill_process_tree(process.pid)
-        server_thread.join()
 
 
 @pytest.mark.parametrize(
@@ -264,37 +194,11 @@ def test_serve_with_openai_spec(tmp_path):
     ],
 )
 def test_serve_with_generate_strategy(tmp_path, generate_strategy):
-    seed_everything(123)
-    ours_config = Config.from_name("pythia-14m")
-    download_from_hub(repo_id="EleutherAI/pythia-14m", tokenizer_only=True, checkpoint_dir=tmp_path)
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer.json"), str(tmp_path))
-    shutil.move(str(tmp_path / "EleutherAI" / "pythia-14m" / "tokenizer_config.json"), str(tmp_path))
-    ours_model = GPT(ours_config)
-    checkpoint_path = tmp_path / "lit_model.pth"
-    torch.save(ours_model.state_dict(), checkpoint_path)
-    config_path = tmp_path / "model_config.yaml"
-    with open(config_path, "w", encoding="utf-8") as fp:
-        yaml.dump(asdict(ours_config), fp)
+    _prepare_checkpoint(tmp_path, "EleutherAI/pythia-14m")
 
-    # Test with generate strategy
-    run_command = ["litgpt", "serve", tmp_path, "--generate_strategy", generate_strategy]
+    extra_args = ["--generate_strategy", generate_strategy]
     if generate_strategy == "tensor_parallel":
-        run_command += ["--devices", "2"]
+        extra_args += ["--devices", "2"]
 
-    process = None
-
-    def run_server():
-        nonlocal process
-        try:
-            process = subprocess.Popen(run_command, stdout=None, stderr=None, text=True)
-        except subprocess.TimeoutExpired:
-            print("Server start-up timeout expired")
-
-    server_thread = threading.Thread(target=run_server)
-    server_thread.start()
-
-    _wait_and_check_response()
-
-    if process:
-        kill_process_tree(process.pid)
-    server_thread.join()
+    with _serve(tmp_path, *extra_args):
+        pass

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -21,20 +21,18 @@ from litgpt import GPT, Config
 from litgpt.scripts.download import download_from_hub
 from litgpt.utils import _RunIf, kill_process_tree
 
-# Startup includes the interpreter and torch imports, loading the checkpoint and, for the distributed
-# strategies, setting up the process group. A generous budget is cheap because `_wait_until_ready`
-# also watches the process and gives up as soon as it exits.
+# Generous, because a dead server no longer has to wait this out: `_wait_until_ready` gives up as
+# soon as the process exits.
 _STARTUP_TIMEOUT = 120
+_SHUTDOWN_TIMEOUT = 30
 
 
 def _find_free_port() -> int:
-    """Return a port that is currently unused.
-
-    Each test serves on its own port. Sharing one made a server that had not finished shutting down
-    yet fail the next one at bind time, which surfaced as an unrelated connection error.
-    """
+    """Return a port that is currently unused, so that each test can serve on its own."""
+    # Bind on all interfaces, like the server does, otherwise a port taken on another interface
+    # would look free here and fail at bind time.
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
+        sock.bind(("", 0))
         return sock.getsockname()[1]
 
 
@@ -65,9 +63,10 @@ def _wait_until_ready(url: str, process: subprocess.Popen, log_path: Path) -> No
                 f"Server exited with code {process.returncode} before it was ready.{_log_tail(log_path)}"
             )
         try:
-            if requests.get(url, timeout=10).status_code == 200:
+            status_code = requests.get(url, timeout=10).status_code
+            if status_code == 200:
                 return
-            err = "the server responded, but not with status 200"
+            err = f"the server answered with status {status_code}"
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as ex:
             err = str(ex)
         time.sleep(1)
@@ -77,17 +76,19 @@ def _wait_until_ready(url: str, process: subprocess.Popen, log_path: Path) -> No
 def _terminate(process: subprocess.Popen) -> None:
     """Kill the server process tree and wait for it to be gone.
 
-    ``kill_process_tree`` only sends the signals. The port stays bound until every process holding it
-    has exited, so returning earlier would leave the next server unable to bind.
+    ``kill_process_tree`` only sends the signals; the workers keep holding their GPU memory and their
+    port until they have actually exited, so the next test has to wait for that here.
     """
+    # Snapshot the children before killing the parent: once it is gone they are reparented and can no
+    # longer be found through it.
     try:
         children = psutil.Process(process.pid).children(recursive=True)
     except psutil.NoSuchProcess:
         children = []
     kill_process_tree(process.pid)
-    psutil.wait_procs(children, timeout=30)
+    psutil.wait_procs(children, timeout=_SHUTDOWN_TIMEOUT)
     with contextlib.suppress(subprocess.TimeoutExpired):
-        process.wait(timeout=30)
+        process.wait(timeout=_SHUTDOWN_TIMEOUT)
 
 
 @contextlib.contextmanager
@@ -100,7 +101,7 @@ def _serve(checkpoint_dir: Path, *extra_args: str) -> Iterator[str]:
     log_path = checkpoint_dir.parent / f"{checkpoint_dir.name}-server.log"
     command = ["litgpt", "serve", str(checkpoint_dir), "--port", str(port), *extra_args]
     with open(log_path, "w", encoding="utf-8") as log_fp:
-        process = subprocess.Popen(command, stdout=log_fp, stderr=subprocess.STDOUT, text=True)
+        process = subprocess.Popen(command, stdout=log_fp, stderr=subprocess.STDOUT)
         try:
             _wait_until_ready(url, process, log_path)
             yield url


### PR DESCRIPTION
## What does this PR do?

Fixes the recurring flake in `tests/test_serve.py`, most often seen on `test_serve_with_generate_strategy[tensor_parallel]`:

```python
AssertionError: Server did not respond as expected. 
Error: HTTPConnectionPool(host='127.0.0.1', port=8000):
Max retries exceeded ... Connection refused
```
<img width="1168" height="77" alt="image" src="https://github.com/user-attachments/assets/5d7db6a2-1db5-4d8c-9b61-96de886c0fb1" />

Each test now serves on its own OS-assigned free port, so servers can no longer collide:

- Waiting stops as soon as the server process exits, and reports its exit code plus a tail of the server log instead of a bare connection error — e.g. `Server exited with code 2 before it was ready.` right away, rather than a connection refused after 30s.
- Teardown always runs through a context manager and waits for the whole process tree to be gone before the next test starts.
- Server output goes to a file rather than an unread pipe, which can fill up and block a chatty server (`NCCL_DEBUG=INFO` on CI) before it binds.
- The boilerplate duplicated across all seven tests collapses into two helpers.

<details>
<summary><b>Root cause</b></summary>

All seven tests bound the hardcoded port `8000`, and teardown never waited for the server to actually exit — `kill_process_tree` only sends the signals, and the thread wrapping the non-blocking `Popen` was joined instead of the process. Three compounding problems:

- **Port still held.** A server that has not finished shutting down makes the next one exit at `bind_socket()` via uvicorn's silent `sys.exit(1)`, which the test can only observe as a connection refused.
- **Leaked servers.** When an assertion fails, the `kill_process_tree` call below it is never reached, so the server survives for the rest of the session and keeps port 8000. `tensor_parallel` runs last, so it inherits the debris.
- **No diagnostics.** Nothing checked whether the server was still alive, so a crash at second one looked exactly like a slow start.

</details>
