### PR TITLE
Add in-memory data support to the JSON DataModule

### DIFF
--- a/litgpt/data/json_data.py
+++ b/litgpt/data/json_data.py
@@ -13,20 +13,24 @@ from litgpt.data import DataModule, SFTDataset, get_sft_collate_fn
 from litgpt.prompts import PromptStyle
 from litgpt.tokenizer import Tokenizer
 
+_JSONScalar = str | int | float | bool | None
+_JSONValue = _JSONScalar | dict[str, Any] | list[Any]
+
 
 @dataclass
 class JSON(DataModule):
     """Loads JSON or JSONL data for supervised finetuning."""
 
-    json_path: Path
-    """A path to a JSON file or a directory with `train.json` and `val.json` containing the data.
+    json_path: Path | None = None
+    """A path to a JSON file or a directory with `train.json` and `val.json` containing the data. Mutually exclusive
+    with ``json_data``.
     The file(s) should contain a list of samples (dicts). Each dict must have the keys 'instruction' and 'output',
     and can optionally have a key 'input' (see Alpaca)."""
     mask_prompt: bool = False
     """Whether to mask the prompt section from the label (with ``ignore_index``)."""
     val_split_fraction: float | None = None
     """The fraction of the dataset to use for the validation dataset. The rest is used for training.
-    Only applies if you passed in a single file to `json_path`."""
+    Only applies if you passed in a single file to `json_path` or an in-memory JSON string to `json_data`."""
     prompt_style: str | PromptStyle = "alpaca"
     """The style to apply to instruction prompts. See `litgpt.prompts` for a list of available styles."""
     ignore_index: int = -100
@@ -35,6 +39,9 @@ class JSON(DataModule):
     """The random seed for creating the train/val splits and shuffling the dataset."""
     num_workers: int = 4
     """How many DataLoader processes to use for loading."""
+    json_data: str | list[dict[str, _JSONValue]] | None = field(default=None, repr=False)
+    """An in-memory JSON string or decoded list of samples (dicts). Mutually exclusive with ``json_path``.
+    When converting a pandas DataFrame, use ``df.to_json(orient="records")``."""
 
     tokenizer: Tokenizer | None = field(default=None, init=False, repr=False)
     batch_size: int = field(default=1, init=False, repr=False)
@@ -44,21 +51,28 @@ class JSON(DataModule):
 
     def __post_init__(self):
         super().__init__()
-        if self.json_path.is_file() and self.val_split_fraction is None:
+        if (self.json_path is None) == (self.json_data is None):
+            raise ValueError("Exactly one of `json_path` or `json_data` must be provided.")
+        single_source = None
+        if self.json_data is not None:
+            single_source = "The `json_data` argument was provided"
+        elif self.json_path is not None and self.json_path.is_file():
+            single_source = "The `json_path` points to a single file"
+        if single_source is not None and self.val_split_fraction is None:
             self.val_split_fraction = 0.05
             warnings.warn(
-                "The `json_path` points to a single file and `val_split_fraction` was not set. "
+                f"{single_source} and `val_split_fraction` was not set. "
                 "Defaulting to `val_split_fraction=0.05`. Set `val_split_fraction` explicitly "
                 "to use a different split percentage.",
                 UserWarning,
                 stacklevel=2,
             )
-        if self.json_path.is_dir() and self.val_split_fraction is not None:
+        if self.json_path is not None and self.json_path.is_dir() and self.val_split_fraction is not None:
             raise ValueError(
                 "If `json_path` is a directory, it must contain 'train.json' and 'val.json' files and"
                 f" hence `val_split_fraction` should not be set. Got `{self.val_split_fraction=}`."
             )
-        if not self.json_path.exists():
+        if self.json_path is not None and not self.json_path.exists():
             raise FileNotFoundError(
                 "The `json_path` must be a file or a directory containing 'train.json' and 'val.json' files,"
                 f" but '{self.json_path!s}' does not exist."
@@ -113,33 +127,64 @@ class JSON(DataModule):
         )
 
     def get_splits(self) -> tuple:
