### PR TITLE
feat: multiturn support for ChatML

### DIFF
--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -177,7 +177,14 @@ class Llama2(PromptStyle):
 class Llama3(PromptStyle):
     supports_multiturn = True
 
-    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
+    def apply(
+        self,
+        prompt: str | list[dict[str, str]],
+        *,
+        sys_prompt: str | None = None,
+        add_generation_prompt: bool = True,
+        **kwargs: str,
+    ) -> str:
         default_system_prompt = sys_prompt or "You are a helpful assistant."
 
         # https://github.com/meta-llama/llama3/blob/359887376f0aaf30e433f23e25df858d8c2a9833/llama/tokenizer.py#L202-L229
@@ -228,7 +235,14 @@ class Llama3(PromptStyle):
 class R1Base(PromptStyle):
     supports_multiturn = True
 
-    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
+    def apply(
+        self,
+        prompt: str | list[dict[str, str]],
+        *,
+        sys_prompt: str | None = None,
+        add_generation_prompt: bool = True,
+        **kwargs: str,
+    ) -> str:
         default_system_prompt = sys_prompt or ""
 
         bos_token = "<｜begin▁of▁sentence｜>"
@@ -384,13 +398,21 @@ class ChatML(PromptStyle):
     def __init__(self, system_message: str | None = None):
         self.system_message = system_message
 
-    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
+    def apply(
+        self,
+        prompt: str | list[dict[str, str]],
+        *,
+        sys_prompt: str | None = None,
+        add_generation_prompt: bool = True,
+        **kwargs: str,
+    ) -> str:
         sys_prompt = sys_prompt or self.system_message
         # omit the system turn when there is no system message (e.g. Qwen3)
         system = f"<|im_start|>system\n{sys_prompt}<|im_end|>\n" if sys_prompt else ""
         if isinstance(prompt, str):
             return f"{system}<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
         elif isinstance(prompt, list):
+
             def encode_message(message: dict[str, str]) -> str:
                 role = message["role"]
                 content = message["content"].strip()

--- a/litgpt/prompts.py
+++ b/litgpt/prompts.py
@@ -14,8 +14,15 @@ if TYPE_CHECKING:
     from litgpt import Tokenizer
 
 
+def has_system_prompt(messages: list[dict[str, str]]) -> bool:
+    """Whether a list of conversation turns opens with a 'system' role message."""
+    return messages[0].get("role", "") == "system" if len(messages) else False
+
+
 class PromptStyle:
     """Base interface for prompt styles."""
+
+    supports_multiturn: bool = False
 
     @abstractmethod
     def apply(self, prompt: str, *, sys_prompt: str | None = None, **kwargs: str) -> str:
@@ -168,7 +175,9 @@ class Llama2(PromptStyle):
 
 
 class Llama3(PromptStyle):
-    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, **kwargs: str) -> str:
+    supports_multiturn = True
+
+    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
         default_system_prompt = sys_prompt or "You are a helpful assistant."
 
         # https://github.com/meta-llama/llama3/blob/359887376f0aaf30e433f23e25df858d8c2a9833/llama/tokenizer.py#L202-L229
@@ -192,9 +201,6 @@ class Llama3(PromptStyle):
                 tokens.append("<|eot_id|>")
                 return tokens
 
-            def has_system_prompt(messages: list[dict[str, str]]) -> bool:
-                return messages[0].get("role", "") == "system" if len(messages) else False
-
             tokens = ["<|begin_of_text|>"]
             if not has_system_prompt(prompt):
                 tokens.extend(encode_message({"role": "system", "content": default_system_prompt}))
@@ -206,7 +212,8 @@ class Llama3(PromptStyle):
                         f"Unknown role: '{message['role']}'. Supported roles are 'assistant', 'user', and 'system'."
                     )
                 tokens.extend(encode_message(message))
-            tokens.extend(encode_header("assistant"))
+            if add_generation_prompt:
+                tokens.extend(encode_header("assistant"))
             return "".join(tokens)
         else:
             raise ValueError(f"Unsupported prompt type: {type(prompt)}")
@@ -219,7 +226,9 @@ class Llama3(PromptStyle):
 
 
 class R1Base(PromptStyle):
-    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, **kwargs: str) -> str:
+    supports_multiturn = True
+
+    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
         default_system_prompt = sys_prompt or ""
 
         bos_token = "<｜begin▁of▁sentence｜>"
@@ -244,7 +253,7 @@ class R1Base(PromptStyle):
 
             # Extract system prompt (if any)
             system_prompt = ""
-            if prompt and prompt[0].get("role") == "system":
+            if has_system_prompt(prompt):
                 system_prompt = prompt[0]["content"]
                 prompt = prompt[1:]  # Remove system message from the list
 
