### PR TITLE
feat: add MultiturnJSON datamodule + full multi-turn SFT support

### DIFF
--- a/litgpt/data/__init__.py
+++ b/litgpt/data/__init__.py
@@ -11,6 +11,7 @@ from litgpt.data.lima import LIMA
 from litgpt.data.lit_data import LitData
 from litgpt.data.longform import LongForm
 from litgpt.data.microllama import MicroLlama
+from litgpt.data.multiturn_json_data import MultiturnJSON
 from litgpt.data.openwebtext import OpenWebText
 from litgpt.data.text_files import TextFiles
 from litgpt.data.tinyllama import TinyLlama
@@ -27,6 +28,7 @@ __all__ = [
     "LitData",
     "DataModule",
     "LongForm",
+    "MultiturnJSON",
     "MultiturnSFTDataset",
     "OpenWebText",
     "SFTDataset",

--- a/litgpt/data/multiturn_json_data.py
+++ b/litgpt/data/multiturn_json_data.py
@@ -1,0 +1,189 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
+import json
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch.utils.data import DataLoader, random_split
+
+from litgpt.data import DataModule, MultiturnSFTDataset, get_sft_collate_fn
+from litgpt.prompts import PromptStyle
+from litgpt.tokenizer import Tokenizer
+
+
+@dataclass
+class MultiturnJSON(DataModule):
+    """Loads JSON or JSONL multi-turn conversation data for supervised finetuning.
+
+    A path to a JSON file or a directory with `train.json` and `val.json` containing the data.
+    The file(s) should contain a list of samples (dicts). Each dict must have a 'messages' key: a
+    list of `{"role": "system"|"user"|"assistant", "content": str}` turns, ending on an
+    "assistant" turn (that's the training target)."""
+
+    json_path: Path
+
+    prompt_style: str | PromptStyle
+    """The style to apply to instruction prompts. Required for multi-turn SFT. See `litgpt.prompts` for a list of available styles."""
+
+    mask_prompt: bool = True
+    """Whether to mask the prompt section from the label (with ``ignore_index``)."""
+    val_split_fraction: float | None = None
+    """The fraction of the dataset to use for the validation dataset. The rest is used for training.
+    Only applies if you passed in a single file to `json_path`."""
+    ignore_index: int = -100
+    """The index to use for elements to be ignored in the label."""
+    seed: int = 42
+    """The random seed for creating the train/val splits and shuffling the dataset."""
+    num_workers: int = 4
+    """How many DataLoader processes to use for loading."""
+
+    tokenizer: Tokenizer | None = field(default=None, init=False, repr=False)
+    batch_size: int = field(default=1, init=False, repr=False)
+    max_seq_length: int = field(default=-1, init=False, repr=False)
+    train_dataset: MultiturnSFTDataset | None = field(default=None, init=False, repr=False)
+    test_dataset: MultiturnSFTDataset | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self):
+        super().__init__()
+        if self.json_path.is_file() and self.val_split_fraction is None:
+            self.val_split_fraction = 0.05
+            warnings.warn(
+                "The `json_path` points to a single file and `val_split_fraction` was not set. "
+                "Defaulting to `val_split_fraction=0.05`. Set `val_split_fraction` explicitly "
+                "to use a different split percentage.",
+                UserWarning,
+                stacklevel=2,
+            )
+        if self.json_path.is_dir() and self.val_split_fraction is not None:
+            raise ValueError(
+                "If `json_path` is a directory, it must contain 'train.json' and 'val.json' files and"
+                f" hence `val_split_fraction` should not be set. Got `{self.val_split_fraction=}`."
+            )
+        if not self.json_path.exists():
+            raise FileNotFoundError(
+                "The `json_path` must be a file or a directory containing 'train.json' and 'val.json' files,"
+                f" but '{self.json_path!s}' does not exist."
+            )
+
+        if isinstance(self.prompt_style, str):
+            self.prompt_style = PromptStyle.from_name(self.prompt_style)
+        if not self.prompt_style.supports_multiturn:
+            raise ValueError(
+                f"The prompt style {self.prompt_style.__class__.__name__} does not support multi-turn conversations. "
+                "Please choose a prompt style that supports multi-turn conversations."
+            )
+
+    def connect(
+        self, tokenizer: Tokenizer | None = None, batch_size: int = 1, max_seq_length: int | None = None
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.batch_size = batch_size
+        self.max_seq_length = -1 if max_seq_length is None else max_seq_length
+
+    def setup(self, stage: str = "") -> None:
+        train_data, test_data = self.get_splits()
+
+        self.train_dataset = MultiturnSFTDataset(
+            data=train_data,
+            tokenizer=self.tokenizer,
+            prompt_style=self.prompt_style,
+            max_seq_length=self.max_seq_length,
+            mask_prompt=self.mask_prompt,
+            ignore_index=self.ignore_index,
+            transform=to_messages,
+        )
+        self.test_dataset = MultiturnSFTDataset(
+            data=test_data,
+            tokenizer=self.tokenizer,
+            prompt_style=self.prompt_style,
+            max_seq_length=self.max_seq_length,
+            mask_prompt=self.mask_prompt,
+            ignore_index=self.ignore_index,
+            transform=to_messages,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=True,
+            generator=torch.Generator().manual_seed(self.seed),
+            num_workers=self.num_workers,
+            collate_fn=get_sft_collate_fn(max_seq_length=self.max_seq_length, ignore_index=self.ignore_index),
+        )
+
+    def val_dataloader(self) -> DataLoader:
+        return DataLoader(
+            self.test_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            collate_fn=get_sft_collate_fn(max_seq_length=self.max_seq_length, ignore_index=self.ignore_index),
+        )
+
+    def get_splits(self) -> tuple:
+        # A single file (gets split into train and test)
+        if self.json_path.is_file():
+            data = load_split(self.json_path)
+
+            # Partition the dataset into train and test
+            train_data, test_data = random_split(
+                data,
+                [1.0 - self.val_split_fraction, self.val_split_fraction],
+                generator=torch.Generator().manual_seed(self.seed),
+            )
+            return train_data, test_data
+
+        # A directory containing train.json and val.json
+        if (train_file := self.find_split("train")) and (val_file := self.find_split("val")):
+            train_data = load_split(train_file)
+            test_data = load_split(val_file)
+            return train_data, test_data
+
+        raise FileNotFoundError(
+            "The `json_path` must be a file or a directory containing 'train.json' and 'val.json' files."
+        )
+
+    def find_split(self, split_name: str) -> Path | None:
+        for suffix in (".json", ".jsonl"):
+            if (file := self.json_path / f"{split_name}{suffix}").is_file():
+                return file
+        return None
+
+
+_SHAREGPT_ROLE_MAP = {"system": "system", "human": "user", "gpt": "assistant"}
+
+
+def sharegpt_to_messages(example: dict) -> list[dict[str, str]]:
+    """Reshape a ShareGPT-style example (``{"conversations": [{"from": ..., "value": ...}]}``) into
+    the ``{"role": ..., "content": ...}`` turns MultiturnSFTDataset expects."""
+    return [{"role": _SHAREGPT_ROLE_MAP[turn["from"]], "content": turn["value"]} for turn in example["conversations"]]
+
+
+def to_messages(example: dict) -> list[dict[str, str]]:
+    """Auto-detect whether an example is OpenAI-style (``"messages"``) or ShareGPT-style
+    (``"conversations"``) and reshape it into ``{"role": ..., "content": ...}`` turns. Raises if
+    neither key is present."""
+    if "messages" in example:
+        return example["messages"]
+    if "conversations" in example:
+        return sharegpt_to_messages(example)
+    raise ValueError(
+        "Could not determine the conversation format for example with keys "
+        f"{list(example.keys())}. Expected a 'messages' (OpenAI-style) or 'conversations' "
+        "(ShareGPT-style) key."
+    )
+
+
+def load_split(json_path: Path) -> Any:
+    if json_path.suffix == ".json":
+        with open(json_path, encoding="utf-8") as file:
+            return json.load(file)
+    if json_path.suffix == ".jsonl":
+        with open(json_path, encoding="utf-8") as file:
+            return [json.loads(line) for line in file]
+    else:
+        raise ValueError(f"Unsupported file format: {json_path.suffix}. Expected `.json` or `.jsonl`.")

--- a/litgpt/utils.py
+++ b/litgpt/utils.py
@@ -13,7 +13,7 @@ import shutil
 import subprocess
 import sys
 import warnings
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import asdict, dataclass, is_dataclass
 from io import BytesIO
 from pathlib import Path
@@ -866,27 +866,41 @@ def create_finetuning_performance_report(training_time, token_counts, device_typ
     return output
 
 
+def _instruction_of(example: Any, transform: Callable[[Any], Any] | None = None) -> str:
+    """Extract a representative "instruction" string from a raw dataset example, for use as an
+    eval-time generation prompt. Handles both single-turn examples (``{"instruction": ...}``) and
+    multi-turn conversations (a list of ``{"role", "content"}`` turns, taking the last user turn)
+    — applying the dataset's own ``transform`` first, if any, so this works regardless of the
+    example's original on-disk shape (e.g. MultiturnJSON's OpenAI/ShareGPT auto-detection)."""
+    if transform is not None:
+        example = transform(example)
+    if isinstance(example, list):
+        user_turns = [turn["content"] for turn in example if turn["role"] == "user"]
+        return user_turns[-1] if user_turns else ""
+    return example["instruction"]
+
+
 def select_sft_generate_example(eval, data):
     if eval.evaluate_example == "first":
         if len(data.test_dataset.data):
-            instruction = data.test_dataset.data[0]["instruction"]
+            instruction = _instruction_of(data.test_dataset.data[0], data.test_dataset.transform)
         else:
-            instruction = data.train_dataset.data[0]["instruction"]
+            instruction = _instruction_of(data.train_dataset.data[0], data.train_dataset.transform)
 
     elif eval.evaluate_example == "random":
         if len(data.test_dataset.data):
             random_idx = random.randint(0, len(data.test_dataset.data) - 1)
-            instruction = data.test_dataset.data[random_idx]["instruction"]
+            instruction = _instruction_of(data.test_dataset.data[random_idx], data.test_dataset.transform)
         else:
             random_idx = random.randint(0, len(data.train_dataset.data) - 1)
-            instruction = data.train_dataset.data[random_idx]["instruction"]
+            instruction = _instruction_of(data.train_dataset.data[random_idx], data.train_dataset.transform)
 
     elif isinstance(eval.evaluate_example, int):
         index = eval.evaluate_example
         if len(data.test_dataset.data) > index:
-            instruction = data.test_dataset.data[index]["instruction"]
+            instruction = _instruction_of(data.test_dataset.data[index], data.test_dataset.transform)
         elif len(data.train_dataset.data) > index:
-            instruction = data.train_dataset.data[index]["instruction"]
+            instruction = _instruction_of(data.train_dataset.data[index], data.train_dataset.transform)
         else:
             raise IndexError(f"Index {index} is out of range for both test and training datasets.")
 

--- a/tests/data/test_multiturn_json.py
+++ b/tests/data/test_multiturn_json.py
@@ -1,0 +1,216 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+import json
+
+import pytest
+
+from litgpt.data import MultiturnJSON
+from litgpt.data.multiturn_json_data import sharegpt_to_messages, to_messages
+from litgpt.prompts import PromptStyle
+
+
+class MultiturnStyle(PromptStyle):
+    supports_multiturn = True
+
+    def apply(self, prompt, *, sys_prompt: str | None = None, add_generation_prompt: bool = True, **kwargs) -> str:
+        text = "".join(f"[{m['role']}]{m['content']}" for m in prompt)
+        if add_generation_prompt:
+            text += "[assistant]"
+        return text
+
+
+def _decode_stripped(mock_tokenizer, row) -> str:
+    # Right-padded rows get pad_id=0 appended, which MockTokenizer decodes as "\x00".
+    return mock_tokenizer.decode(row).rstrip("\x00")
+
+
+@pytest.mark.parametrize("as_jsonl", [False, True])
+def test_multiturn_json(as_jsonl, tmp_path, mock_tokenizer):
+    json_path = tmp_path / ("data.jsonl" if as_jsonl else "data.json")
+    mock_data = [
+        {"messages": [{"role": "user", "content": "Add"}, {"role": "assistant", "content": "4"}]},
+        {"messages": [{"role": "user", "content": "Subtract"}, {"role": "assistant", "content": "2"}]},
+        {"messages": [{"role": "user", "content": "Multiply"}, {"role": "assistant", "content": "24"}]},
+        {"messages": [{"role": "user", "content": "Divide"}, {"role": "assistant", "content": "5"}]},
+    ]
+
+    with open(json_path, "w", encoding="utf-8") as fp:
+        if as_jsonl:
+            for line in mock_data:
+                json.dump(line, fp)
+                fp.write("\n")
+        else:
+            json.dump(mock_data, fp)
+
+    data = MultiturnJSON(json_path, val_split_fraction=0.5, prompt_style=MultiturnStyle(), num_workers=0)
+    data.connect(tokenizer=mock_tokenizer, batch_size=2)
+    data.prepare_data()  # does nothing
+    data.setup()
+
+    train_dataloader = data.train_dataloader()
+    val_dataloader = data.val_dataloader()
+
+    assert len(train_dataloader) == 1
+    assert len(val_dataloader) == 1
+
+    train_data = list(train_dataloader)
+    val_data = list(val_dataloader)
+
+    assert train_data[0]["input_ids"].size(0) == 2
+    assert val_data[0]["input_ids"].size(0) == 2
+
+    decoded = {
+        _decode_stripped(mock_tokenizer, row) for batch in (*train_data, *val_data) for row in batch["input_ids"]
+    }
+    assert decoded == {
+        "[user]Add[assistant]4",
+        "[user]Subtract[assistant]2",
+        "[user]Multiply[assistant]24",
+        "[user]Divide[assistant]5",
+    }
+
+    assert isinstance(train_dataloader.dataset.prompt_style, MultiturnStyle)
+    assert isinstance(val_dataloader.dataset.prompt_style, MultiturnStyle)
+
+    # has attributes from super class `LightningDataModule`
+    assert data.prepare_data_per_node
+
+
+def test_multiturn_json_sharegpt_format(tmp_path, mock_tokenizer):
+    json_path = tmp_path / "data.json"
+    mock_data = [
+        {"conversations": [{"from": "human", "value": "Add"}, {"from": "gpt", "value": "4"}]},
+        {"conversations": [{"from": "human", "value": "Subtract"}, {"from": "gpt", "value": "2"}]},
+    ]
+    with open(json_path, "w", encoding="utf-8") as fp:
+        json.dump(mock_data, fp)
+
+    data = MultiturnJSON(json_path, val_split_fraction=0.5, prompt_style=MultiturnStyle(), num_workers=0)
+    data.connect(tokenizer=mock_tokenizer, batch_size=2)
+    data.setup()
+
+    decoded = {
+        _decode_stripped(mock_tokenizer, row)
+        for batch in (*data.train_dataloader(), *data.val_dataloader())
+        for row in batch["input_ids"]
+    }
+    assert decoded == {"[user]Add[assistant]4", "[user]Subtract[assistant]2"}
+
+
+def test_multiturn_json_mixed_formats(tmp_path, mock_tokenizer):
+    # OpenAI-style and ShareGPT-style records in the same file should both work, since format
+    # detection happens per example.
+    json_path = tmp_path / "data.json"
+    mock_data = [
+        {"messages": [{"role": "user", "content": "Add"}, {"role": "assistant", "content": "4"}]},
+        {"conversations": [{"from": "human", "value": "Subtract"}, {"from": "gpt", "value": "2"}]},
+    ]
+    with open(json_path, "w", encoding="utf-8") as fp:
+        json.dump(mock_data, fp)
+
+    data = MultiturnJSON(json_path, val_split_fraction=0.5, prompt_style=MultiturnStyle(), num_workers=0)
+    data.connect(tokenizer=mock_tokenizer, batch_size=2)
+    data.setup()
+
+    decoded = {
+        _decode_stripped(mock_tokenizer, row)
+        for batch in (*data.train_dataloader(), *data.val_dataloader())
+        for row in batch["input_ids"]
+    }
+    assert decoded == {"[user]Add[assistant]4", "[user]Subtract[assistant]2"}
+
+
+def test_multiturn_json_input_validation(tmp_path):
+    with pytest.raises(FileNotFoundError, match="The `json_path` must be a file or a directory"):
+        MultiturnJSON(tmp_path / "not exist", prompt_style=MultiturnStyle())
+
+    with pytest.raises(ValueError, match="`val_split_fraction` should not be set"):
+        MultiturnJSON(tmp_path, val_split_fraction=0.5, prompt_style=MultiturnStyle())
+
+    data = MultiturnJSON(tmp_path, prompt_style=MultiturnStyle())
+    data.prepare_data()  # does nothing
+
+    # Empty directory
+    with pytest.raises(FileNotFoundError, match="must be a file or a directory containing"):
+        data.setup()
+
+    # Only train.json exists
+    (tmp_path / "train.json").touch()
+    with pytest.raises(FileNotFoundError, match="must be a file or a directory containing"):
+        data.setup()
+
+    # When a single file is passed without val_split_fraction, it defaults to 0.05 and warns.
+    with pytest.warns(UserWarning, match="Defaulting to `val_split_fraction=0.05`"):
+        data = MultiturnJSON(tmp_path / "train.json", val_split_fraction=None, prompt_style=MultiturnStyle())
+    assert data.val_split_fraction == 0.05
+
+
+def test_multiturn_json_requires_multiturn_style(tmp_path):
+    with pytest.raises(ValueError, match="does not support multi-turn conversations"):
+        MultiturnJSON(tmp_path, prompt_style="alpaca")
+
+
+@pytest.mark.parametrize("as_jsonl", [False, True])
+def test_multiturn_json_with_splits(as_jsonl, tmp_path, mock_tokenizer):
+    mock_train_data = [
+        {"messages": [{"role": "user", "content": "Add"}, {"role": "assistant", "content": "4"}]},
+        {"messages": [{"role": "user", "content": "Subtract"}, {"role": "assistant", "content": "2"}]},
+        {"messages": [{"role": "user", "content": "Multiply"}, {"role": "assistant", "content": "24"}]},
+    ]
+    mock_test_data = [
+        {"messages": [{"role": "user", "content": "Divide"}, {"role": "assistant", "content": "5"}]},
+    ]
+
+    train_file = tmp_path / ("train.jsonl" if as_jsonl else "train.json")
+    val_file = tmp_path / ("val.jsonl" if as_jsonl else "val.json")
+
+    with open(train_file, "w", encoding="utf-8") as fp:
+        if as_jsonl:
+            for line in mock_train_data:
+                json.dump(line, fp)
+                fp.write("\n")
+        else:
+            json.dump(mock_train_data, fp)
+    with open(val_file, "w", encoding="utf-8") as fp:
+        if as_jsonl:
+            for line in mock_test_data:
+                json.dump(line, fp)
+                fp.write("\n")
+        else:
+            json.dump(mock_test_data, fp)
+
+    data = MultiturnJSON(tmp_path, prompt_style=MultiturnStyle(), num_workers=0)
+    data.connect(tokenizer=mock_tokenizer, batch_size=2)
+    data.prepare_data()  # does nothing
+    data.setup()
+
+    train_dataloader = data.train_dataloader()
+    val_dataloader = data.val_dataloader()
+
+    assert len(train_dataloader) == 2
+    assert len(val_dataloader) == 1
+
+
+def test_to_messages_openai_style():
+    example = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
+    assert to_messages(example) == example["messages"]
+
+
+def test_to_messages_sharegpt_style():
+    example = {
+        "conversations": [
+            {"from": "system", "value": "sys"},
+            {"from": "human", "value": "hi"},
+            {"from": "gpt", "value": "hello"},
+        ]
+    }
+    assert to_messages(example) == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    assert to_messages(example) == sharegpt_to_messages(example)
+
+
+def test_to_messages_unknown_format_raises():
+    with pytest.raises(ValueError, match="Could not determine the conversation format"):
+        to_messages({"foo": "bar"})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,6 +25,7 @@ from litgpt.constants import (
     _TENSORBOARD_AVAILABLE,
     _WANDB_AVAILABLE,
 )
+from litgpt.data.multiturn_json_data import to_messages
 from litgpt.parser_config import save_hyperparameters
 from litgpt.utils import (
     CLI,
@@ -811,6 +812,8 @@ def test_select_sft_generate_example():
 
     data_mock.test_dataset.data = test_dataset["data"]
     data_mock.train_dataset.data = train_dataset["data"]
+    data_mock.test_dataset.transform = None
+    data_mock.train_dataset.transform = None
 
     # Test "first" instruction from test dataset
     eval_mock.evaluate_example = "first"
@@ -857,3 +860,43 @@ def test_select_sft_generate_example():
     eval_mock.evaluate_example = "unknown"
     with pytest.raises(ValueError):
         select_sft_generate_example(eval_mock, data_mock)
+
+
+def test_select_sft_generate_example_multiturn():
+    eval_mock = mock.MagicMock()
+    eval_mock.evaluate_example = "first"
+    data_mock = mock.MagicMock()
+
+    # MultiturnSFTDataset used directly (no transform): .data is already a list of
+    # {"role", "content"} turns per example.
+    data_mock.test_dataset.data = [
+        [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+    ]
+    data_mock.test_dataset.transform = None
+    data_mock.train_dataset.data = []
+    data_mock.train_dataset.transform = None
+    instruction = select_sft_generate_example(eval_mock, data_mock)
+    assert instruction == "hi"
+
+    # MultiturnJSON-style: raw JSON records with a transform (e.g. to_messages) that must run
+    # first to reshape them into {"role", "content"} turns.
+    data_mock.test_dataset.data = [
+        {"conversations": [{"from": "human", "value": "yo"}, {"from": "gpt", "value": "sup"}]},
+    ]
+    data_mock.test_dataset.transform = to_messages
+    instruction = select_sft_generate_example(eval_mock, data_mock)
+    assert instruction == "yo"
+
+    # Multiple user turns: the *last* user turn should be used.
+    data_mock.test_dataset.data = [
+        {
+            "messages": [
+                {"role": "user", "content": "first question"},
+                {"role": "assistant", "content": "first answer"},
+                {"role": "user", "content": "follow-up question"},
+            ]
+        },
+    ]
+    data_mock.test_dataset.transform = to_messages
+    instruction = select_sft_generate_example(eval_mock, data_mock)
+    assert instruction == "follow-up question"


### PR DESCRIPTION
## Summary

Adds `MultiturnJSON`, the `DataModule` that wires `MultiturnSFTDataset` (#<PR for sj/multiturnsftdataset>)
up to `litgpt finetune`, plus a fix to a downstream assumption that would otherwise
crash any real training run using it. Together these make multi-turn JSON finetuning
work end-to-end: `litgpt finetune lora --data MultiturnJSON --data.json_path ... --data.prompt_style llama3 ...`.

Stacked on #2315, which itself stacks on #2314

## What's included

### `MultiturnJSON` DataModule (`litgpt/data/multiturn_json_data.py`)

- Loads a JSON/JSONL file or a `train.json`/`val.json` directory, same file/dir/split-loading
  behavior as `JSON` (`litgpt/data/json_data.py`) — reuses its pattern rather than duplicating it.
- `prompt_style` is **required**, no default (unlike `JSON`'s `prompt_style="alpaca"`) — there's
  no single safe default chat template across checkpoints, and silently applying the wrong one is
  a real correctness risk.
- Validates `prompt_style.supports_multiturn` at construction, raising immediately with a clear
  message instead of failing deep inside a `DataLoader` worker.
- `mask_prompt` defaults to `True` (vs. `JSON`'s `False`) — masking is the whole point of
  multi-turn SFT: only assistant turns should contribute to the loss.
- **Two input schemas, auto-detected per example** (`to_messages()`):
  - OpenAI-style: `{"messages": [{"role": "system"|"user"|"assistant", "content": str}]}`
  - ShareGPT-style: `{"conversations": [{"from": "system"|"human"|"gpt", "value": str}]}`
    (role-mapped via `sharegpt_to_messages()`: `human`→`user`, `gpt`→`assistant`)
  - Detection happens per record, so a single file can freely mix both formats.
  - Unrecognized shape raises `ValueError` naming the offending example's keys.
- Exported from `litgpt.data` alongside `JSON`/`MultiturnSFTDataset`.

### Fix: `select_sft_generate_example` crashed on multi-turn data (`litgpt/utils.py`)

This function powers the periodic and end-of-training "generate a sample" step in every
finetune script (`litgpt/finetune/lora.py` etc.) — it runs **unconditionally** at the end of
every training run and periodically every `eval.interval` steps, so it's not something a config
flag can route around. It assumed every dataset example has an `"instruction"` key, which isn't
true for multi-turn examples (`{"messages": [...]}` / `{"conversations": [...]}"`), so any real
`MultiturnJSON`-backed finetune run would `KeyError` mid-training.

Added `_instruction_of(example, transform)`: applies the dataset's own `transform` first (reusing
the same mechanism `MultiturnSFTDataset`/`SFTDataset` already carry, rather than hardcoding
schema knowledge into `utils.py`), then returns `example["instruction"]` for single-turn examples
or the last user turn's content for multi-turn ones. This is fully backward compatible — for
every existing single-turn `DataModule` (with or without a transform), behavior is unchanged.

## This is now ready for real multi-turn finetuning end-to-end

Verified beyond unit tests — actually ran the full path with a real (non-mocked) `MultiturnJSON`
instance: `DataModule.setup()` → `MultiturnSFTDataset` → `DataLoader` batching → collate →
`select_sft_generate_example()`, for both OpenAI-style and ShareGPT-style records, mixed in the
same file. `litgpt finetune lora --data MultiturnJSON ...` should now run start to finish without
crashing at the sample-generation step.

## Tests

- `tests/data/test_multiturn_json.py` (new, mirrors `tests/data/test_json.py`'s structure):
  file/JSONL loading, directory splits, path/warning validation, the `supports_multiturn` guard,
  ShareGPT format, mixed-format files, and direct unit tests of `to_messages`/`sharegpt_to_messages`.
- `tests/test_utils.py::test_select_sft_generate_example` — updated so its mocks accurately
  reflect a real dataset's default `transform=None` (this test regressed against the fix until
  fixed, since `MagicMock().transform` auto-vends a truthy mock instead of `None`).
- `tests/test_utils.py::test_select_sft_generate_example_multiturn` (new) — direct multi-turn
  data with no transform, `MultiturnJSON`-style data with a transform, and multi-user-turn
  conversations (confirms the *last* user turn is used).

## Out of scope (follow-up)

- `litgpt/prompts.py`'s `prompt_styles` name-lookup dict doesn't register the `ChatML`/`R1Base`
  base classes by name — only `ChatML`'s specific subclasses (`qwen2.5`, `qwen3`, `smollm2`,
  `salamandra`) and `Llama3` are. So `--data.prompt_style chatml` currently `KeyError`s;
  `--data.prompt_style llama3` (or a `ChatML` subclass name) works today. Worth a small follow-up
  since `chatml` is the most likely first thing people try.
- Inference-side multi-turn support (`litgpt chat` conversation history, `LLM.generate(messages=...)`)
  is unrelated to this data-loading PR.
- `deita.py`/`lima.py` still flatten multi-turn source data into independent single-turn pairs
  rather than routing through `MultiturnSFTDataset` — not touched here.

## Test plan

- `pytest tests/data/test_multiturn_json.py tests/data/test_json.py tests/data/test_base.py tests/test_prompts.py tests/test_utils.py` — 125 passing, 6 skipped (unrelated/environment-gated).
- `ruff check` / `ruff format --check` clean.
- Manually exercised the real (non-mocked) end-to-end path for both `MultiturnJSON` and plain
  `JSON` through `select_sft_generate_example`, confirming no crash and correct output.