-        # A single file (gets split into train and test)
-        if self.json_path.is_file():
-            data = load_split(self.json_path)
+        if self.json_data is not None:
+            if isinstance(self.json_data, str):
+                try:
+                    data = json.loads(self.json_data)
+                except json.JSONDecodeError as ex:
+                    raise ValueError("`json_data` must be valid JSON.") from ex
+            else:
+                data = self.json_data
+            data = _validate_json_data(data)
+        else:
+            json_path = self.json_path
+            if json_path is None:
+                raise RuntimeError("Expected `json_path` when `json_data` is not provided.")
+            if not json_path.is_file():
+                # A directory containing train.json and val.json
+                if (train_file := self.find_split("train")) and (val_file := self.find_split("val")):
+                    train_data = load_split(train_file)
+                    test_data = load_split(val_file)
+                    return train_data, test_data
 
-            # Partition the dataset into train and test
-            train_data, test_data = random_split(
-                data,
-                [1.0 - self.val_split_fraction, self.val_split_fraction],
-                generator=torch.Generator().manual_seed(self.seed),
-            )
-            return train_data, test_data
+                raise FileNotFoundError(
+                    "The `json_path` must be a file or a directory containing 'train.json' and 'val.json' files."
+                )
+            data = load_split(json_path)
 