@@ -253,7 +262,8 @@ class R1Base(PromptStyle):
             for message in prompt:
                 formatted_prompt += encode_message(message)
 
-            formatted_prompt += "<｜Assistant｜>"  # Prepares for assistant response
+            if add_generation_prompt:
+                formatted_prompt += "<｜Assistant｜>"  # Prepares for assistant response
             return formatted_prompt
         else:
             raise ValueError(f"Unsupported prompt type: {type(prompt)}")
@@ -369,14 +379,39 @@ class OLMo(PromptStyle):
 
 
 class ChatML(PromptStyle):
+    supports_multiturn = True
+
     def __init__(self, system_message: str | None = None):
         self.system_message = system_message
 
-    def apply(self, prompt: str, *, sys_prompt: str | None = None, **kwargs: str) -> str:
+    def apply(self, prompt: str | list[dict[str, str]], *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs: str) -> str:
         sys_prompt = sys_prompt or self.system_message
         # omit the system turn when there is no system message (e.g. Qwen3)
         system = f"<|im_start|>system\n{sys_prompt}<|im_end|>\n" if sys_prompt else ""
-        return f"{system}<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+        if isinstance(prompt, str):
+            return f"{system}<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+        elif isinstance(prompt, list):
+            def encode_message(message: dict[str, str]) -> str:
+                role = message["role"]
+                content = message["content"].strip()
+                return f"<|im_start|>{role}\n{content}<|im_end|>\n"
+
+            tokens = ""
+            if not has_system_prompt(prompt):
+                tokens += system
+            for i, message in enumerate(prompt):
+                if i != 0 and message["role"] == "system":
+                    raise ValueError("'system' role is only allowed at the beginning of the conversation list.")
+                if message["role"] not in ["assistant", "user", "system"]:
+                    raise ValueError(
+                        f"Unknown role: '{message['role']}'. Supported roles are 'assistant', 'user', and 'system'."
+                    )
+                tokens += encode_message(message)
+            if add_generation_prompt:
+                tokens += "<|im_start|>assistant\n"
+            return tokens
+        else:
+            raise ValueError(f"Unsupported prompt type: {type(prompt)}")
 
 
 class Qwen2_5(ChatML):

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -202,3 +202,13 @@ What can I do there?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
     output = style.apply(msgs)
     simple_output = style.apply(content)
     assert output == simple_output
+
+    # add_generation_prompt=False: training case, conversation already ends on assistant
+    msgs = [
+        {"role": "user", "content": "What is France's capital?"},
+        {"role": "assistant", "content": "Bonjour! The capital of France is Paris!"},
+    ]
+    inference_output = style.apply(msgs)
+    training_output = style.apply(msgs, add_generation_prompt=False)
+    assert inference_output == training_output + "<|start_header_id|>assistant<|end_header_id|>\n\n"
+    assert training_output.endswith("Bonjour! The capital of France is Paris!<|eot_id|>")


### PR DESCRIPTION
This pull request enhances the prompt formatting system to better support multi-turn conversations and training/inference scenarios for several prompt styles. The most important changes include adding a `supports_multiturn` attribute, introducing an `add_generation_prompt` parameter, and refactoring prompt application logic for consistency and extensibility.

**Multi-turn and Prompt Formatting Enhancements:**

* Added a `supports_multiturn` attribute to `PromptStyle` and its subclasses (`Llama3`, `R1Base`, `ChatML`), indicating whether each style supports multi-turn conversations. [[1]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR17-R26) [[2]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL171-R180) [[3]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL222-R231) [[4]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR382-R414)
* Updated the `apply` method signature for multi-turn styles to accept an `add_generation_prompt` argument, allowing control over whether a generation prompt is appended (for inference vs. training). [[1]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL171-R180) [[2]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL222-R231) [[3]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR382-R414)

**Prompt Logic Refactoring:**

* Moved the `has_system_prompt` utility function to the module level for reuse and clarity, and updated its usage in prompt formatting logic. [[1]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR17-R26) [[2]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL195-L197) [[3]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eL247-R256) [[4]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR382-R414)

**Training/Inference Handling:**

* Modified prompt formatting logic in `Llama3`, `R1Base`, and `ChatML` to conditionally add the generation prompt based on the `add_generation_prompt` parameter, supporting both inference and training workflows. [[1]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR215) [[2]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR265) [[3]](diffhunk://#diff-490f26232e88d4077215cba48f04682660506c56eb8f548408a32ff0bfc64c0eR382-R414)

**Testing Improvements:**

* Added and updated tests to verify that prompt formatting behaves correctly for both inference and training cases, specifically checking the behavior of the `add_generation_prompt` parameter.