### PR TITLE
fix(generate): reject top_k below 1 instead of masking every logit

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -56,6 +56,8 @@ def sample(
 ) -> torch.Tensor:
     if top_p < 0.0 or top_p > 1.0:
         raise ValueError(f"top_p must be in [0, 1], got {top_p}")
+    if top_k is not None and top_k < 1:
+        raise ValueError(f"top_k must be >= 1, got {top_k}")
     logits = logits[0, -1]
     # optionally crop the logits to only the top k options
     if top_k is not None:

--- a/litgpt/generate/speculative_decoding.py
+++ b/litgpt/generate/speculative_decoding.py
@@ -39,6 +39,8 @@ def sample(
 ) -> torch.Tensor:
     if top_p < 0.0 or top_p > 1.0:
         raise ValueError(f"top_p must be in [0, 1], got {top_p}")
+    if top_k is not None and top_k < 1:
+        raise ValueError(f"top_k must be >= 1, got {top_k}")
     logits = logits[0, -1]
     # optionally crop the logits to only the top k options
     if top_k is not None:

--- a/tests/generate/test_main.py
+++ b/tests/generate/test_main.py
@@ -151,6 +151,31 @@ def test_sample_top_p_zero_is_greedy():
         )
 
 
+@pytest.mark.parametrize("top_k", (0, -1))
+def test_sample_rejects_top_k_below_one(top_k):
+    """`top_k` below 1 selects no candidates at all, which is not a usable request.
+
+    Without the check the failure is silent in greedy mode: every logit is masked to
+    -inf, so argmax returns index 0 for any input. In sampling mode it surfaces far
+    from the caller as an opaque `RuntimeError` out of `torch.multinomial`, or as
+    "selected index k out of range" out of `torch.topk` for negative values.
+    """
+    logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
+
+    for temperature in (0.0, 1.0):
+        with pytest.raises(ValueError, match=re.escape(f"top_k must be >= 1, got {top_k}")):
+            sample(logits, temperature=temperature, top_k=top_k)
+
+
+def test_sample_top_k_one_is_greedy():
+    """The smallest accepted `top_k` keeps working and pins sampling to the argmax."""
+    logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
+    expected = torch.argmax(logits[0, -1], dim=-1).item()
+
+    results = [sample(logits, temperature=1.0, top_k=1).item() for _ in range(10)]
+    assert all(r == expected for r in results), results
+
+
 def test_generate_different_results_with_different_top_p():
     config = Config(block_size=128, vocab_size=16, n_layer=1, n_head=4, n_embd=8)
     model = GPT(config)

--- a/tests/test_generate_speculatively.py
+++ b/tests/test_generate_speculatively.py
@@ -16,6 +16,21 @@ from litgpt import GPT, Config
 from litgpt.utils import _RunIf
 
 
+@pytest.mark.parametrize("top_k", (0, -1))
+def test_sample_rejects_top_k_below_one(top_k):
+    """Same guard as `litgpt.generate.base.sample`: `top_k` below 1 selects nothing.
+
+    Here the silent mode is worse than in base: with `apply_softmax=False` the masked
+    logits are filled with 0 instead of -inf, so the draft distribution handed to the
+    acceptance test is all zeros rather than an error.
+    """
+    logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
+
+    for temperature in (0.0, 1.0):
+        with pytest.raises(ValueError, match=re.escape(f"top_k must be >= 1, got {top_k}")):
+            generate.sample(logits, temperature=temperature, top_k=top_k)
+
+
 def test_speculative_decoding_target_never_accepts_draft_tokens():
     class DraftModel(nn.Module):
         def forward(self, **kwargs):


### PR DESCRIPTION
## What

`sample()` validates `top_p` but not `top_k`. A `top_k` below 1 selects no
candidates at all, and the failure is silent in greedy mode.

## The bug

```python
if top_k is not None:
    v, i = torch.topk(logits, min(top_k, logits.size(-1)))
    logits = torch.full_like(logits, float("-inf")).scatter_(-1, i, v)
```

With `top_k=0`, `torch.topk(..., 0)` returns empty tensors, the scatter writes
nothing, and every logit stays at the fill value. The output stops depending on
the model:

```python
>>> logits = torch.tensor([[[0.5, -1.2, 3.1, 0.8, -0.3, 2.7, -0.9, 1.4]]])
>>> sample(logits, temperature=0.0, top_k=0).item()
0          # argmax over an all -inf row; the real argmax is 2
>>> sample(logits, temperature=1.0, top_k=0)
RuntimeError: probability tensor contains either `inf`, `nan` or element < 0
>>> sample(logits, temperature=1.0, top_k=-1)
RuntimeError: selected index k out of range
```

Greedy decoding is the one that hurts: no warning, no exception, just token 0
emitted at every step. The two sampling-mode errors do stop the run, but they
surface inside `torch.multinomial` / `torch.topk` and name neither `top_k` nor
`sample`.

`top_k` arrives here straight from the caller — `litgpt generate`,
`litgpt chat`, `LLM.generate()`, and the LitServe endpoints in
`litgpt/deploy/serve.py` all forward it unchanged.

## The fix

Add the range check next to the one `top_p` already has:

```python
if top_p < 0.0 or top_p > 1.0:
    raise ValueError(f"top_p must be in [0, 1], got {top_p}")
if top_k is not None and top_k < 1:
    raise ValueError(f"top_k must be >= 1, got {top_k}")
```

`litgpt/generate/speculative_decoding.py` has the same `sample()` with the same
`top_p` guard and the same unguarded `top_k`, so it gets the same check. The
silent mode there is worse: with `apply_softmax=False` the mask fill value is
`0` instead of `-inf`, so the draft distribution handed to the acceptance test
comes out all zeros.

## Compatibility

No default in the tree is below 1 — they are `None` or `50` — so no working
configuration changes. The values that now raise are exactly the ones that
could only produce garbage before.

`top_p=0` and `temperature=0` keep their documented meaning (greedy); this only
covers `top_k`, whose domain starts at 1.

## Tests

`tests/generate/test_main.py`
- `test_sample_rejects_top_k_below_one` — `top_k` in `(0, -1)` × `temperature`
  in `(0.0, 1.0)` all raise `ValueError`
- `test_sample_top_k_one_is_greedy` — the smallest accepted value still works
  and pins sampling to the argmax

`tests/test_generate_speculatively.py`
- `test_sample_rejects_top_k_below_one` — same guard on the speculative copy

Verified locally on Windows / Python 3.12 / torch 2.x:

```
tests/generate/test_main.py          11 passed, 1 xfailed
tests/test_generate_speculatively.py 18 passed
```

(`test_cli` in both files fails identically before and after this change — it
shells out to a `litgpt` entry point that is not installed in my environment.)

`ruff check` and `ruff format --check` clean at the pinned `v0.15.9` from
`.pre-commit-config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
