### PR TITLE
fix(thunder): remove duplicate _configure_launcher that dropped the external-launch guard

### DIFF
--- a/extensions/thunder/strategies/thunder_ddp.py
+++ b/extensions/thunder/strategies/thunder_ddp.py
@@ -112,11 +112,6 @@ class ThunderDDPStrategy(ParallelStrategy):
         return self._process_group_backend
 
     @override
-    def _configure_launcher(self) -> None:
-        assert self.cluster_environment is not None
-        self._launcher = _SubprocessScriptLauncher(self.cluster_environment, self.num_processes, self.num_nodes)
-
-    @override
     def setup_environment(self) -> None:
         super().setup_environment()
         self._setup_distributed()


### PR DESCRIPTION
### Problem

`ThunderDDPStrategy` in `extensions/thunder/strategies/thunder_ddp.py` defines `_configure_launcher` **twice** within the same class:

```python
@override
def _configure_launcher(self) -> None:
    assert self.cluster_environment is not None
    if not self.cluster_environment.creates_processes_externally:   # guarded
        self._launcher = _SubprocessScriptLauncher(self.cluster_environment, self.num_processes, self.num_nodes)

@property
def process_group_backend(self) -> str | None:
    return self._process_group_backend

@override
def _configure_launcher(self) -> None:                              # duplicate, wins
    assert self.cluster_environment is not None
    self._launcher = _SubprocessScriptLauncher(self.cluster_environment, self.num_processes, self.num_nodes)
```

The second definition silently overrides the first and **drops the `if not self.cluster_environment.creates_processes_externally` guard**. As a result, a `_SubprocessScriptLauncher` is always installed — even when the processes are launched externally (e.g. `torchrun`, SLURM, or any environment where `creates_processes_externally` is `True`). In that case the strategy should *not* create a subprocess launcher, otherwise it attempts to re-spawn the worker processes itself.

### Fix

Remove the unguarded duplicate, keeping the guarded version. This matches:

- the sibling `ThunderFSDPStrategy._configure_launcher` in the same directory (`thunder_fsdp.py`), which has the single, guarded implementation, and
- Lightning's own `DDPStrategy._configure_launcher`.

No behavior change when launching normally; the guard is now honored again for externally-launched processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
