### PR TITLE
fix(tokenizer): decode_stream drops leading space per-word on the huggingface backend

### DIFF
--- a/litgpt/tokenizer.py
+++ b/litgpt/tokenizer.py
@@ -159,18 +159,16 @@ class Tokenizer:
         return self.processor.decode(tokens)
 
     def decode_stream(self, token_stream: Iterable[torch.Tensor], device: torch.device | None = None) -> Iterator[str]:
-        if self.backend == "huggingface":
-            try:
-                for token in token_stream:
-                    yield self.decode(token)
-            except KeyboardInterrupt:
-                return
-        elif self.backend == "sentencepiece":
+        if self.backend in ("huggingface", "sentencepiece"):
             # TODO: Is there a way to not have to do this?
             # This may actually affect our tokens per second.
 
-            # sentencepiece does not support decoding token-by-token because it adds spaces based on the surrounding tokens
-            # meaning that we need to decode everything each time
+            # Neither backend supports decoding token-by-token: both add spaces based on the
+            # surrounding tokens (sentencepiece always; huggingface too, for tokenizers whose
+            # vocab carries a leading-space marker per word, e.g. Mistral's Metaspace decoder —
+            # decoding a single token in isolation drops its leading space because the decoder
+            # treats it as the first token of the whole sequence). So we decode everything each
+            # time and yield only the newly-decoded suffix.
             so_far = torch.tensor([], dtype=torch.long, device=device)
             decoded_so_far = ""
             try:

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+import torch
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import GatedRepoError
 from tokenizers import Tokenizer as HFTokenizer
+from tokenizers import decoders, pre_tokenizers
 from tokenizers.models import BPE
 from transformers import AutoTokenizer
 
@@ -106,6 +108,30 @@ def test_tokenizer_against_hf(config, tmp_path):
         if ours.apply_decoding_fix and decoded_output[0] == " ":
             decoded_output = decoded_output[1:]  # the "hack" adds an empty space to the beginning
         assert decoded_output == ours.decode(actual), type(theirs)
+
+
+def test_tokenizer_decode_stream_huggingface_backend_spacing(tmp_path):
+    # Regression test for #1822. Some huggingface-backend tokenizers (e.g. Mistral's, whose
+    # vocab uses a Metaspace `▁` marker to mean "a space precedes this word") can only place
+    # that space correctly when they see the token in context. decode_stream's huggingface
+    # branch used to decode each new token completely alone, so every word-starting token was
+    # treated as if it were the very first token of the whole text and lost its leading space —
+    # "Hello world!" streamed back as "Helloworld!". Assert the fix: streaming decode must match
+    # a plain batch decode of the same tokens.
+    vocab = {"<unk>": 0, "Hello": 1, "▁world": 2, "!": 3}
+    hf_tokenizer = HFTokenizer(BPE(vocab, [], unk_token="<unk>"))
+    hf_tokenizer.pre_tokenizer = pre_tokenizers.Metaspace()
+    hf_tokenizer.decoder = decoders.Metaspace()
+    hf_tokenizer.save(str(tmp_path / "tokenizer.json"))
+
+    tokenizer = Tokenizer(tmp_path)
+    assert tokenizer.backend == "huggingface"
+
+    token_ids = [1, 2, 3]
+    token_stream = (torch.tensor(i) for i in token_ids)
+    streamed = "".join(tokenizer.decode_stream(token_stream))
+
+    assert streamed == tokenizer.decode(torch.tensor(token_ids)) == "Hello world!"
 
 
 def test_tokenizer_input_validation():


### PR DESCRIPTION
## Summary
`decode_stream`'s `huggingface` branch decoded each new token completely alone (`yield self.decode(token)`). Some huggingface-backend tokenizers — Mistral's included — mark the start of a new word with a leading-space token (a Metaspace `▁` marker), which the decoder can only place correctly when it can see the token isn't actually the first token of the whole sequence. Decoding a single token in total isolation makes the decoder treat it as the first token every time, so every word-starting token lost its leading space — `"Hello world!"` streamed back as `"Helloworld!"`.

Fixes #1822.

The `sentencepiece` branch a few lines below already carries the fix for the identical problem: decode the whole sequence-so-far on every new token, and yield only the newly-decoded suffix, so the decoder always has full context to place spaces correctly. Since that fix isn't backend-specific (`self.decode()` already dispatches on `self.processor` for both backends), this merges the two branches into one instead of duplicating the same 5 lines under two conditions.

## Verification
Before applying the fix, reproduced the bug empirically against a real `tokenizers` `Metaspace` decoder (matching how Mistral's `tokenizer.json` is structured — this is not a guess, I built a tiny BPE tokenizer with the same Metaspace pre-tokenizer/decoder and confirmed `tokenizer.decode([single_token])` drops the leading space while `tokenizer.decode([whole_sequence])` keeps it):

```
>>> tok.decode([1, 2, 3])   # "Hello", "▁world", "!" together
'Hello world!'
>>> tok.decode([2])         # "▁world" decoded alone
'world'                     # space lost
```

## Test plan
- Added `test_tokenizer_decode_stream_huggingface_backend_spacing` in `tests/test_tokenizer.py`, built on the same lightweight from-scratch-BPE pattern the file already uses (`test_tokenizer_config_without_tokenizer_class`) — no network download, no real checkpoint needed. Confirmed this test **fails** against the pre-fix code (`assert 'Helloworld!' == 'Hello world!'`) and **passes** against the fix.
- `pytest tests/test_tokenizer.py` — 220 passed, 40 skipped (offline/gated-repo skips, pre-existing), 1 xfailed (pre-existing), 0 failed.
- `pre-commit run --files litgpt/tokenizer.py tests/test_tokenizer.py` — clean (ruff auto-fixed one import-sort nit in the test file, no logic changes).