-        # A directory containing train.json and val.json
-        if (train_file := self.find_split("train")) and (val_file := self.find_split("val")):
-            train_data = load_split(train_file)
-            test_data = load_split(val_file)
-            return train_data, test_data
-
-        raise FileNotFoundError(
-            "The `json_path` must be a file or a directory containing 'train.json' and 'val.json' files."
+        val_split_fraction = self.val_split_fraction
+        if val_split_fraction is None:
+            raise RuntimeError("Expected `val_split_fraction` for a single JSON data source.")
+        return random_split(
+            data,
+            [1.0 - val_split_fraction, val_split_fraction],
+            generator=torch.Generator().manual_seed(self.seed),
         )
 
     def find_split(self, split_name: str) -> Path | None:
+        if self.json_path is None:
+            return None
         for suffix in (".json", ".jsonl"):
             if (file := self.json_path / f"{split_name}{suffix}").is_file():
                 return file
         return None
+
+
+def _validate_json_data(data: Any) -> list[dict[str, _JSONValue]]:
+    if not isinstance(data, list):
+        raise ValueError(
+            f"`json_data` must decode to a list of JSON objects, got {type(data).__name__}. "
+            'When using pandas, call `DataFrame.to_json(orient="records")`.'
+        )
+
+    required_fields = {"instruction", "output"}
+    for index, sample in enumerate(data):
+        if not isinstance(sample, dict):
+            raise ValueError(f"`json_data` sample at index {index} must be a JSON object, got {type(sample).__name__}.")
+        if missing_fields := required_fields - sample.keys():
+            formatted_fields = ", ".join(f"`{field}`" for field in sorted(missing_fields))
+            raise ValueError(f"`json_data` sample at index {index} is missing required field(s): {formatted_fields}.")
+    return data
 
 
 def load_split(json_path: Path) -> Any:

--- a/tests/data/test_json.py
+++ b/tests/data/test_json.py
@@ -1,7 +1,9 @@
 # Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
 import json
+import warnings
 
 import pytest
+from jsonargparse import ArgumentParser
 
 from litgpt.data import JSON
 from litgpt.prompts import PromptStyle
@@ -66,6 +68,12 @@ def test_json(as_jsonl, tmp_path, mock_tokenizer):
 
 
 def test_json_input_validation(tmp_path):
+    with pytest.raises(ValueError, match="Exactly one of `json_path` or `json_data`"):
+        JSON()
+
+    with pytest.raises(ValueError, match="Exactly one of `json_path` or `json_data`"):
+        JSON(tmp_path, json_data="[]")
+
     with pytest.raises(FileNotFoundError, match="The `json_path` must be a file or a directory"):
         JSON(tmp_path / "not exist")
 
@@ -88,6 +96,96 @@ def test_json_input_validation(tmp_path):
     with pytest.warns(UserWarning, match="Defaulting to `val_split_fraction=0.05`"):
         data = JSON(tmp_path / "train.json", val_split_fraction=None)
     assert data.val_split_fraction == 0.05
+
+    # Adding a new input source must not change the existing positional arguments.
+    data = JSON(tmp_path / "train.json", True, 0.25)
+    assert data.mask_prompt
+    assert data.val_split_fraction == 0.25
+
+
+@pytest.mark.parametrize("serialize", [False, True])
+def test_json_data(serialize, mock_tokenizer):
+    mock_data = [
+        {"instruction": "Add", "input": "2+2", "output": "4"},
+        {"instruction": "Subtract", "input": "5-3", "output": "2"},
+        {"instruction": "Multiply", "input": "6*4", "output": "24"},
+        {"instruction": "Divide", "input": "10/2", "output": "5"},
+    ]
+
+    json_data = json.dumps(mock_data) if serialize else mock_data
+    data = JSON(json_data=json_data, val_split_fraction=0.5, num_workers=0)
+    assert "json_data" not in repr(data)
+    assert "Subtract" not in repr(data)
+
+    data.connect(tokenizer=mock_tokenizer, batch_size=2)
+    data.setup()
+
+    train_batch = next(iter(data.train_dataloader()))
+    val_batch = next(iter(data.val_dataloader()))
+
+    assert train_batch["input_ids"].size(0) == 2
+    assert val_batch["input_ids"].size(0) == 2
+    assert sorted(
+        [*data.train_dataset.data, *data.test_dataset.data], key=lambda sample: sample["instruction"]
+    ) == sorted(mock_data, key=lambda sample: sample["instruction"])
+
+
+def test_json_data_default_validation_split():
+    mock_data = [{"instruction": "Add", "input": "2+2", "output": "4"}]
+
+    with pytest.warns(UserWarning, match="Defaulting to `val_split_fraction=0.05`"):
+        data = JSON(json_data=json.dumps(mock_data))
+    assert data.val_split_fraction == 0.05
+
+
+@pytest.mark.parametrize(
+    ("json_data", "error"),
+    [
+        ("{", "must be valid JSON"),
+        ("null", "must decode to a list of JSON objects"),
+        (
+            json.dumps({"instruction": {"0": "Add"}, "output": {"0": "4"}}),
+            'DataFrame.to_json\\(orient="records"\\)',
+        ),
+        (json.dumps(["not an object"]), "sample at index 0 must be a JSON object"),
+        (json.dumps([{"instruction": "Add"}]), "missing required field.*`output`"),
+    ],
+)
+def test_json_data_validation(json_data, error):
+    data = JSON(json_data=json_data, val_split_fraction=0.5)
+    with pytest.raises(ValueError, match=error):
+        data.get_splits()
+
+
+def test_json_data_cli_parsing():
+    mock_data = [
+        {
+            "instruction": "Add",
+            "input": "2+2",
+            "output": "4",
+            "score": 4,
+            "enabled": True,
+            "messages": [{"role": "user", "content": "2+2"}],
+            "metadata": {"source": "math", "nested": {"difficulty": 1}},
+            "matrix": [[1, 2], [3, 4]],
+        },
+        {"instruction": "Subtract", "input": "5-3", "output": "2"},
+    ]
+    parser = ArgumentParser(exit_on_error=False)
+    parser.add_class_arguments(JSON, "data")
+
+    config = parser.parse_args(["--data.json_data", json.dumps(mock_data), "--data.val_split_fraction", "0.5"])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        serialized_config = parser.dump(config)
+    data = parser.instantiate_classes(config).data
+
+    assert "output: '4'" in serialized_config
+    assert isinstance(data, JSON)
+    assert data.json_data == mock_data
+    assert data.json_data[0]["output"] == "4"
+    train_data, val_data = data.get_splits()
+    assert sorted([*train_data, *val_data], key=lambda sample: sample["instruction"]) == mock_data
 
 
 @pytest.mark.parametrize("as_jsonl", [False, True])


### PR DESCRIPTION
Fixes #1976

Adds an optional `json_data` input to the supervised-finetuning `JSON`
DataModule. It accepts either a raw JSON string or a decoded list of
sample dictionaries while preserving the existing file and directory
inputs.

The change:

- requires exactly one of `json_path` and `json_data`
- validates in-memory records before dataset splitting
- supports natural jsonargparse CLI input and nested JSON values
- preserves string scalar types during config serialization
- excludes raw training samples from the dataclass representation
- preserves the existing positional constructor arguments

When converting a pandas DataFrame, the supported format is
`df.to_json(orient="records")`.

Tests cover the full train and validation DataLoader path, malformed and
unsupported payloads, CLI parsing and serialization, nested JSON values,
default validation splitting, and backward compatibility.

Testing:

- `python -m pytest -q tests/data/test_json.py`
- `python -m pytest -q tests/data`
- `python -m pytest -q tests/test_cli.py`
- applicable pre-commit hooks
- jsonargparse 4.37.0 compatibility check
- real `litgpt finetune_lora --print_config` invocation
