### PR TITLE
fix(generate): preserve sampling support for CPU float16 probabilities

### DIFF
--- a/litgpt/generate/base.py
+++ b/litgpt/generate/base.py
@@ -29,6 +29,10 @@ from litgpt.utils import (
 
 
 def multinomial_num_samples_1(probs: torch.Tensor) -> torch.Tensor:
+    if probs.device.type == "cpu" and probs.dtype == torch.float16:
+        # FP16 exponential samples can underflow to zero on CPU, allowing
+        # zero-probability tokens to win argmax through 0 / 0 = NaN.
+        probs = probs.float()
     if torch._dynamo.is_compiling():
         # Faster alternative to `torch.multinomial(probs, num_samples=1)` that is also CUDAGraph friendly
         distribution = torch.empty_like(probs).exponential_(1)

--- a/tests/generate/test_sampling_precision.py
+++ b/tests/generate/test_sampling_precision.py
@@ -1,0 +1,47 @@
+# Copyright Lightning AI. Licensed under the Apache License 2.0, see LICENSE file.
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from litgpt.generate.base import multinomial_num_samples_1, sample
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
+def test_zero_probability_token_cannot_win_after_exponential_underflow(dtype):
+    probs = torch.tensor([1.0, 0.0], dtype=dtype)
+
+    def exponential_samples(tensor, rate=1):
+        # A valid positive exponential sample rounds to zero in FP16.
+        tensor.copy_(torch.tensor([1.0, 1e-8], dtype=torch.float64))
+        return tensor
+
+    with (
+        patch("torch._dynamo.is_compiling", return_value=True),
+        patch.object(torch.Tensor, "exponential_", exponential_samples),
+    ):
+        token = multinomial_num_samples_1(probs)
+
+    assert token.shape == (1,)
+    assert token.dtype == torch.int64
+    assert token.item() == 0
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32, torch.float64])
+@pytest.mark.parametrize("compiling", [False, True])
+def test_top_k_one_preserves_sampling_support(dtype, compiling):
+    # A large vocabulary makes FP16 exponential underflow observable on CPU.
+    logits = torch.zeros((1, 1, 50304), dtype=dtype)
+    logits[0, 0, 253] = 1
+    previous_threads = torch.get_num_threads()
+    try:
+        torch.set_num_threads(1)
+        with torch.random.fork_rng(devices=[]), patch("torch._dynamo.is_compiling", return_value=compiling):
+            torch.manual_seed(20)
+            token = sample(logits, temperature=1.0, top_k=1)
+        assert token.shape == (1,)
+        assert token.dtype == torch.int64
+        assert token.item() == 253
+    finally:
+        torch.set_num_threads(previous_threads)


### PR DESCRIPTION
Promote CPU float16 probabilities to float32 before either sampling path. As reported in #2323, CPU FP16 exponential samples can underflow to zero: a zero-probability token then produces 0/0 and can win argmax. With 50,304 categories and seed 20, the regression selects token 5833 despite top_k=1 retaining only token 253.

Add a support-invariant regression for float16, bfloat16, float32 and float64, exercising eager sampling and the compiled-path dispatch. Add a seed-independent underflow regression using a controlled positive exponential sample that rounds to zero in FP16. The expanded sampling suite has 3 failures and 9 passes with the baseline, and all 12 cases pass with the fix.

Validation:
- Generation tests: 20 passed, 1 expected xfail; the subprocess CLI test passes separately (1 passed).
- CPU experiment, five seeds and 2,000 draws per configuration: FP16 support violations fall from 5 to 0 in each dispatch path; FP32 controls have 0 violations.
- A 20,000-draw [0, .25, .75, 0] control yields [0, 4946, 15054, 0] after the fix.
- Real CPU `torch.compile(backend="inductor", fullgraph=True)` sampling: 100 seeds per dtype (FP16/BF16/FP32/FP64), no invalid tokens after the fix. The baseline also passes this compiled experiment; it is compatibility evidence, not an Inductor bug reproduction.
- Public Pythia-14m checkpoint (revision cf967c0a9a04383db6f7b1108d86b2962634b4ac), loaded through LLM.load/distribute/generate on CPU: at seed 20 the original sampler returns token 5833, while the fixed sampler and greedy decoding return 253. Six tested seeds all match the sole legal token after the fix. The baseline sampler is extracted unchanged from the pinned Git revision and substituted only for the comparison.
- A randomly initialized one-layer FP16 GPT generates the same 8 tokens as greedy decoding under top_k=1 after the fix; the baseline diverges on its first generated token.
- Ruff, formatting and all applicable Python-file pre-commit hooks pass, as does `git diff --check`. The all-hooks launcher could not initialize the unrelated Prettier environment because its npm mirror returned 403.

This is a CPU float16 correctness fix. CUDA behavior is unchanged and no GPU or end-to-end performance improvement is claimed. The original failure report and root-cause diagnosis belong to the issue author; this PR supplies the scoped fix and regression coverage.

Fixes #2323
