### PR TITLE
feat: MultiturnSFTDataset

### DIFF
--- a/litgpt/data/__init__.py
+++ b/litgpt/data/__init__.py
@@ -3,7 +3,7 @@
 from litgpt.data.alpaca import Alpaca
 from litgpt.data.alpaca_2k import Alpaca2k
 from litgpt.data.alpaca_gpt4 import AlpacaGPT4
-from litgpt.data.base import DataModule, SFTDataset, get_sft_collate_fn
+from litgpt.data.base import DataModule, MultiturnSFTDataset, SFTDataset, get_sft_collate_fn
 from litgpt.data.deita import Deita
 from litgpt.data.flan import FLAN
 from litgpt.data.json_data import JSON
@@ -27,6 +27,7 @@ __all__ = [
     "LitData",
     "DataModule",
     "LongForm",
+    "MultiturnSFTDataset",
     "OpenWebText",
     "SFTDataset",
     "TextFiles",

--- a/litgpt/data/base.py
+++ b/litgpt/data/base.py
@@ -109,6 +109,111 @@ class SFTDataset(Dataset):
         }
 
 
+class MultiturnSFTDataset(Dataset):
+    """An in-memory dataset for supervised finetuning on multi-turn conversations, producing `input_ids` and
+    `labels`.
+
+    Args:
+        data: A list of conversations, each a list of ``{"role": "system"|"user"|"assistant", "content": str}``
+            turns. Each conversation must end on an "assistant" turn (that's the training target).
+        tokenizer: The tokenizer to use. Should match the one that was used to pretrain the model.
+        prompt_style: The style to apply to prompts. Must have ``supports_multiturn=True`` (e.g. ChatML, Llama3,
+            R1Base). See `litgpt.prompts` for a list of available styles.
+        max_seq_length: Truncate sequences that are longer than this value. By default, no truncation is applied.
+        mask_prompt: Whether to mask non-assistant turns from the label (with ``ignore_index``), so loss is only
+            computed on the assistant's own tokens.
+        ignore_index: The index to use for elements to be ignored in the label.
+        transform: An optional transform to apply to the sample before it gets tokenized. Use this to reshape a
+            differently-keyed conversation (e.g. ShareGPT's ``{"from": ..., "value": ...}``) into the expected
+            ``{"role": ..., "content": ...}`` turns, with ``role`` one of ``"system"``, ``"user"``, or
+            ``"assistant"``.
+
+    Returns a dict with two keys:
+        input_ids: The encoded conversation.
+        labels: Same as input_ids, unless ``mask_prompt=True`` in which case every non-assistant turn is replaced
+            with the ``ignore_index``.
+    """
+
+    def __init__(
+        self,
+        data: list[list[dict[str, str]]],
+        tokenizer: Tokenizer,
+        prompt_style: str | PromptStyle,
+        max_seq_length: int = -1,
+        mask_prompt: bool = True,
+        ignore_index: int = -100,
+        transform: Callable[[Any], Any] | None = None,
+    ) -> None:
+        self.data = data
+        self.tokenizer = tokenizer
+        self.prompt_style = (
+            prompt_style if isinstance(prompt_style, PromptStyle) else PromptStyle.from_name(prompt_style)
+        )
+        if not self.prompt_style.supports_multiturn:
+            raise ValueError(f"Prompt style {self.prompt_style} does not support multiturn prompts.")
+        self.max_seq_length = max_seq_length
+        self.mask_prompt = mask_prompt
+        self.ignore_index = ignore_index
+        self.transform = transform
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __getitem__(self, idx: int) -> dict[str, Tensor | dict[str, int]]:
+        messages = self.data[idx]
+        if self.transform is not None:
+            messages = self.transform(messages)
+        if not messages or messages[-1]["role"] != "assistant":
+            raise ValueError(f"Conversation at index {idx} must end with an 'assistant' message.")
+
+        if not self.mask_prompt:
+            # No masking needed, so there's no need to know per-turn boundaries: tokenize the
+            # whole rendered conversation in a single pass and use it as both input and label.
+            text = self.prompt_style.apply(messages, add_generation_prompt=False)
+            input_ids = self.tokenizer.encode(text).type(torch.int64)
+            labels = input_ids.clone()
+        else:
+            # Masking needs to know which tokens belong to which turn. apply() only returns a
+            # flat string, so we recover turn boundaries by re-rendering growing prefixes of the
+            # conversation and diffing the tokenized lengths.
+            chunks: list[tuple[Tensor, bool]] = []
+            prev_len = 0
+            for k in range(1, len(messages) + 1):
+                text = self.prompt_style.apply(messages[:k], add_generation_prompt=False)
+                # bos must be applied the same way on every iteration: the offset it adds to the
+                # first prefix has to stay constant across all prefixes for the length-diffing
+                # below to isolate the right turn boundary, not just the first one.
+                ids = self.tokenizer.encode(text)
+                turn_ids = ids[prev_len:]
+                is_assistant = messages[k - 1]["role"] == "assistant"
+                chunks.append((turn_ids, is_assistant))
+                prev_len = len(ids)
+
+            input_ids = torch.cat([ids for ids, _ in chunks]).type(torch.int64)
+            labels = torch.cat(
+                [
+                    ids.clone() if is_assistant else torch.full_like(ids, self.ignore_index)
+                    for ids, is_assistant in chunks
+                ]
+            ).type(torch.int64)
+
+        if self.max_seq_length > 0:  # do not slice off last token when self.max_seq_length = -1
+            input_ids = input_ids[: self.max_seq_length]
+            labels = labels[: self.max_seq_length]
+
+        # Token count with no prompt-style template overhead: just the turns' own content, plain.
+        raw_token_count = sum(len(self.tokenizer.encode(m["content"])) for m in messages)
+
+        return {
+            "input_ids": input_ids,
+            "labels": labels,
+            "token_counts": {
+                "raw": raw_token_count,
+                "raw_plus_prompt_template": len(input_ids),
+            },
+        }
+
+
 def get_sft_collate_fn(max_seq_length: int = -1, pad_id: int = 0, ignore_index: int = -100):
     """Returns the collate function for supervised finetuning (needed in the DataLoader).
 

--- a/tests/data/test_base.py
+++ b/tests/data/test_base.py
@@ -4,8 +4,8 @@
 import pytest
 import torch
 
-from litgpt.data.base import SFTDataset, get_sft_collate_fn
-from litgpt.prompts import PromptStyle
+from litgpt.data.base import MultiturnSFTDataset, SFTDataset, get_sft_collate_fn
+from litgpt.prompts import ChatML, PromptStyle
 
 
 @pytest.mark.parametrize("mask_prompt", [True, False])
@@ -41,6 +41,88 @@ def test_sft_dataset(max_seq_length, ignore_index, mask_prompt, mock_tokenizer):
     else:
         assert torch.equal(dataset[0]["input_ids"], expected_input_ids[:max_seq_length])
         assert torch.equal(dataset[0]["labels"], expected_labels[:max_seq_length])
+
+
+@pytest.mark.parametrize("mask_prompt", [True, False])
+@pytest.mark.parametrize("ignore_index", [-1, -100])
+@pytest.mark.parametrize("max_seq_length", [1000, 5, -1])
+def test_multiturn_sft_dataset(max_seq_length, ignore_index, mask_prompt, mock_tokenizer):
+    class Style(PromptStyle):
+        supports_multiturn = True
+
+        def apply(self, prompt, *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs) -> str:
+            text = "".join(f"[{m['role']}]{m['content']}" for m in prompt)
+            if add_generation_prompt:
+                text += "[assistant]"
+            return text
+
+    messages = [{"role": "user", "content": "Foo"}, {"role": "assistant", "content": "Bar"}]
+
+    dataset = MultiturnSFTDataset(
+        data=[messages],
+        tokenizer=mock_tokenizer,
+        prompt_style=Style(),
+        mask_prompt=mask_prompt,
+        ignore_index=ignore_index,
+        max_seq_length=max_seq_length,
+    )
+    assert len(dataset) == 1
+
+    expected_input_ids = mock_tokenizer.encode("[user]Foo[assistant]Bar")
+    expected_labels = expected_input_ids.clone()
+    if mask_prompt:
+        prompt_len = len(mock_tokenizer.encode("[user]Foo"))
+        expected_labels[:prompt_len] = ignore_index
+
+    if max_seq_length == -1:
+        assert torch.equal(dataset[0]["input_ids"], expected_input_ids)
+        assert torch.equal(dataset[0]["labels"], expected_labels)
+    else:
+        assert torch.equal(dataset[0]["input_ids"], expected_input_ids[:max_seq_length])
+        assert torch.equal(dataset[0]["labels"], expected_labels[:max_seq_length])
+
+    expected_raw = len(mock_tokenizer.encode("Foo")) + len(mock_tokenizer.encode("Bar"))
+    assert dataset[0]["token_counts"]["raw"] == expected_raw
+    assert dataset[0]["token_counts"]["raw_plus_prompt_template"] == len(dataset[0]["input_ids"])
+
+
+def test_multiturn_sft_dataset_masks_only_assistant_turns(mock_tokenizer):
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "bye"},
+        {"role": "assistant", "content": "later"},
+    ]
+    dataset = MultiturnSFTDataset(data=[messages], tokenizer=mock_tokenizer, prompt_style=ChatML())
+    item = dataset[0]
+
+    full_text = ChatML().apply(messages, add_generation_prompt=False)
+    assert mock_tokenizer.decode(item["input_ids"]) == full_text
+
+    decoded_labels = "".join(chr(int(t)) if t.item() != -100 else "." for t in item["labels"])
+    expected_labels = (
+        "." * len("<|im_start|>user\nhi<|im_end|>\n")
+        + "<|im_start|>assistant\nhello<|im_end|>\n"
+        + "." * len("<|im_start|>user\nbye<|im_end|>\n")
+        + "<|im_start|>assistant\nlater<|im_end|>\n"
+    )
+    assert decoded_labels == expected_labels
+
+
+def test_multiturn_sft_dataset_requires_multiturn_style(mock_tokenizer):
+    class SingleTurnStyle(PromptStyle):
+        def apply(self, prompt: str, *, sys_prompt: str | None = None, **kwargs) -> str:
+            return prompt
+
+    with pytest.raises(ValueError, match="does not support multiturn"):
+        MultiturnSFTDataset(data=[[]], tokenizer=mock_tokenizer, prompt_style=SingleTurnStyle())
+
+
+def test_multiturn_sft_dataset_requires_trailing_assistant_turn(mock_tokenizer):
+    messages = [{"role": "user", "content": "hi"}]
+    dataset = MultiturnSFTDataset(data=[messages], tokenizer=mock_tokenizer, prompt_style=ChatML())
+    with pytest.raises(ValueError, match="must end with an 'assistant' message"):
+        dataset[0]
 
 
 @pytest.mark.parametrize("ignore_index", [-1, -100])


### PR DESCRIPTION
## Summary

Adds `MultiturnSFTDataset`, a training-data counterpart to `SFTDataset` for
supervised finetuning on multi-turn conversations. Builds on the multi-turn
`apply()` support landed in #<PR number of 62ffd7b> (ChatML/Llama3/R1Base +
`add_generation_prompt`).

## Motivation

litgpt's SFT pipeline (`SFTDataset`) only supports single-turn
instruction/output pairs — one prompt string in, one response string out,
with a single masked prefix span. There's no way to train on a full
conversation (multiple user/assistant turns) with per-turn loss masking:
every assistant turn should contribute to the loss while prior turns stay as
context, not get flattened into independent single-turn examples the way
`deita.py`/`lima.py` currently do.

## What's included

- `MultiturnSFTDataset` (`litgpt/data/base.py`): takes a list of
  conversations (`list[list[{"role", "content"}]]`), and produces
  `input_ids`/`labels` with masking applied per-turn instead of a single
  prefix boundary.
  - Fast path when `mask_prompt=False`: one `apply()` + `encode()` call over
    the whole conversation.
  - When `mask_prompt=True`: since `PromptStyle.apply()` only returns a flat
    string with no turn-boundary info, turn boundaries are recovered by
    re-rendering growing prefixes of the conversation
    (`apply(messages[:k], add_generation_prompt=False)`) and diffing
    tokenized lengths — `bos` is applied consistently across every prefix so
    the diff stays aligned.
  - Requires `prompt_style.supports_multiturn`; raises a clear `ValueError`
    at construction otherwise.
  - Requires each conversation to end on an `assistant` turn (the training
    target); raises otherwise.
  - `token_counts` reports both `raw` (plain per-turn content, no template
    overhead) and `raw_plus_prompt_template` (actual sequence length),
    matching `SFTDataset`'s existing convention used by the finetuning
    performance report.
- Exported from `litgpt.data` alongside `SFTDataset`.
- Tests in `tests/data/test_base.py`: parametrized coverage mirroring
  `test_sft_dataset` (mask_prompt / ignore_index / max_seq_length), a
  dedicated regression test for a longer alternating-turn conversation
  (catches a real bug found during development where inconsistent `bos`
  handling across prefixes corrupted turn boundaries), and both `ValueError`
  guard paths.

## Out of scope (follow-up)

This PR is infrastructure only — no `DataModule` wires up
`MultiturnSFTDataset` yet. A follow-up PR will add a `JSONConversations`
(or similarly named) `DataModule` so `litgpt finetune` can actually consume
multi-turn JSON data end-to-end. Also out of scope: inference-side
multi-turn support (`litgpt chat` history, `LLM.generate(messages=...)`).

## Test plan

- `pytest tests/data/test_base.py tests/test_prompts.py` — all passing.
- `ruff check` / `ruff format --check` clean.
