### PR TITLE
Fix first token handling in speculative decoding

### DIFF
--- a/litgpt/generate/speculative_decoding.py
+++ b/litgpt/generate/speculative_decoding.py
@@ -256,9 +256,12 @@ def generate(
     input_pos_maxp1 += 1
 
     # Step 2: Main generation loop.
-    tokens = []
+    prefill_token = token.squeeze(0)
+    stop_reached = prefill_token in stop_tokens
+    tokens = [] if stop_reached else [prefill_token]
+    max_generated_tokens = max_returned_tokens - prompt_size
     total_generated, total_accepted = 0, 0  # Track acceptance statistics
-    while input_pos < max_returned_tokens - 1:
+    while not stop_reached and input_pos < max_returned_tokens - 1:
         # Calculate speculative tokens to generate
         _speculative_k = min(speculative_k, (max_returned_tokens - input_pos - 1).item())
 
@@ -287,6 +290,9 @@ def generate(
                 should_break = True
                 break
             tokens.append(new_token)
+            if len(tokens) == max_generated_tokens:
+                should_break = True
+                break
 
         if should_break:
             break
@@ -297,7 +303,7 @@ def generate(
         token = new_tokens[-1].unsqueeze(0)
 
     # Finalize generated sequence
-    tokens = torch.stack(tokens)
+    tokens = torch.stack(tokens) if tokens else prompt.new_empty(0)
     if include_prompt:
         tokens = torch.cat([prompt, tokens])
     acceptance_rate = total_accepted / total_generated if total_generated > 0 else 0.0

--- a/tests/test_generate_speculatively.py
+++ b/tests/test_generate_speculatively.py
@@ -101,6 +101,55 @@ def test_speculative_decoding_target_sometimes_accepts_draft_tokens():
     assert torch.equal(output, torch.tensor([4, 4, 9]))
 
 
+def test_generate_includes_prefill_token(monkeypatch):
+    model = nn.Module()
+    model.max_seq_length = 3
+    prompt = torch.tensor([1, 2])
+    next_token_mock = Mock(side_effect=[torch.tensor([9]), torch.tensor([7])])
+    speculative_decoding_mock = Mock()
+    monkeypatch.setattr(generate, "next_token", next_token_mock)
+    monkeypatch.setattr(generate, "speculative_decoding", speculative_decoding_mock)
+
+    output, acceptance_rate = generate.generate(model, model, prompt, 3, speculative_k=1)
+
+    assert torch.equal(output, torch.tensor([1, 2, 7]))
+    assert acceptance_rate == 0.0
+    speculative_decoding_mock.assert_not_called()
+
+
+def test_generate_does_not_exceed_max_returned_tokens(monkeypatch):
+    model = nn.Module()
+    model.max_seq_length = 8
+    prompt = torch.tensor([1, 2])
+    next_token_mock = Mock(side_effect=[torch.tensor([9]), torch.tensor([7])])
+    speculative_decoding_mock = Mock(side_effect=lambda speculative_k, **_: torch.arange(speculative_k + 1))
+    monkeypatch.setattr(generate, "next_token", next_token_mock)
+    monkeypatch.setattr(generate, "speculative_decoding", speculative_decoding_mock)
+
+    output, _ = generate.generate(model, model, prompt, 8, speculative_k=3)
+
+    assert output.size(0) == 8
+
+
+def test_generate_stops_on_prefill_token(monkeypatch):
+    model = nn.Module()
+    model.max_seq_length = 4
+    prompt = torch.tensor([1, 2])
+    next_token_mock = Mock(side_effect=[torch.tensor([9]), torch.tensor([7])])
+    speculative_decoding_mock = Mock()
+    monkeypatch.setattr(generate, "next_token", next_token_mock)
+    monkeypatch.setattr(generate, "speculative_decoding", speculative_decoding_mock)
+
+    output, acceptance_rate = generate.generate(
+        model, model, prompt, 4, stop_tokens=[7], include_prompt=False, speculative_k=1
+    )
+
+    assert output.numel() == 0
+    assert output.dtype == prompt.dtype
+    assert acceptance_rate == 0.0
+    speculative_decoding_mock.assert_not_called()
+
+
 @pytest.mark.parametrize("max_seq_length", (10, 15, 20, 25))
 @pytest.mark.parametrize("speculative_k", (1, 2, 3))
 def test_generate(max_seq_length, speculative_k):
@@ -122,7 +171,7 @@ def test_generate(max_seq_length, speculative_k):
     )
 
     # validate
-    assert out.size(0) == T + max_new_tokens - 1, (out.size(0), T + max_new_tokens - 1)
+    assert out.size(0) == T + max_new_tokens, (out.size(0), T + max_new_tokens)
     assert 0.0 <= acceptance_rate <= 1.0
 
 


### PR DESCRIPTION
## What changed

- return the target model's prefill sample as the first completion token
- stop immediately when that token matches a stop token
- keep the generated sequence within `max_returned_tokens` when a speculative round returns `k + 1` tokens
- add CPU regression coverage for the prefill, stop-token, and output-limit paths

## Why

The target model samples the first completion token during prefill, but `generate()` previously
initialized the output accumulator as empty and only appended tokens from later speculative
decoding rounds. This dropped the first token from the generated text and could return one fewer
token than requested. It also skipped stop-token handling for that first sample.

Fixes #2307.

## Validation

- `pytest -q tests/test_generate_speculatively.py`: 19 passed, 1 skipped (GPU-only)
- `ruff check litgpt/generate/speculative_decoding.py tests/test_generate_speculatively.py`
- `ruff format --check litgpt/generate/speculative_decoding.py tests/test_generate_speculatively.py`
- all applicable pre-commit hooks passed for the two changed Python files; the Prettier hook was skipped because it only targets JSON, YAML, and TOML files

